### PR TITLE
fix(core): add empty instruction handling for servers

### DIFF
--- a/src/core/instructions/instructionAggregator.ts
+++ b/src/core/instructions/instructionAggregator.ts
@@ -291,6 +291,12 @@ export class InstructionAggregator extends EventEmitter {
           instructions: serverInstructions.trim(),
           hasInstructions: true,
         });
+      } else {
+        servers.push({
+          name: serverName,
+          instructions: '',
+          hasInstructions: false,
+        });
       }
     }
 


### PR DESCRIPTION
When server instructions are empty or null, the application now properly handles this case by setting hasInstructions to false and providing an empty string for instructions instead of leaving the server object in an inconsistent state.