### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/core/capabilities/internal/discoveryTools.ts
+++ b/src/core/capabilities/internal/discoveryTools.ts
@@ -29,6 +29,11 @@ export function createSearchTool(): Tool {
     description: 'Search for MCP servers in the registry',
     inputSchema: zodToInputSchema(McpSearchToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpSearchOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Search MCP Servers',
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
   };
 }
 
@@ -43,6 +48,11 @@ export function createRegistryStatusTool(): Tool {
     description: 'Check registry availability and performance',
     inputSchema: zodToInputSchema(McpRegistryStatusSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpRegistryStatusOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Check Registry Status',
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
   };
 }
 
@@ -55,6 +65,11 @@ export function createRegistryInfoTool(): Tool {
     description: 'Get detailed registry information',
     inputSchema: zodToInputSchema(McpRegistryInfoSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpRegistryInfoOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Get Registry Info',
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
   };
 }
 
@@ -67,6 +82,11 @@ export function createRegistryListTool(): Tool {
     description: 'List available registries',
     inputSchema: zodToInputSchema(McpRegistryListSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpRegistryListOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'List Registries',
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
   };
 }
 
@@ -79,5 +99,10 @@ export function createInfoTool(): Tool {
     description: 'Get detailed information about a specific MCP server',
     inputSchema: zodToInputSchema(McpInfoToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpInfoOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Get Server Info',
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
   };
 }

--- a/src/core/capabilities/internal/installationTools.ts
+++ b/src/core/capabilities/internal/installationTools.ts
@@ -26,6 +26,11 @@ export function createInstallTool(): Tool {
       'Install a new MCP server. Use package+command+args for direct package installation (e.g., npm packages), or just name for registry-based installation',
     inputSchema: zodToInputSchema(McpInstallToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpInstallOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Install MCP Server',
+      destructiveHint: true,
+      openWorldHint: true,
+    },
   };
 }
 
@@ -38,6 +43,10 @@ export function createUninstallTool(): Tool {
     description: 'Remove an MCP server',
     inputSchema: zodToInputSchema(McpUninstallToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpUninstallOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Uninstall MCP Server',
+      destructiveHint: true,
+    },
   };
 }
 
@@ -50,5 +59,10 @@ export function createUpdateTool(): Tool {
     description: 'Update an MCP server',
     inputSchema: zodToInputSchema(McpUpdateToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpUpdateOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Update MCP Server',
+      destructiveHint: true,
+      openWorldHint: true,
+    },
   };
 }

--- a/src/core/capabilities/internal/managementTools.ts
+++ b/src/core/capabilities/internal/managementTools.ts
@@ -31,6 +31,10 @@ export function createEnableTool(): Tool {
     description: 'Enable an MCP server',
     inputSchema: zodToInputSchema(McpEnableToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpEnableOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Enable MCP Server',
+      destructiveHint: true,
+    },
   };
 }
 
@@ -43,6 +47,10 @@ export function createDisableTool(): Tool {
     description: 'Disable an MCP server',
     inputSchema: zodToInputSchema(McpDisableToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpDisableOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Disable MCP Server',
+      destructiveHint: true,
+    },
   };
 }
 
@@ -55,6 +63,10 @@ export function createListTool(): Tool {
     description: 'List MCP servers',
     inputSchema: zodToInputSchema(McpListToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpListOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'List MCP Servers',
+      readOnlyHint: true,
+    },
   };
 }
 
@@ -67,6 +79,10 @@ export function createStatusTool(): Tool {
     description: 'Get MCP server status',
     inputSchema: zodToInputSchema(McpStatusToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpStatusOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Get Server Status',
+      readOnlyHint: true,
+    },
   };
 }
 
@@ -79,6 +95,10 @@ export function createEditTool(): Tool {
     description: 'Edit MCP server configuration',
     inputSchema: zodToInputSchema(McpEditToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpEditOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Edit Server Config',
+      destructiveHint: true,
+    },
   };
 }
 
@@ -91,5 +111,10 @@ export function createReloadTool(): Tool {
     description: 'Reload MCP server or configuration',
     inputSchema: zodToInputSchema(McpReloadToolSchema) as Tool['inputSchema'],
     outputSchema: zodToOutputSchema(McpReloadOutputSchema) as Tool['outputSchema'],
+    annotations: {
+      title: 'Reload Server',
+      destructiveHint: true,
+      idempotentHint: true,
+    },
   };
 }


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `openWorldHint`, `idempotentHint`, `title`) to all 14 internal tools to help MCP clients better understand tool behavior and make safer decisions about tool execution.

## Changes

### Discovery Tools (5 read-only tools)
- `mcp_search` - Added `readOnlyHint: true`, `openWorldHint: true`
- `mcp_registry_status` - Added `readOnlyHint: true`, `openWorldHint: true`
- `mcp_registry_info` - Added `readOnlyHint: true`, `openWorldHint: true`
- `mcp_registry_list` - Added `readOnlyHint: true`, `openWorldHint: true`
- `mcp_info` - Added `readOnlyHint: true`, `openWorldHint: true`

### Installation Tools (3 destructive tools)
- `mcp_install` - Added `destructiveHint: true`, `openWorldHint: true`
- `mcp_uninstall` - Added `destructiveHint: true`
- `mcp_update` - Added `destructiveHint: true`, `openWorldHint: true`

### Management Tools (6 mixed tools)
- `mcp_enable` - Added `destructiveHint: true`
- `mcp_disable` - Added `destructiveHint: true`
- `mcp_list` - Added `readOnlyHint: true`
- `mcp_status` - Added `readOnlyHint: true`
- `mcp_edit` - Added `destructiveHint: true`
- `mcp_reload` - Added `destructiveHint: true`, `idempotentHint: true`

All tools also have human-readable `title` annotations added.

## Why This Matters

Tool annotations provide semantic metadata that enables MCP clients to:
- Auto-approve read-only tools without user confirmation
- Show warnings or confirmation prompts for destructive operations
- Display human-readable titles in UI
- Implement smarter caching and retry strategies
- Understand which tools access external resources (registries)

## Testing

- [x] Server builds successfully (`pnpm run build`)
- [x] Linter passes (`pnpm run lint`)
- [x] Pre-commit hooks pass (TypeScript type check, ESLint, Prettier)
- [x] Annotations verified in compiled JavaScript output
- [x] Annotation values correctly categorize tool behavior

## Before/After

**Before:**
```typescript
export function createSearchTool(): Tool {
  return {
    name: 'mcp_search',
    description: 'Search for MCP servers in the registry',
    inputSchema: zodToInputSchema(McpSearchToolSchema) as Tool['inputSchema'],
    outputSchema: zodToOutputSchema(McpSearchOutputSchema) as Tool['outputSchema'],
  };
}
```

**After:**
```typescript
export function createSearchTool(): Tool {
  return {
    name: 'mcp_search',
    description: 'Search for MCP servers in the registry',
    inputSchema: zodToInputSchema(McpSearchToolSchema) as Tool['inputSchema'],
    outputSchema: zodToOutputSchema(McpSearchOutputSchema) as Tool['outputSchema'],
    annotations: {
      title: 'Search MCP Servers',
      readOnlyHint: true,
      openWorldHint: true,
    },
  };
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)