### PR TITLE
refactor(preset): remove last used tracking feature

### DIFF
--- a/docs/en/commands/preset/delete.md
+++ b/docs/en/commands/preset/delete.md
@@ -50,7 +50,6 @@ npx -y @1mcp/agent preset delete old-staging
    Preset details:
    • Strategy: OR logic
    • Created: 8/15/2025
-   • Last used: never
 
 ? Are you sure? (y/N) y
 

--- a/docs/en/commands/preset/list.md
+++ b/docs/en/commands/preset/list.md
@@ -34,7 +34,6 @@ The command shows:
 - **Name**: Preset identifier (truncated if longer than 16 characters)
 - **Strategy**: Filtering approach (OR logic, AND logic, Advanced)
 - **Query**: Tag query summary (truncated if longer than 33 characters)
-- **Last Used**: Date when preset was last accessed (or "never")
 
 ## Examples
 
@@ -54,11 +53,11 @@ npx -y @1mcp/agent preset list
 └─────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────┐
-│  Name              Strategy   Query                               Last Used  │
-│  ────────────────  ─────────  ──────────────────────────────────  ─────────  │
-│  dev              OR logic   {"$or":[...                        never      │
-│  production       Advanced  {"$and":[...                       never      │
-│  staging          OR logic   {"tag":"staging"}                 9/6/2025   │
+│  Name              Strategy   Query                               │
+│  ────────────────  ─────────  ──────────────────────────────────  │
+│  dev              OR logic   {"$or":[...                        │
+│  production       Advanced  {"$and":[...                       │
+│  staging          OR logic   {"tag":"staging"}                 │
 └─────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────┐
@@ -98,11 +97,6 @@ Create your first preset with:
 
 Long queries are truncated with "..." to maintain table formatting. Use `preset show <name>` to see the complete query.
 
-### Last Used Tracking
-
-- **Date format**: MM/DD/YYYY when preset was last accessed
-- **"never"**: Preset has not been used since creation
-
 ## Workflow Integration
 
 The list command works well with other preset commands:
@@ -124,7 +118,6 @@ npx -y @1mcp/agent preset url production
 ## Usage Tips
 
 - **Regular review**: Use `preset list` to periodically review your preset configurations
-- **Cleanup old presets**: Look for unused presets (showing "never" in Last Used column)
 - **Quick scanning**: The table format makes it easy to compare strategies and identify presets
 - **Follow up with details**: Use `preset show <name>` when you need complete information
 

--- a/docs/en/commands/preset/show.md
+++ b/docs/en/commands/preset/show.md
@@ -29,7 +29,7 @@ The `preset show` command provides comprehensive information about a specific pr
 
 ### Information Displayed
 
-- **Basic Information**: Name, strategy, description, creation date, last used
+- **Basic Information**: Name, strategy, description, creation date
 - **Client URL**: Ready-to-use URL for MCP client configuration
 - **Tag Query**: Complete JSON query with proper formatting (no truncation)
 - **Server Matching**: Which servers match the preset criteria
@@ -55,7 +55,6 @@ npx -y @1mcp/agent preset show production
 │ Strategy: OR logic - Match ANY tags   │
 │ Description: Development servers      │
 │ Created: 9/6/2025                     │
-│ Last Used: Never                      │
 │                                       │
 │ Client URL:                           │
 │ http://127.0.0.1:3050/?preset=dev     │
@@ -86,7 +85,6 @@ npx -y @1mcp/agent preset show production
 - **Strategy**: Human-readable strategy description
 - **Description**: Optional user-provided description
 - **Created**: When the preset was first created
-- **Last Used**: When the preset was last accessed (or "Never")
 
 ### Client URL
 

--- a/docs/zh/commands/preset/delete.md
+++ b/docs/zh/commands/preset/delete.md
@@ -50,7 +50,6 @@ npx -y @1mcp/agent preset delete old-staging
    Preset details:
    • Strategy: OR logic
    • Created: 8/15/2025
-   • Last used: never
 
 ? Are you sure? (y/N) y
 
@@ -68,7 +67,6 @@ npx -y @1mcp/agent preset delete production
    Preset details:
    • Strategy: Advanced
    • Created: 9/1/2025
-   • Last used: 9/6/2025
 
 ? Are you sure? (y/N) n
 
@@ -83,7 +81,7 @@ npx -y @1mcp/agent preset delete production
 # 审查未使用的预设
 npx -y @1mcp/agent preset list
 
-# 删除在最后使用列中显示"从未"的预设
+# 删除在预设列表中显示的未使用预设
 npx -y @1mcp/agent preset delete unused-preset
 npx -y @1mcp/agent preset delete old-experiment
 ```
@@ -111,7 +109,7 @@ npx -y @1mcp/agent preset delete old-team-config
 
 在删除正在使用的预设之前：
 
-1. **检查使用情况**：在 `preset list` 中查看"最后使用"日期
+1. **检查预设列表**：在 `preset list` 中查看所有预设
 2. **验证影响**：确保没有团队成员依赖该预设
 3. **记录更改**：告知团队预设删除
 4. **考虑重命名**：考虑重命名以提高清晰度，而不是删除
@@ -161,7 +159,7 @@ npx -y @1mcp/agent preset delete corrupted-preset
 # 1. 审查所有预设
 npx -y @1mcp/agent preset list
 
-# 2. 识别未使用的预设（最后使用：从未，旧日期）
+# 2. 识别未使用的预设（创建日期较早）
 # 3. 与团队验证预设确实未使用
 # 4. 删除未使用的预设
 npx -y @1mcp/agent preset delete unused-1

--- a/docs/zh/commands/preset/list.md
+++ b/docs/zh/commands/preset/list.md
@@ -34,7 +34,6 @@ npx -y @1mcp/agent preset list
 - **名称**：预设标识符（如果超过 16 个字符则截断）
 - **策略**：过滤方法（OR 逻辑、AND 逻辑、Advanced）
 - **查询**：标签查询摘要（如果超过 33 个字符则截断）
-- **最后使用**：预设最后访问的日期（或"从未"）
 
 ## 示例
 
@@ -53,13 +52,13 @@ npx -y @1mcp/agent preset list
 │   Found 3 presets in your configuration     │
 └─────────────────────────────────────────────┘
 
-┌──────────── Preset Overview ─────────────┐
-│  Name         Strategy  Query      Last  │
-│  ─────────    ────────  ─────────  ────  │
-│  dev          OR logic  {"$or"...  never │
-│  production   Advanced  {"$and"... never │
-│  staging      OR logic  {"tag":"...9/6   │
-└──────────────────────────────────────────┘
+┌─────────────────────────────────────────────┐
+│  Name              Strategy   Query                               │
+│  ────────────────  ─────────  ──────────────────────────────────  │
+│  dev              OR logic   {"$or":[...                        │
+│  production       Advanced  {"$and":[...                       │
+│  staging          OR logic   {"tag":"staging"}                 │
+└─────────────────────────────────────────────────────────────────────────────┘
 
 ┌──────────── Quick Reference ─────────────┐
 │  Available Commands:                     │
@@ -97,11 +96,6 @@ Create your first preset with:
 
 长查询会截断为 "..." 以保持表格格式。使用 `preset show <name>` 查看完整查询。
 
-### 最后使用跟踪
-
-- **日期格式**：预设最后访问时的 MM/DD/YYYY
-- **"从未"**：预设自创建以来未使用过
-
 ## 工作流程集成
 
 list 命令与其他预设命令配合良好：
@@ -123,7 +117,7 @@ npx -y @1mcp/agent preset url production
 ## 使用技巧
 
 - **定期审查**：使用 `preset list` 定期审查您的预设配置
-- **清理旧预设**：查找未使用的预设（在最后使用列中显示"从未"）
+- **清理旧预设**：查找不需要的预设
 - **快速扫描**：表格格式使比较策略和识别预设变得容易
 - **跟进详细信息**：需要完整信息时使用 `preset show <name>`
 

--- a/docs/zh/commands/preset/show.md
+++ b/docs/zh/commands/preset/show.md
@@ -29,7 +29,7 @@ npx -y @1mcp/agent preset show <name>
 
 ### 显示的信息
 
-- **基本信息**：名称、策略、描述、创建日期、最后使用
+- **基本信息**：名称、策略、描述、创建日期
 - **客户端 URL**：用于 MCP 客户端配置的即用型 URL
 - **标签查询**：具有适当格式的完整 JSON 查询（无截断）
 - **服务器匹配**：哪些服务器匹配预设条件
@@ -55,7 +55,6 @@ npx -y @1mcp/agent preset show production
 │ Strategy: OR logic - Match ANY tags   │
 │ Description: Development servers      │
 │ Created: 9/6/2025                     │
-│ Last Used: Never                      │
 │                                       │
 │ Client URL:                           │
 │ http://127.0.0.1:3050/?preset=dev     │
@@ -86,7 +85,6 @@ npx -y @1mcp/agent preset show production
 - **策略**：人类可读的策略描述
 - **描述**：可选的用户提供的描述
 - **创建**：预设首次创建的时间
-- **最后使用**：预设最后访问的时间（或"从未"）
 
 ### 客户端 URL
 

--- a/src/commands/mcp/tokens.ts
+++ b/src/commands/mcp/tokens.ts
@@ -439,9 +439,6 @@ export async function tokensCommand(argv: Arguments<TokensCommandArgs>): Promise
           const serverTags = (serverConfig as MCPServerParams).tags || [];
           return TagQueryEvaluator.evaluate(preset.tagQuery, serverTags);
         });
-
-        // Update preset usage tracking
-        await presetManager.markPresetUsed(argv.preset);
       } catch (error) {
         console.error(
           chalk.red(

--- a/src/commands/preset/interactive.ts
+++ b/src/commands/preset/interactive.ts
@@ -109,10 +109,9 @@ async function offerPresetSelection(availablePresets: any[], selector: Interacti
   // Show available presets
   for (let i = 0; i < availablePresets.length; i++) {
     const preset = availablePresets[i];
-    const lastUsed = preset.lastUsed ? new Date(preset.lastUsed).toLocaleDateString() : 'never';
     const strategyDesc = getStrategyDescription(preset.strategy);
 
-    console.log(`   ${i + 1}. ${preset.name} (${strategyDesc}) - Last used: ${lastUsed}`);
+    console.log(`   ${i + 1}. ${preset.name} (${strategyDesc})`);
     if (preset.description) {
       console.log(`      ${preset.description}`);
     }

--- a/src/commands/preset/list.ts
+++ b/src/commands/preset/list.ts
@@ -75,12 +75,11 @@ async function listPresets(presetManager: PresetManager, _selector: InteractiveS
   let tableContent = '';
 
   // Table header
-  tableContent += chalk.cyan.bold('  Name              Strategy   Query                               Last Used\n');
-  tableContent += chalk.gray('  ────────────────  ─────────  ──────────────────────────────────  ─────────\n');
+  tableContent += chalk.cyan.bold('  Name              Strategy   Query\n');
+  tableContent += chalk.gray('  ────────────────  ─────────  ──────────────────────────────────\n');
 
   // Table rows
   for (const preset of presets) {
-    const lastUsed = preset.lastUsed ? new Date(preset.lastUsed).toLocaleDateString() : 'never';
     const strategyDesc = getStrategyDescription(preset.strategy);
     const queryStr = JSON.stringify(preset.tagQuery) || '{}';
 
@@ -88,13 +87,11 @@ async function listPresets(presetManager: PresetManager, _selector: InteractiveS
     const name = preset.name.length > 16 ? preset.name.slice(0, 13) + '...' : preset.name;
     const strategy = strategyDesc.length > 9 ? strategyDesc.slice(0, 9) : strategyDesc;
     const query = queryStr.length > 33 ? queryStr.slice(0, 30) + '...' : queryStr;
-    const lastUsedStr = lastUsed.length > 9 ? lastUsed.slice(0, 9) : lastUsed;
 
     tableContent +=
       `  ${chalk.yellow(name.padEnd(16))}  ` +
       `${chalk.blue(strategy.padEnd(9))}  ` +
-      `${chalk.green(query.padEnd(33))}  ` +
-      `${chalk.gray(lastUsedStr)}\n`;
+      `${chalk.green(query.padEnd(33))}\n`;
   }
 
   const tableBox = boxen(tableContent.trim(), {

--- a/src/commands/preset/show.ts
+++ b/src/commands/preset/show.ts
@@ -73,9 +73,6 @@ async function showPresetDetails(
     mainContent += chalk.gray(`Description: ${preset.description}\n`);
   }
   mainContent += chalk.dim(`Created: ${new Date(preset.created).toLocaleDateString()}\n`);
-  mainContent += chalk.dim(
-    `Last Used: ${preset.lastUsed ? new Date(preset.lastUsed).toLocaleDateString() : 'Never'}\n`,
-  );
 
   // URL section
   const urlResult = await urlGenerator.validateAndGeneratePresetUrl(name);

--- a/src/utils/presetManager.test.ts
+++ b/src/utils/presetManager.test.ts
@@ -906,18 +906,6 @@ describe('PresetManager', () => {
       });
     });
 
-    it('should mark preset as used', async () => {
-      await presetManager.markPresetUsed('dev');
-
-      const writeCall = mockFs.writeFile.mock.calls.find(
-        (call: any) => call[0] === '/mock/home/.config/1mcp/presets.json',
-      );
-      const savedData = JSON.parse(writeCall[1]);
-
-      expect(savedData.presets.dev.lastUsed).toBeDefined();
-      expect(new Date(savedData.presets.dev.lastUsed)).toBeInstanceOf(Date);
-    });
-
     it('should get configuration path', () => {
       const configPath = presetManager.getConfigPath();
       expect(configPath).toBe('/mock/home/.config/1mcp/presets.json');

--- a/src/utils/presetManager.ts
+++ b/src/utils/presetManager.ts
@@ -424,7 +424,6 @@ export class PresetManager {
       name: preset.name,
       description: preset.description,
       strategy: preset.strategy,
-      lastUsed: preset.lastUsed,
       tagQuery: preset.tagQuery,
     }));
   }
@@ -442,19 +441,6 @@ export class PresetManager {
 
     logger.info('Preset deleted successfully', { name });
     return true;
-  }
-
-  /**
-   * Update preset usage timestamp
-   */
-  public async markPresetUsed(name: string): Promise<void> {
-    const preset = this.presets.get(name);
-    if (!preset) {
-      return;
-    }
-
-    preset.lastUsed = new Date().toISOString();
-    await this.savePresets();
   }
 
   /**
@@ -520,11 +506,6 @@ export class PresetManager {
     }
 
     try {
-      // Mark preset as used
-      this.markPresetUsed(name).catch((error) => {
-        logger.warn('Failed to update preset usage', { name, error });
-      });
-
       // Convert JSON query to string representation for backward compatibility
       const expression = TagQueryEvaluator.queryToString(preset.tagQuery);
 

--- a/src/utils/presetTypes.ts
+++ b/src/utils/presetTypes.ts
@@ -28,7 +28,6 @@ export interface PresetConfig {
   tagQuery: TagQuery; // JSON-based query format
   created: string;
   lastModified: string;
-  lastUsed?: string;
 }
 
 export interface PresetStorage {
@@ -45,7 +44,6 @@ export interface PresetValidationResult {
 export interface PresetUsageStats {
   name: string;
   serverCount: number;
-  lastUsed?: string;
   usageFrequency: number;
 }
 
@@ -53,6 +51,5 @@ export interface PresetListItem {
   name: string;
   description?: string;
   strategy: PresetStrategy;
-  lastUsed?: string;
   tagQuery: TagQuery;
 }


### PR DESCRIPTION
- Remove last used tracking from preset functionality
- Update preset list and show commands to remove last used information
- Delete markPresetUsed method from PresetManager
- Remove lastUsed property from PresetConfig and related interfaces