### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/server/auth/sessionManager.ts
+++ b/src/server/auth/sessionManager.ts
@@ -118,7 +118,12 @@ export class SessionManager {
    * @returns Full file path for the auth code file
    */
   private getAuthCodeFilePath(code: string): string {
-    return path.join(this.sessionStoragePath, `auth_code_${code}${AUTH_CONFIG.SESSION_FILE_EXTENSION}`);
+    const unsafePath = path.join(this.sessionStoragePath, `auth_code_${code}${AUTH_CONFIG.SESSION_FILE_EXTENSION}`);
+    const normalizedPath = fs.realpathSync(path.resolve(unsafePath));
+    if (!normalizedPath.startsWith(this.sessionStoragePath)) {
+      throw new Error('Invalid authorization code path');
+    }
+    return normalizedPath;
   }
 
   /**


### PR DESCRIPTION
Potential fix for [https://github.com/1mcp-app/agent/security/code-scanning/4](https://github.com/1mcp-app/agent/security/code-scanning/4)

To fix the issue, the `code` parameter must be validated or sanitized before being used to construct file paths. The best approach is to ensure that the constructed file path is contained within the intended directory (`sessionStoragePath`). This can be achieved by normalizing the path using `path.resolve` and verifying that it starts with the `sessionStoragePath`. Additionally, symbolic links should be resolved using `fs.realpathSync`.

Changes are required in the `getAuthCodeFilePath` method in `src/server/auth/sessionManager.ts` to implement this validation. The method should normalize the constructed path and verify its containment within `sessionStoragePath`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
