### PR TITLE
fix(config): fix config directory resolution and improve config context reliability

### DIFF
--- a/src/commands/app/consolidate.ts
+++ b/src/commands/app/consolidate.ts
@@ -21,7 +21,8 @@ import { validateOperation, generateOperationPreview } from '../../utils/validat
 import { createBackup, withFileLock } from '../../utils/backupManager.js';
 import { getAppBackupDir } from '../../constants.js';
 import { McpConfigManager } from '../../config/mcpConfigManager.js';
-import { setServer } from '../mcp/utils/configUtils.js';
+import { setServer, initializeConfigContext } from '../mcp/utils/configUtils.js';
+import ConfigContext from '../../config/configContext.js';
 import { MCPServerParams } from '../../core/types/index.js';
 import { GlobalOptions } from '../../globalOptions.js';
 import { generateSupportedAppsHelp } from '../../utils/appPresets.js';
@@ -235,6 +236,8 @@ async function consolidateApp(
   serverUrl: string,
   options: ConsolidateOptions,
 ): Promise<ConsolidationResult> {
+  // Initialize ConfigContext with CLI options
+  initializeConfigContext(options.config, options['config-dir']);
   // Check if app is already consolidated (unless force mode)
   if (!options.force) {
     const consolidationStatus = await checkConsolidationStatus(appName);
@@ -449,7 +452,11 @@ function convertToMCPServerParams(server: any): MCPServerParams {
  * Import MCP servers to 1mcp configuration
  */
 async function importServersTo1mcp(servers: any[]): Promise<void> {
-  const mcpConfig = McpConfigManager.getInstance();
+  // Use resolved config path from ConfigContext
+  const configContext = ConfigContext.getInstance();
+  const filePath = configContext.getResolvedConfigPath();
+
+  const mcpConfig = McpConfigManager.getInstance(filePath);
 
   // Get current transport config
   const currentConfig = mcpConfig.getTransportConfig();

--- a/src/commands/mcp/enable.ts
+++ b/src/commands/mcp/enable.ts
@@ -8,6 +8,7 @@ import {
   validateConfigPath,
   backupConfig,
   reloadMcpConfig,
+  initializeConfigContext,
 } from './utils/configUtils.js';
 import { validateServerName } from './utils/validation.js';
 
@@ -46,7 +47,10 @@ export function buildDisableCommand(yargs: Argv) {
  */
 export async function enableCommand(argv: EnableDisableCommandArgs): Promise<void> {
   try {
-    const { name, config: configPath } = argv;
+    const { name, config: configPath, 'config-dir': configDir } = argv;
+
+    // Initialize config context with CLI options
+    initializeConfigContext(configPath, configDir);
 
     console.log(`Enabling MCP server: ${name}`);
 
@@ -54,15 +58,15 @@ export async function enableCommand(argv: EnableDisableCommandArgs): Promise<voi
     validateServerName(name);
 
     // Validate config path
-    validateConfigPath(configPath);
+    validateConfigPath();
 
     // Check if server exists
-    if (!serverExists(name, configPath)) {
+    if (!serverExists(name)) {
       throw new Error(`Server '${name}' does not exist. Use 'mcp add' to create it first.`);
     }
 
     // Get current server configuration
-    const currentConfig = getServer(name, configPath);
+    const currentConfig = getServer(name);
     if (!currentConfig) {
       throw new Error(`Failed to retrieve server '${name}' configuration.`);
     }
@@ -74,7 +78,7 @@ export async function enableCommand(argv: EnableDisableCommandArgs): Promise<voi
     }
 
     // Create backup
-    const backupPath = backupConfig(configPath);
+    const backupPath = backupConfig();
 
     // Update configuration to enable the server
     const updatedConfig: MCPServerParams = {
@@ -86,10 +90,10 @@ export async function enableCommand(argv: EnableDisableCommandArgs): Promise<voi
     delete updatedConfig.disabled;
 
     // Save the updated configuration
-    setServer(name, updatedConfig, configPath);
+    setServer(name, updatedConfig);
 
     // Reload MCP configuration
-    reloadMcpConfig(configPath);
+    reloadMcpConfig();
 
     // Success message
     console.log(`✅ Successfully enabled server '${name}'`);
@@ -107,7 +111,10 @@ export async function enableCommand(argv: EnableDisableCommandArgs): Promise<voi
  */
 export async function disableCommand(argv: EnableDisableCommandArgs): Promise<void> {
   try {
-    const { name, config: configPath } = argv;
+    const { name, config: configPath, 'config-dir': configDir } = argv;
+
+    // Initialize config context with CLI options
+    initializeConfigContext(configPath, configDir);
 
     console.log(`Disabling MCP server: ${name}`);
 
@@ -115,15 +122,15 @@ export async function disableCommand(argv: EnableDisableCommandArgs): Promise<vo
     validateServerName(name);
 
     // Validate config path
-    validateConfigPath(configPath);
+    validateConfigPath();
 
     // Check if server exists
-    if (!serverExists(name, configPath)) {
+    if (!serverExists(name)) {
       throw new Error(`Server '${name}' does not exist. Use 'mcp add' to create it first.`);
     }
 
     // Get current server configuration
-    const currentConfig = getServer(name, configPath);
+    const currentConfig = getServer(name);
     if (!currentConfig) {
       throw new Error(`Failed to retrieve server '${name}' configuration.`);
     }
@@ -135,7 +142,7 @@ export async function disableCommand(argv: EnableDisableCommandArgs): Promise<vo
     }
 
     // Create backup
-    const backupPath = backupConfig(configPath);
+    const backupPath = backupConfig();
 
     // Update configuration to disable the server
     const updatedConfig: MCPServerParams = {
@@ -144,10 +151,10 @@ export async function disableCommand(argv: EnableDisableCommandArgs): Promise<vo
     };
 
     // Save the updated configuration
-    setServer(name, updatedConfig, configPath);
+    setServer(name, updatedConfig);
 
     // Reload MCP configuration
-    reloadMcpConfig(configPath);
+    reloadMcpConfig();
 
     // Success message
     console.log(`✅ Successfully disabled server '${name}'`);

--- a/src/commands/mcp/list.ts
+++ b/src/commands/mcp/list.ts
@@ -1,7 +1,7 @@
 import type { Argv } from 'yargs';
 import { MCPServerParams } from '../../core/types/index.js';
 import { GlobalOptions } from '../../globalOptions.js';
-import { getAllServers, validateConfigPath, parseTags } from './utils/configUtils.js';
+import { getAllServers, validateConfigPath, parseTags, initializeConfigContext } from './utils/configUtils.js';
 import { validateTags } from './utils/validation.js';
 import { inferTransportType } from '../../transport/transportFactory.js';
 import { redactCommandArgs, redactUrl, redactSensitiveValue, sanitizeHeaders } from '../../utils/sanitization.js';
@@ -55,14 +55,18 @@ export async function listCommand(argv: ListCommandArgs): Promise<void> {
   try {
     const {
       config: configPath,
+      'config-dir': configDir,
       'show-disabled': showDisabled = false,
       'show-secrets': showSecrets = false,
       tags: tagsFilter,
       verbose = false,
     } = argv;
 
+    // Initialize config context with CLI options
+    initializeConfigContext(configPath, configDir);
+
     // Validate config path
-    validateConfigPath(configPath);
+    validateConfigPath();
 
     // Validate tags filter if provided
     if (tagsFilter) {
@@ -70,7 +74,7 @@ export async function listCommand(argv: ListCommandArgs): Promise<void> {
     }
 
     // Get all servers
-    const allServers = getAllServers(configPath);
+    const allServers = getAllServers();
 
     if (Object.keys(allServers).length === 0) {
       console.log('No MCP servers are configured.');

--- a/src/commands/mcp/remove.ts
+++ b/src/commands/mcp/remove.ts
@@ -7,6 +7,7 @@ import {
   validateConfigPath,
   backupConfig,
   reloadMcpConfig,
+  initializeConfigContext,
 } from './utils/configUtils.js';
 import { validateServerName } from './utils/validation.js';
 import { GlobalOptions } from '../../globalOptions.js';
@@ -43,7 +44,10 @@ export function buildRemoveCommand(yargs: Argv) {
  */
 export async function removeCommand(argv: RemoveCommandArgs): Promise<void> {
   try {
-    const { name, config: configPath, yes = false } = argv;
+    const { name, config: configPath, 'config-dir': configDir, yes = false } = argv;
+
+    // Initialize config context with CLI options
+    initializeConfigContext(configPath, configDir);
 
     console.log(`Removing MCP server: ${name}`);
 
@@ -51,15 +55,15 @@ export async function removeCommand(argv: RemoveCommandArgs): Promise<void> {
     validateServerName(name);
 
     // Validate config path
-    validateConfigPath(configPath);
+    validateConfigPath();
 
     // Check if server exists
-    if (!serverExists(name, configPath)) {
+    if (!serverExists(name)) {
       throw new Error(`Server '${name}' does not exist in the configuration.`);
     }
 
     // Get server details for confirmation
-    const serverConfig = getServer(name, configPath);
+    const serverConfig = getServer(name);
     if (!serverConfig) {
       throw new Error(`Failed to retrieve server '${name}' configuration.`);
     }
@@ -98,16 +102,16 @@ export async function removeCommand(argv: RemoveCommandArgs): Promise<void> {
     }
 
     // Create backup
-    const backupPath = backupConfig(configPath);
+    const backupPath = backupConfig();
 
     // Remove the server
-    const removed = removeServer(name, configPath);
+    const removed = removeServer(name);
     if (!removed) {
       throw new Error(`Failed to remove server '${name}' from configuration.`);
     }
 
     // Reload MCP configuration
-    reloadMcpConfig(configPath);
+    reloadMcpConfig();
 
     // Success message
     console.log(`✅ Successfully removed server '${name}'`);

--- a/src/commands/mcp/status.ts
+++ b/src/commands/mcp/status.ts
@@ -1,7 +1,7 @@
 import type { Argv } from 'yargs';
 import { MCPServerParams } from '../../core/types/index.js';
 import { GlobalOptions } from '../../globalOptions.js';
-import { getAllServers, getServer, validateConfigPath } from './utils/configUtils.js';
+import { getAllServers, getServer, validateConfigPath, initializeConfigContext } from './utils/configUtils.js';
 import { validateServerName } from './utils/validation.js';
 import { inferTransportType } from '../../transport/transportFactory.js';
 
@@ -37,17 +37,20 @@ export function buildStatusCommand(yargs: Argv) {
  */
 export async function statusCommand(argv: StatusCommandArgs): Promise<void> {
   try {
-    const { name, config: configPath, verbose = false } = argv;
+    const { name, config: configPath, 'config-dir': configDir, verbose = false } = argv;
+
+    // Initialize config context with CLI options
+    initializeConfigContext(configPath, configDir);
 
     // Validate config path
-    validateConfigPath(configPath);
+    validateConfigPath();
 
     if (name) {
       // Show status for specific server
-      await showServerStatus(name, configPath, verbose);
+      await showServerStatus(name, verbose);
     } else {
       // Show status for all servers
-      await showAllServersStatus(configPath, verbose);
+      await showAllServersStatus(verbose);
     }
   } catch (error) {
     console.error(`❌ Failed to get server status: ${error instanceof Error ? error.message : error}`);
@@ -58,12 +61,12 @@ export async function statusCommand(argv: StatusCommandArgs): Promise<void> {
 /**
  * Show status for a specific server
  */
-async function showServerStatus(serverName: string, configPath?: string, verbose: boolean = false): Promise<void> {
+async function showServerStatus(serverName: string, verbose: boolean = false): Promise<void> {
   // Validate server name
   validateServerName(serverName);
 
   // Get server configuration
-  const serverConfig = getServer(serverName, configPath);
+  const serverConfig = getServer(serverName);
   if (!serverConfig) {
     throw new Error(`Server '${serverName}' does not exist.`);
   }
@@ -76,8 +79,8 @@ async function showServerStatus(serverName: string, configPath?: string, verbose
 /**
  * Show status for all servers
  */
-async function showAllServersStatus(configPath?: string, verbose: boolean = false): Promise<void> {
-  const allServers = getAllServers(configPath);
+async function showAllServersStatus(verbose: boolean = false): Promise<void> {
+  const allServers = getAllServers();
 
   if (Object.keys(allServers).length === 0) {
     console.log('No MCP servers are configured.');

--- a/src/commands/mcp/status.ts
+++ b/src/commands/mcp/status.ts
@@ -39,7 +39,7 @@ export async function statusCommand(argv: StatusCommandArgs): Promise<void> {
   try {
     const { name, config: configPath, 'config-dir': configDir, verbose = false } = argv;
 
-    // Initialize config context with CLI options
+    // Initialize ConfigContext with CLI options
     initializeConfigContext(configPath, configDir);
 
     // Validate config path

--- a/src/commands/mcp/tokens.ts
+++ b/src/commands/mcp/tokens.ts
@@ -2,7 +2,7 @@ import type { Arguments, Argv } from 'yargs';
 import logger from '../../logger/logger.js';
 import { TokenEstimationService, type ServerTokenEstimate } from '../../services/tokenEstimationService.js';
 import { TagQueryParser, type TagExpression } from '../../utils/tagQueryParser.js';
-import { loadConfig, type ServerConfig } from './utils/configUtils.js';
+import { loadConfig, type ServerConfig, initializeConfigContext } from './utils/configUtils.js';
 import type { MCPServerParams } from '../../core/types/index.js';
 import { GlobalOptions } from '../../globalOptions.js';
 import { McpConnectionHelper } from './utils/connectionHelper.js';
@@ -299,8 +299,11 @@ export async function tokensCommand(argv: Arguments<TokensCommandArgs>): Promise
   try {
     logger.debug('Starting tokens command with args:', argv);
 
+    // Initialize config context with CLI options
+    initializeConfigContext(argv.config, argv['config-dir']);
+
     // Load MCP configuration using utility function
-    const config: ServerConfig = loadConfig(argv.config);
+    const config: ServerConfig = loadConfig();
 
     if (!config.mcpServers || Object.keys(config.mcpServers).length === 0) {
       console.log('No MCP servers configured. Use "1mcp mcp add" to add servers.');

--- a/src/commands/mcp/update.ts
+++ b/src/commands/mcp/update.ts
@@ -10,6 +10,7 @@ import {
   validateConfigPath,
   backupConfig,
   reloadMcpConfig,
+  initializeConfigContext,
 } from './utils/configUtils.js';
 import {
   validateServerName,
@@ -115,7 +116,10 @@ export function buildUpdateCommand(yargs: Argv) {
  */
 export async function updateCommand(argv: UpdateCommandArgs): Promise<void> {
   try {
-    const { name, config: configPath } = argv;
+    const { name, config: configPath, 'config-dir': configDir } = argv;
+
+    // Initialize config context with CLI options
+    initializeConfigContext(configPath, configDir);
 
     console.log(`Updating MCP server: ${name}`);
 
@@ -123,15 +127,15 @@ export async function updateCommand(argv: UpdateCommandArgs): Promise<void> {
     validateServerName(name);
 
     // Validate config path
-    validateConfigPath(configPath);
+    validateConfigPath();
 
     // Check if server exists
-    if (!serverExists(name, configPath)) {
+    if (!serverExists(name)) {
       throw new Error(`Server '${name}' does not exist. Use 'mcp add' to create it first.`);
     }
 
     // Get current server configuration
-    const currentConfig = getServer(name, configPath);
+    const currentConfig = getServer(name);
     if (!currentConfig) {
       throw new Error(`Failed to retrieve server '${name}' configuration.`);
     }
@@ -291,13 +295,13 @@ export async function updateCommand(argv: UpdateCommandArgs): Promise<void> {
     }
 
     // Create backup
-    const backupPath = backupConfig(configPath);
+    const backupPath = backupConfig();
 
     // Save the updated configuration
-    setServer(name, updatedConfig, configPath);
+    setServer(name, updatedConfig);
 
     // Reload MCP configuration
-    reloadMcpConfig(configPath);
+    reloadMcpConfig();
 
     // Success message
     console.log(`✅ Successfully updated server '${name}'`);

--- a/src/commands/mcp/utils/configUtils.ts
+++ b/src/commands/mcp/utils/configUtils.ts
@@ -1,13 +1,29 @@
 import fs from 'fs';
 import path from 'path';
 import { McpConfigManager } from '../../../config/mcpConfigManager.js';
-import { getGlobalConfigPath } from '../../../constants.js';
 import { MCPServerParams } from '../../../core/types/index.js';
 import logger from '../../../logger/logger.js';
+import ConfigContext from '../../../config/configContext.js';
 
 /**
  * Configuration file utilities for server management commands
  */
+
+/**
+ * Initialize the configuration context with CLI options
+ * This should be called at the beginning of each command
+ */
+export function initializeConfigContext(configPath?: string, configDir?: string): void {
+  const configContext = ConfigContext.getInstance();
+
+  if (configPath) {
+    configContext.setConfigPath(configPath);
+  } else if (configDir) {
+    configContext.setConfigDir(configDir);
+  } else {
+    configContext.reset(); // Use defaults
+  }
+}
 
 export interface ServerConfig {
   mcpServers: Record<string, MCPServerParams>;
@@ -15,9 +31,11 @@ export interface ServerConfig {
 
 /**
  * Load the MCP configuration from a file
+ * Uses ConfigContext to resolve the appropriate config file path
  */
-export function loadConfig(configPath?: string): ServerConfig {
-  const filePath = configPath || getGlobalConfigPath();
+export function loadConfig(): ServerConfig {
+  const configContext = ConfigContext.getInstance();
+  const filePath = configContext.getResolvedConfigPath();
 
   try {
     if (!fs.existsSync(filePath)) {
@@ -42,15 +60,17 @@ export function loadConfig(configPath?: string): ServerConfig {
 
 /**
  * Save the MCP configuration to a file
+ * Uses ConfigContext to resolve the appropriate config file path
  */
-export function saveConfig(config: ServerConfig, configPath?: string): void {
-  const filePath = configPath || getGlobalConfigPath();
+export function saveConfig(config: ServerConfig): void {
+  const configContext = ConfigContext.getInstance();
+  const filePath = configContext.getResolvedConfigPath();
 
   try {
     // Ensure directory exists
-    const configDir = path.dirname(filePath);
-    if (!fs.existsSync(configDir)) {
-      fs.mkdirSync(configDir, { recursive: true });
+    const fileDir = path.dirname(filePath);
+    if (!fs.existsSync(fileDir)) {
+      fs.mkdirSync(fileDir, { recursive: true });
     }
 
     // Write configuration with pretty formatting
@@ -65,9 +85,9 @@ export function saveConfig(config: ServerConfig, configPath?: string): void {
 /**
  * Check if a server exists in the configuration
  */
-export function serverExists(serverName: string, configPath?: string): boolean {
+export function serverExists(serverName: string): boolean {
   try {
-    const config = loadConfig(configPath);
+    const config = loadConfig();
     return serverName in config.mcpServers;
   } catch (_error) {
     return false;
@@ -77,9 +97,9 @@ export function serverExists(serverName: string, configPath?: string): boolean {
 /**
  * Get a specific server configuration
  */
-export function getServer(serverName: string, configPath?: string): MCPServerParams | null {
+export function getServer(serverName: string): MCPServerParams | null {
   try {
-    const config = loadConfig(configPath);
+    const config = loadConfig();
     return config.mcpServers[serverName] || null;
   } catch (_error) {
     return null;
@@ -89,25 +109,25 @@ export function getServer(serverName: string, configPath?: string): MCPServerPar
 /**
  * Add or update a server in the configuration
  */
-export function setServer(serverName: string, serverConfig: MCPServerParams, configPath?: string): void {
-  const config = loadConfig(configPath);
+export function setServer(serverName: string, serverConfig: MCPServerParams): void {
+  const config = loadConfig();
   config.mcpServers[serverName] = serverConfig;
-  saveConfig(config, configPath);
+  saveConfig(config);
 }
 
 /**
  * Remove a server from the configuration
  */
-export function removeServer(serverName: string, configPath?: string): boolean {
+export function removeServer(serverName: string): boolean {
   try {
-    const config = loadConfig(configPath);
+    const config = loadConfig();
 
     if (!(serverName in config.mcpServers)) {
       return false;
     }
 
     delete config.mcpServers[serverName];
-    saveConfig(config, configPath);
+    saveConfig(config);
     return true;
   } catch (error) {
     throw new Error(`Failed to remove server ${serverName}: ${error}`);
@@ -117,9 +137,9 @@ export function removeServer(serverName: string, configPath?: string): boolean {
 /**
  * Get all servers in the configuration
  */
-export function getAllServers(configPath?: string): Record<string, MCPServerParams> {
+export function getAllServers(): Record<string, MCPServerParams> {
   try {
-    const config = loadConfig(configPath);
+    const config = loadConfig();
     return config.mcpServers;
   } catch (_error) {
     return {};
@@ -201,8 +221,9 @@ export function parseTags(tagsString?: string): string[] {
 /**
  * Validate configuration file path
  */
-export function validateConfigPath(configPath?: string): string {
-  const filePath = configPath || getGlobalConfigPath();
+export function validateConfigPath(): string {
+  const configContext = ConfigContext.getInstance();
+  const filePath = configContext.getResolvedConfigPath();
 
   try {
     // Check if file exists
@@ -228,8 +249,9 @@ export function validateConfigPath(configPath?: string): string {
 /**
  * Create a backup of the configuration file
  */
-export function backupConfig(configPath?: string): string {
-  const filePath = configPath || getGlobalConfigPath();
+export function backupConfig(): string {
+  const configContext = ConfigContext.getInstance();
+  const filePath = configContext.getResolvedConfigPath();
   const timestamp = Date.now();
   const backupPath = `${filePath}.backup.${timestamp}`;
 
@@ -300,10 +322,13 @@ export function validateServerConfig(serverConfig: MCPServerParams): void {
 /**
  * Reload MCP config manager after configuration changes
  */
-export function reloadMcpConfig(configPath?: string): void {
+export function reloadMcpConfig(): void {
   try {
+    const configContext = ConfigContext.getInstance();
+    const filePath = configContext.getResolvedConfigPath();
+
     // Get the config manager instance and reload it
-    const configManager = McpConfigManager.getInstance(configPath);
+    const configManager = McpConfigManager.getInstance(filePath);
     configManager.reloadConfig();
     logger.info('MCP configuration reloaded');
   } catch (error) {

--- a/src/commands/mcp/utils/configUtils.ts
+++ b/src/commands/mcp/utils/configUtils.ts
@@ -33,9 +33,9 @@ export interface ServerConfig {
  * Load the MCP configuration from a file
  * Uses ConfigContext to resolve the appropriate config file path
  */
-export function loadConfig(): ServerConfig {
+export function loadConfig(configPath?: string): ServerConfig {
   const configContext = ConfigContext.getInstance();
-  const filePath = configContext.getResolvedConfigPath();
+  const filePath = configPath || configContext.getResolvedConfigPath();
 
   try {
     if (!fs.existsSync(filePath)) {
@@ -221,9 +221,9 @@ export function parseTags(tagsString?: string): string[] {
 /**
  * Validate configuration file path
  */
-export function validateConfigPath(): string {
+export function validateConfigPath(configPath?: string): string {
   const configContext = ConfigContext.getInstance();
-  const filePath = configContext.getResolvedConfigPath();
+  const filePath = configPath || configContext.getResolvedConfigPath();
 
   try {
     // Check if file exists

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -10,6 +10,7 @@ import { AgentConfigManager } from '../../core/server/agentConfig.js';
 import { displayLogo } from '../../utils/logo.js';
 import { McpLoadingManager } from '../../core/loading/mcpLoadingManager.js';
 import { TagQueryParser, TagExpression } from '../../utils/tagQueryParser.js';
+import ConfigContext from '../../config/configContext.js';
 
 export interface ServeOptions {
   config?: string;
@@ -110,7 +111,19 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
       displayLogo();
     }
 
-    McpConfigManager.getInstance(parsedArgv.config);
+    // Initialize ConfigContext with CLI options
+    const configContext = ConfigContext.getInstance();
+    if (parsedArgv.config) {
+      configContext.setConfigPath(parsedArgv.config);
+    } else if (parsedArgv['config-dir']) {
+      configContext.setConfigDir(parsedArgv['config-dir']);
+    } else {
+      configContext.reset();
+    }
+
+    // Initialize MCP config manager using resolved config path
+    const configFilePath = configContext.getResolvedConfigPath();
+    McpConfigManager.getInstance(configFilePath);
 
     // Configure server settings from CLI arguments
     const serverConfigManager = AgentConfigManager.getInstance();

--- a/src/config/configContext.test.ts
+++ b/src/config/configContext.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import ConfigContext from './configContext.js';
+import { getConfigPath } from '../constants.js';
+
+describe('ConfigContext', () => {
+  let configContext: ConfigContext;
+
+  beforeEach(() => {
+    configContext = ConfigContext.getInstance();
+    configContext.reset(); // Ensure clean state for each test
+  });
+
+  afterEach(() => {
+    configContext.reset(); // Clean up after each test
+  });
+
+  describe('Singleton pattern', () => {
+    it('should return the same instance', () => {
+      const instance1 = ConfigContext.getInstance();
+      const instance2 = ConfigContext.getInstance();
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('setConfigPath', () => {
+    it('should set config path correctly', () => {
+      const testPath = '/test/config.json';
+      configContext.setConfigPath(testPath);
+      expect(configContext.getResolvedConfigPath()).toBe(testPath);
+    });
+
+    it('should handle undefined config path', () => {
+      configContext.setConfigPath(undefined);
+      // Should fall back to default config path
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath());
+    });
+
+    it('should override previously set config directory', () => {
+      configContext.setConfigDir('/test/dir');
+      configContext.setConfigPath('/override/config.json');
+      expect(configContext.getResolvedConfigPath()).toBe('/override/config.json');
+    });
+  });
+
+  describe('setConfigDir', () => {
+    it('should set config directory correctly', () => {
+      const testDir = '/test/dir';
+      configContext.setConfigDir(testDir);
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath(testDir));
+    });
+
+    it('should handle undefined config directory', () => {
+      configContext.setConfigDir(undefined);
+      // Should fall back to default config path
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath());
+    });
+
+    it('should override previously set config path', () => {
+      configContext.setConfigPath('/override/config.json');
+      configContext.setConfigDir('/test/dir');
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath('/test/dir'));
+    });
+  });
+
+  describe('getResolvedConfigPath', () => {
+    it('should return config path when set', () => {
+      const testPath = '/test/config.json';
+      configContext.setConfigPath(testPath);
+      expect(configContext.getResolvedConfigPath()).toBe(testPath);
+    });
+
+    it('should return config path from directory when directory is set', () => {
+      const testDir = '/test/dir';
+      configContext.setConfigDir(testDir);
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath(testDir));
+    });
+
+    it('should return default config path when nothing is set', () => {
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath());
+    });
+
+    it('should prioritize config path over config directory', () => {
+      const testPath = '/test/config.json';
+      const testDir = '/test/dir';
+
+      configContext.setConfigDir(testDir);
+      configContext.setConfigPath(testPath);
+
+      expect(configContext.getResolvedConfigPath()).toBe(testPath);
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear all configuration', () => {
+      configContext.setConfigPath('/test/config.json');
+      configContext.setConfigDir('/test/dir');
+
+      configContext.reset();
+
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath());
+    });
+
+    it('should work when nothing was set', () => {
+      configContext.reset();
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath());
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty string config path', () => {
+      configContext.setConfigPath('');
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath());
+    });
+
+    it('should handle empty string config directory', () => {
+      configContext.setConfigDir('');
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath());
+    });
+
+    it('should handle multiple resets', () => {
+      configContext.setConfigPath('/test/config.json');
+      configContext.reset();
+      configContext.reset();
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath());
+    });
+
+    it('should handle alternating between path and directory', () => {
+      const testPath = '/test/config.json';
+      const testDir = '/test/dir';
+
+      configContext.setConfigPath(testPath);
+      expect(configContext.getResolvedConfigPath()).toBe(testPath);
+
+      configContext.setConfigDir(testDir);
+      expect(configContext.getResolvedConfigPath()).toBe(getConfigPath(testDir));
+
+      configContext.setConfigPath(testPath);
+      expect(configContext.getResolvedConfigPath()).toBe(testPath);
+    });
+  });
+});

--- a/src/config/configContext.ts
+++ b/src/config/configContext.ts
@@ -1,19 +1,22 @@
+import { getConfigPath } from '../constants.js';
+
 /**
- * Configuration context for managing config directory and file paths
- * This provides a centralized way to handle config directory resolution
- * without passing parameters through every function call
+ * Singleton context for managing configuration file resolution
+ * Centralizes the logic for resolving config paths from CLI options
  */
-
-import { getConfigPath, getGlobalConfigPath } from '../constants.js';
-
 class ConfigContext {
-  private static instance: ConfigContext;
+  private static instance: ConfigContext | null = null;
   private configDir?: string;
   private configPath?: string;
 
-  private constructor() {}
+  private constructor() {
+    // Private constructor for singleton
+  }
 
-  public static getInstance(): ConfigContext {
+  /**
+   * Get the singleton instance
+   */
+  static getInstance(): ConfigContext {
     if (!ConfigContext.instance) {
       ConfigContext.instance = new ConfigContext();
     }
@@ -21,24 +24,36 @@ class ConfigContext {
   }
 
   /**
-   * Set the config directory for this context
+   * Set the config directory
    */
-  public setConfigDir(configDir?: string): void {
-    this.configDir = configDir;
-    this.configPath = undefined; // Reset config path when dir changes
+  setConfigDir(dir?: string): void {
+    this.configDir = dir;
+    this.configPath = undefined; // Clear config path when setting dir
   }
 
   /**
-   * Set the config file path directly (takes precedence over configDir)
+   * Set the config path directly
    */
-  public setConfigPath(configPath?: string): void {
-    this.configPath = configPath;
+  setConfigPath(path?: string): void {
+    this.configPath = path;
+    this.configDir = undefined; // Clear config dir when setting path
   }
 
   /**
-   * Get the resolved config file path based on current context
+   * Reset all configuration
    */
-  public getResolvedConfigPath(): string {
+  reset(): void {
+    this.configDir = undefined;
+    this.configPath = undefined;
+  }
+
+  /**
+   * Get the resolved config path based on priority:
+   * 1. Explicit config path (highest priority)
+   * 2. Config directory + mcp.json
+   * 3. Default global config path
+   */
+  getResolvedConfigPath(): string {
     if (this.configPath) {
       return this.configPath;
     }
@@ -47,15 +62,7 @@ class ConfigContext {
       return getConfigPath(this.configDir);
     }
 
-    return getGlobalConfigPath();
-  }
-
-  /**
-   * Reset the context to default state
-   */
-  public reset(): void {
-    this.configDir = undefined;
-    this.configPath = undefined;
+    return getConfigPath();
   }
 }
 

--- a/src/config/configContext.ts
+++ b/src/config/configContext.ts
@@ -1,0 +1,62 @@
+/**
+ * Configuration context for managing config directory and file paths
+ * This provides a centralized way to handle config directory resolution
+ * without passing parameters through every function call
+ */
+
+import { getConfigPath, getGlobalConfigPath } from '../constants.js';
+
+class ConfigContext {
+  private static instance: ConfigContext;
+  private configDir?: string;
+  private configPath?: string;
+
+  private constructor() {}
+
+  public static getInstance(): ConfigContext {
+    if (!ConfigContext.instance) {
+      ConfigContext.instance = new ConfigContext();
+    }
+    return ConfigContext.instance;
+  }
+
+  /**
+   * Set the config directory for this context
+   */
+  public setConfigDir(configDir?: string): void {
+    this.configDir = configDir;
+    this.configPath = undefined; // Reset config path when dir changes
+  }
+
+  /**
+   * Set the config file path directly (takes precedence over configDir)
+   */
+  public setConfigPath(configPath?: string): void {
+    this.configPath = configPath;
+  }
+
+  /**
+   * Get the resolved config file path based on current context
+   */
+  public getResolvedConfigPath(): string {
+    if (this.configPath) {
+      return this.configPath;
+    }
+
+    if (this.configDir) {
+      return getConfigPath(this.configDir);
+    }
+
+    return getGlobalConfigPath();
+  }
+
+  /**
+   * Reset the context to default state
+   */
+  public reset(): void {
+    this.configDir = undefined;
+    this.configPath = undefined;
+  }
+}
+
+export default ConfigContext;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,7 +48,7 @@ export function getGlobalConfigDir(): string {
  * Priority: CLI option (includes env var via yargs ONE_MCP prefix) -> Default global config dir
  */
 export function getConfigDir(configDirOption?: string): string {
-  if (configDirOption !== undefined) {
+  if (configDirOption !== undefined && configDirOption !== '') {
     return configDirOption;
   }
 
@@ -60,6 +60,15 @@ export function getConfigDir(configDirOption?: string): string {
  */
 export function getGlobalConfigPath(): string {
   return `${getGlobalConfigDir()}/${MCP_CONFIG_FILE}`;
+}
+
+/**
+ * Get the config file path with directory override support
+ * Priority: configDir option -> Default global config dir
+ */
+export function getConfigPath(configDir?: string): string {
+  const baseDir = getConfigDir(configDir);
+  return `${baseDir}/${MCP_CONFIG_FILE}`;
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -63,12 +63,13 @@ export function getGlobalConfigPath(): string {
 }
 
 /**
- * Get the config file path with directory override support
- * Priority: configDir option -> Default global config dir
+ * Get config file path from directory or global default
  */
 export function getConfigPath(configDir?: string): string {
-  const baseDir = getConfigDir(configDir);
-  return `${baseDir}/${MCP_CONFIG_FILE}`;
+  if (configDir) {
+    return `${configDir}/${MCP_CONFIG_FILE}`;
+  }
+  return getGlobalConfigPath();
 }
 
 /**

--- a/test/e2e/commands/mcp/mcp-config-context.test.ts
+++ b/test/e2e/commands/mcp/mcp-config-context.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import { CommandTestEnvironment, CliTestRunner } from '../../utils/index.js';
+import { TestFixtures } from '../../fixtures/TestFixtures.js';
+import { join } from 'path';
+import { mkdirSync, writeFileSync } from 'fs';
+
+describe('MCP Config Context E2E Tests', () => {
+  let environment: CommandTestEnvironment;
+  let runner: CliTestRunner;
+  let customConfigDir: string;
+
+  beforeEach(async () => {
+    environment = new CommandTestEnvironment(TestFixtures.createTestScenario('config-context-test', 'basic'));
+    await environment.setup();
+    runner = new CliTestRunner(environment);
+
+    // Create a custom config directory for testing
+    customConfigDir = join(environment.getTempDir(), 'custom-config');
+    mkdirSync(customConfigDir, { recursive: true });
+
+    // Create a test mcp.json in the custom directory with a unique server
+    const customConfigPath = join(customConfigDir, 'mcp.json');
+    const testConfig = {
+      mcpServers: {
+        'config-context-test-server': {
+          command: 'echo',
+          args: ['config-test'],
+          enabled: true,
+        },
+      },
+    };
+    writeFileSync(customConfigPath, JSON.stringify(testConfig, null, 2));
+  });
+
+  afterEach(async () => {
+    await environment.cleanup();
+  });
+
+  describe('--config-dir CLI flag', () => {
+    it('should use config directory specified via --config-dir flag', async () => {
+      const result = await runner.runCommand('mcp', 'status', {
+        args: ['--config-dir', customConfigDir],
+      });
+
+      runner.assertSuccess(result);
+      // Should find the unique test server we created in the custom config
+      runner.assertOutputContains(result, 'config-context-test-server');
+    });
+
+    it('should work with -d short flag', async () => {
+      const result = await runner.runCommand('mcp', 'status', {
+        args: ['-d', customConfigDir],
+      });
+
+      runner.assertSuccess(result);
+      runner.assertOutputContains(result, 'config-context-test-server');
+    });
+
+    it('should prioritize --config-dir over default config', async () => {
+      // First, get status from default config (should show echo-server from basic fixture)
+      const defaultResult = await runner.runMcpCommand('status');
+      runner.assertSuccess(defaultResult);
+      runner.assertOutputContains(defaultResult, 'echo-server'); // From basic fixture
+
+      // Then get status from custom config dir (should show different server)
+      const customResult = await runner.runCommand('mcp', 'status', {
+        args: ['--config-dir', customConfigDir],
+      });
+      runner.assertSuccess(customResult);
+      runner.assertOutputContains(customResult, 'config-context-test-server'); // From custom config
+      runner.assertOutputDoesNotContain(customResult, 'echo-server'); // Should not show default
+    });
+  });
+
+  describe('ONE_MCP_CONFIG_DIR environment variable', () => {
+    it('should use config directory from ONE_MCP_CONFIG_DIR environment variable', async () => {
+      const result = await runner.runCommandWithCustomEnv('mcp', 'status', {
+        ONE_MCP_CONFIG_DIR: customConfigDir,
+      });
+
+      runner.assertSuccess(result);
+      runner.assertOutputContains(result, 'config-context-test-server');
+    });
+
+    it('should prioritize --config-dir over ONE_MCP_CONFIG_DIR', async () => {
+      // Create another config directory for CLI flag
+      const anotherConfigDir = join(environment.getTempDir(), 'another-config');
+      mkdirSync(anotherConfigDir, { recursive: true });
+
+      const anotherConfigPath = join(anotherConfigDir, 'mcp.json');
+      const anotherTestConfig = {
+        mcpServers: {
+          'cli-flag-server': {
+            command: 'echo',
+            args: ['cli-flag'],
+            enabled: true,
+          },
+        },
+      };
+      writeFileSync(anotherConfigPath, JSON.stringify(anotherTestConfig, null, 2));
+
+      // Use environment variable pointing to one dir, but CLI flag pointing to another
+      const result = await runner.runCommandWithCustomEnv(
+        'mcp',
+        'status',
+        {
+          ONE_MCP_CONFIG_DIR: customConfigDir, // Should be overridden by CLI flag
+        },
+        {
+          args: ['--config-dir', anotherConfigDir],
+        },
+      );
+
+      runner.assertSuccess(result);
+      // Should use the CLI flag directory (anotherConfigDir), not env var
+      runner.assertOutputContains(result, 'cli-flag-server');
+      runner.assertOutputDoesNotContain(result, 'config-context-test-server');
+    });
+  });
+
+  describe('Config file vs directory priority', () => {
+    it('should prioritize --config file over --config-dir', async () => {
+      // Create a specific config file
+      const specificConfigPath = join(environment.getTempDir(), 'specific.json');
+      const specificConfig = {
+        mcpServers: {
+          'specific-file-server': {
+            command: 'echo',
+            args: ['specific-file'],
+            enabled: true,
+          },
+        },
+      };
+      writeFileSync(specificConfigPath, JSON.stringify(specificConfig, null, 2));
+
+      const result = await runner.runCommand('mcp', 'status', {
+        args: ['--config', specificConfigPath, '--config-dir', customConfigDir],
+      });
+
+      runner.assertSuccess(result);
+      // Should use the specific config file, not the directory
+      runner.assertOutputContains(result, 'specific-file-server');
+      runner.assertOutputDoesNotContain(result, 'config-context-test-server');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes broken config directory functionality that was expected to work but had implementation issues. The `--config-dir` flag and `ONE_MCP_CONFIG_DIR` environment variable were not properly resolving custom config paths.

**Key Changes:**
- Fixed ConfigContext singleton pattern to properly maintain state across commands
- Fixed config directory resolution priority logic (explicit path > config dir > default)
- Added missing E2E tests to prevent regression of config directory functionality
- Enhanced CLI test runner to support config isolation testing

## Test Plan

- [x] E2E tests for `--config-dir` and `-d` short flag
- [x] Environment variable `ONE_MCP_CONFIG_DIR` support testing
- [x] Priority resolution testing (explicit path vs config dir vs default)
- [x] Verify existing functionality remains unchanged
- [x] Test config isolation between different directory setups