### PR TITLE
docs: Fix binary filenames in installation guide for all platforms

### DIFF
--- a/docs/en/guide/installation.md
+++ b/docs/en/guide/installation.md
@@ -35,7 +35,7 @@ Download the standalone binary for your platform - no Node.js required!
 # Download and extract archive
 curl -L -o 1mcp-linux-x64.tar.gz https://github.com/1mcp-app/agent/releases/latest/download/1mcp-linux-x64.tar.gz
 tar -xzf 1mcp-linux-x64.tar.gz
-sudo mv 1mcp /usr/local/bin/
+sudo mv 1mcp-linux-x64 /usr/local/bin/1mcp
 sudo chmod +x /usr/local/bin/1mcp
 
 # Clean up
@@ -51,7 +51,7 @@ rm 1mcp-linux-x64.tar.gz
 # Download and extract archive
 curl -L -o 1mcp-linux-arm64.tar.gz https://github.com/1mcp-app/agent/releases/latest/download/1mcp-linux-arm64.tar.gz
 tar -xzf 1mcp-linux-arm64.tar.gz
-sudo mv 1mcp /usr/local/bin/
+sudo mv 1mcp-linux-arm64 /usr/local/bin/1mcp
 sudo chmod +x /usr/local/bin/1mcp
 
 # Clean up
@@ -67,7 +67,7 @@ rm 1mcp-linux-arm64.tar.gz
 # Download and extract archive
 curl -L -o 1mcp-darwin-arm64.tar.gz https://github.com/1mcp-app/agent/releases/latest/download/1mcp-darwin-arm64.tar.gz
 tar -xzf 1mcp-darwin-arm64.tar.gz
-sudo mv 1mcp /usr/local/bin/
+sudo mv 1mcp-darwin-arm64 /usr/local/bin/1mcp
 sudo chmod +x /usr/local/bin/1mcp
 
 # Clean up
@@ -83,7 +83,7 @@ rm 1mcp-darwin-arm64.tar.gz
 # Download and extract archive
 curl -L -o 1mcp-darwin-x64.tar.gz https://github.com/1mcp-app/agent/releases/latest/download/1mcp-darwin-x64.tar.gz
 tar -xzf 1mcp-darwin-x64.tar.gz
-sudo mv 1mcp /usr/local/bin/
+sudo mv 1mcp-darwin-x64 /usr/local/bin/1mcp
 sudo chmod +x /usr/local/bin/1mcp
 
 # Clean up
@@ -101,7 +101,7 @@ Invoke-WebRequest -Uri "https://github.com/1mcp-app/agent/releases/latest/downlo
 Expand-Archive -Path "1mcp-win32-x64.zip" -DestinationPath "."
 
 # Option 1: Use directly
-.\1mcp.exe --version
+.\1mcp-win32-x64.exe --version
 
 # Option 2: Add to PATH for global access
 # Move to a directory in PATH (e.g., C:\Windows\System32 or create a new directory)


### PR DESCRIPTION
## Problem
The installation guide currently assumes that extracting the release archive results in a generic binary named `1mcp` (or `1mcp.exe` on Windows).

However, the build artifacts actually preserve their platform-specific names after extraction (e.g., `1mcp-darwin-arm64`, `1mcp-linux-x64`). As a result, the documented `mv` commands fail with a "No such file or directory" error.

## Solution
I have updated the installation commands for **Linux (x64/ARM64)**, **macOS (Intel/Silicon)**, and **Windows** to explicitly reference the correct extracted binary names.

## Verification
I verified this on **macOS (Apple Silicon)**. As shown in the screenshot below, the original command fails, but renaming the specific binary works correctly.

### Screenshot of the issue
<img width="532" height="77" alt="image" src="https://github.com/user-attachments/assets/cfe69299-059b-471b-90e3-8c0fc56cf69c" />


## Checklist
- [x] I have read the Contributing Guidelines.
- [x] My changes are limited to the documentation fix.