### PR TITLE
fix: sanitize tool names for AI provider compliance

### DIFF
--- a/src/commands/mcp/index.ts
+++ b/src/commands/mcp/index.ts
@@ -37,9 +37,8 @@ export function setupMcpCommands(yargs: Argv): Argv {
           builder: buildAddCommand,
           handler: async (argv) => {
             const { addCommand } = await import('./add.js');
-            const { parseDoubleHyphenArgs, hasDoubleHyphen, mergeDoubleHyphenArgs } = await import(
-              './utils/doubleHyphenParser.js'
-            );
+            const { parseDoubleHyphenArgs, hasDoubleHyphen, mergeDoubleHyphenArgs } =
+              await import('./utils/doubleHyphenParser.js');
 
             // Check if " -- " pattern is used
             if (hasDoubleHyphen(process.argv)) {
@@ -84,9 +83,8 @@ export function setupMcpCommands(yargs: Argv): Argv {
           builder: buildUpdateCommand,
           handler: async (argv) => {
             const { updateCommand } = await import('./update.js');
-            const { parseDoubleHyphenArgs, hasDoubleHyphen, mergeDoubleHyphenArgs } = await import(
-              './utils/doubleHyphenParser.js'
-            );
+            const { parseDoubleHyphenArgs, hasDoubleHyphen, mergeDoubleHyphenArgs } =
+              await import('./utils/doubleHyphenParser.js');
 
             // Check if " -- " pattern is used
             if (hasDoubleHyphen(process.argv)) {

--- a/src/core/protocol/requestHandlers.ts
+++ b/src/core/protocol/requestHandlers.ts
@@ -36,7 +36,7 @@ import { ClientStatus, InboundConnection, OutboundConnection, OutboundConnection
 import { setLogLevel } from '@src/logger/logger.js';
 import logger from '@src/logger/logger.js';
 import { withErrorHandling } from '@src/utils/core/errorHandling.js';
-import { buildUri, parseUri } from '@src/utils/core/parsing.js';
+import { buildUri, desanitizeToolName, parseUri, sanitizeToolName } from '@src/utils/core/parsing.js';
 import { getRequestTimeout } from '@src/utils/core/timeoutUtils.js';
 import { handlePagination } from '@src/utils/ui/pagination.js';
 
@@ -421,7 +421,7 @@ function registerToolHandlers(
         // Add internal tools to the result (with 1mcp prefix)
         const internalToolsWithPrefix = nonLazyTools.map((tool) => ({
           ...tool,
-          name: buildUri('1mcp', tool.name, MCP_URI_SEPARATOR),
+          name: sanitizeToolName(buildUri('1mcp', tool.name, MCP_URI_SEPARATOR)),
         }));
 
         // Combine lazy-loaded tools with internal tools
@@ -447,7 +447,7 @@ function registerToolHandlers(
         (outboundConn, result) =>
           result.tools?.map((tool) => ({
             ...tool,
-            name: buildUri(outboundConn.name, tool.name, MCP_URI_SEPARATOR),
+            name: sanitizeToolName(buildUri(outboundConn.name, tool.name, MCP_URI_SEPARATOR)),
           })) ?? [],
         inboundConn.enablePagination ?? false,
       );
@@ -460,7 +460,7 @@ function registerToolHandlers(
       // Add internal tools to the result (with 1mcp prefix)
       const internalToolsWithPrefix = internalTools.map((tool) => ({
         ...tool,
-        name: buildUri('1mcp', tool.name, MCP_URI_SEPARATOR),
+        name: sanitizeToolName(buildUri('1mcp', tool.name, MCP_URI_SEPARATOR)),
       }));
 
       // Combine external and internal tools
@@ -534,7 +534,7 @@ function registerToolHandlers(
         };
       }
 
-      const { clientName, resourceName: extractedToolName } = parseUri(toolName, MCP_URI_SEPARATOR);
+      const { clientName, resourceName: extractedToolName } = parseUri(desanitizeToolName(toolName), MCP_URI_SEPARATOR);
 
       // Handle 1mcp tools (includes both internal tools and lazy tools)
       if (clientName === '1mcp') {

--- a/src/core/server/clientInstancePool.ts
+++ b/src/core/server/clientInstancePool.ts
@@ -6,6 +6,7 @@ import logger, { debugIf, infoIf } from '@src/logger/logger.js';
 import { HandlebarsTemplateRenderer } from '@src/template/handlebarsTemplateRenderer.js';
 import { createTransportsWithContext } from '@src/transport/transportFactory.js';
 import type { ContextData } from '@src/types/context.js';
+import { getConnectionTimeout } from '@src/utils/core/timeoutUtils.js';
 import { createHash } from '@src/utils/crypto.js';
 
 /**
@@ -428,8 +429,9 @@ export class ClientInstancePool {
     const clientManager = ClientManager.getOrCreateInstance();
     const client = clientManager.createPooledClientInstance();
 
-    // Connect client to the upstream server
-    await client.connect(transport);
+    // Connect client to the upstream server, respecting connectionTimeout from transport config
+    const connectionTimeout = getConnectionTimeout(transport);
+    await client.connect(transport, connectionTimeout ? { timeout: connectionTimeout } : undefined);
 
     return {
       id: this.generateInstanceId(),

--- a/src/core/tools/internal/adapters/installationAdapter.test.ts
+++ b/src/core/tools/internal/adapters/installationAdapter.test.ts
@@ -64,9 +64,8 @@ describe('Installation Adapter', () => {
         config: { type: 'stdio', command: 'node', args: ['server.js'] },
       };
 
-      const { createServerInstallationService } = await import(
-        '@src/domains/server-management/serverInstallationService.js'
-      );
+      const { createServerInstallationService } =
+        await import('@src/domains/server-management/serverInstallationService.js');
       const mockService = (createServerInstallationService as any)();
       mockService.installServer.mockResolvedValue(mockResult);
 
@@ -102,9 +101,8 @@ describe('Installation Adapter', () => {
     });
 
     it('should handle installation errors', async () => {
-      const { createServerInstallationService } = await import(
-        '@src/domains/server-management/serverInstallationService.js'
-      );
+      const { createServerInstallationService } =
+        await import('@src/domains/server-management/serverInstallationService.js');
       const mockService = (createServerInstallationService as any)();
       mockService.installServer.mockRejectedValue(new Error('Installation failed'));
 
@@ -126,9 +124,8 @@ describe('Installation Adapter', () => {
         operationId: 'test-op-id',
       };
 
-      const { createServerInstallationService } = await import(
-        '@src/domains/server-management/serverInstallationService.js'
-      );
+      const { createServerInstallationService } =
+        await import('@src/domains/server-management/serverInstallationService.js');
       const mockService = (createServerInstallationService as any)();
       mockService.uninstallServer.mockResolvedValue(mockResult);
 
@@ -153,9 +150,8 @@ describe('Installation Adapter', () => {
     });
 
     it('should handle uninstallation errors', async () => {
-      const { createServerInstallationService } = await import(
-        '@src/domains/server-management/serverInstallationService.js'
-      );
+      const { createServerInstallationService } =
+        await import('@src/domains/server-management/serverInstallationService.js');
       const mockService = (createServerInstallationService as any)();
       mockService.uninstallServer.mockRejectedValue(new Error('Uninstall failed'));
 
@@ -178,9 +174,8 @@ describe('Installation Adapter', () => {
         operationId: 'test-op-id',
       };
 
-      const { createServerInstallationService } = await import(
-        '@src/domains/server-management/serverInstallationService.js'
-      );
+      const { createServerInstallationService } =
+        await import('@src/domains/server-management/serverInstallationService.js');
       const mockService = (createServerInstallationService as any)();
       mockService.updateServer.mockResolvedValue(mockResult);
 
@@ -214,9 +209,8 @@ describe('Installation Adapter', () => {
     });
 
     it('should handle update errors', async () => {
-      const { createServerInstallationService } = await import(
-        '@src/domains/server-management/serverInstallationService.js'
-      );
+      const { createServerInstallationService } =
+        await import('@src/domains/server-management/serverInstallationService.js');
       const mockService = (createServerInstallationService as any)();
       mockService.updateServer.mockRejectedValue(new Error('Update failed'));
 

--- a/src/domains/backup/backupManager.ts
+++ b/src/domains/backup/backupManager.ts
@@ -31,16 +31,16 @@ function isValidBackupInfo(obj: unknown): obj is BackupInfo {
 
   return Boolean(
     typeof backup.originalPath === 'string' &&
-      typeof backup.backupPath === 'string' &&
-      typeof backup.timestamp === 'number' &&
-      typeof backup.checksum === 'string' &&
-      backup.metadata &&
-      typeof backup.metadata === 'object' &&
-      typeof (backup.metadata as Record<string, unknown>).app === 'string' &&
-      typeof (backup.metadata as Record<string, unknown>).operation === 'string' &&
-      typeof (backup.metadata as Record<string, unknown>).version === 'string' &&
-      typeof (backup.metadata as Record<string, unknown>).serverCount === 'number' &&
-      typeof (backup.metadata as Record<string, unknown>).fileSize === 'number',
+    typeof backup.backupPath === 'string' &&
+    typeof backup.timestamp === 'number' &&
+    typeof backup.checksum === 'string' &&
+    backup.metadata &&
+    typeof backup.metadata === 'object' &&
+    typeof (backup.metadata as Record<string, unknown>).app === 'string' &&
+    typeof (backup.metadata as Record<string, unknown>).operation === 'string' &&
+    typeof (backup.metadata as Record<string, unknown>).version === 'string' &&
+    typeof (backup.metadata as Record<string, unknown>).serverCount === 'number' &&
+    typeof (backup.metadata as Record<string, unknown>).fileSize === 'number',
   );
 }
 

--- a/src/transport/http/routes/sseRoutes.test.ts
+++ b/src/transport/http/routes/sseRoutes.test.ts
@@ -158,9 +158,8 @@ describe('SSE Routes', () => {
 
     it('should handle SSE connection successfully', async () => {
       const { SSEServerTransport } = await import('@modelcontextprotocol/sdk/server/sse.js');
-      const { getValidatedTags, getTagExpression, getTagFilterMode, getPresetName } = await import(
-        '../middlewares/scopeAuthMiddleware.js'
-      );
+      const { getValidatedTags, getTagExpression, getTagFilterMode, getPresetName } =
+        await import('../middlewares/scopeAuthMiddleware.js');
 
       // Clear mocks specifically for this test
       vi.mocked(mockServerManager.connectTransport).mockClear();
@@ -197,9 +196,8 @@ describe('SSE Routes', () => {
 
     it('should handle SSE connection with pagination disabled', async () => {
       const { SSEServerTransport } = await import('@modelcontextprotocol/sdk/server/sse.js');
-      const { getValidatedTags, getTagExpression, getTagFilterMode, getPresetName } = await import(
-        '../middlewares/scopeAuthMiddleware.js'
-      );
+      const { getValidatedTags, getTagExpression, getTagFilterMode, getPresetName } =
+        await import('../middlewares/scopeAuthMiddleware.js');
 
       // Clear mocks specifically for this test
       vi.mocked(mockServerManager.connectTransport).mockClear();
@@ -260,9 +258,8 @@ describe('SSE Routes', () => {
 
     it('should setup onclose handler for transport', async () => {
       const { SSEServerTransport } = await import('@modelcontextprotocol/sdk/server/sse.js');
-      const { getValidatedTags, getTagExpression, getTagFilterMode, getPresetName } = await import(
-        '../middlewares/scopeAuthMiddleware.js'
-      );
+      const { getValidatedTags, getTagExpression, getTagFilterMode, getPresetName } =
+        await import('../middlewares/scopeAuthMiddleware.js');
 
       // Clear mocks specifically for this test
       vi.mocked(mockServerManager.connectTransport).mockClear();
@@ -293,9 +290,8 @@ describe('SSE Routes', () => {
 
     it('should handle empty validated tags', async () => {
       const { SSEServerTransport } = await import('@modelcontextprotocol/sdk/server/sse.js');
-      const { getValidatedTags, getTagExpression, getTagFilterMode, getPresetName } = await import(
-        '../middlewares/scopeAuthMiddleware.js'
-      );
+      const { getValidatedTags, getTagExpression, getTagFilterMode, getPresetName } =
+        await import('../middlewares/scopeAuthMiddleware.js');
 
       // Clear mocks specifically for this test
       vi.mocked(mockServerManager.connectTransport).mockClear();

--- a/src/transport/http/utils/sessionService.test.ts
+++ b/src/transport/http/utils/sessionService.test.ts
@@ -96,9 +96,8 @@ describe('SessionService', () => {
   describe('restoreSession', () => {
     beforeEach(async () => {
       // Mock RestorableStreamableHTTPServerTransport methods to succeed by default
-      const { RestorableStreamableHTTPServerTransport } = await import(
-        '@src/transport/http/restorableStreamableTransport.js'
-      );
+      const { RestorableStreamableHTTPServerTransport } =
+        await import('@src/transport/http/restorableStreamableTransport.js');
       vi.spyOn(RestorableStreamableHTTPServerTransport.prototype, 'handleRequest').mockResolvedValue(undefined);
       vi.spyOn(RestorableStreamableHTTPServerTransport.prototype, 'markAsRestored').mockImplementation(() => {});
     });
@@ -170,9 +169,8 @@ describe('SessionService', () => {
     });
 
     it('should call markAsRestored after successful virtual initialize', async () => {
-      const { RestorableStreamableHTTPServerTransport } = await import(
-        '@src/transport/http/restorableStreamableTransport.js'
-      );
+      const { RestorableStreamableHTTPServerTransport } =
+        await import('@src/transport/http/restorableStreamableTransport.js');
       const markAsRestoredSpy = vi.spyOn(RestorableStreamableHTTPServerTransport.prototype, 'markAsRestored');
 
       const mockSessionData = {
@@ -441,9 +439,8 @@ describe('SessionService', () => {
   describe('SessionRestoreResult type', () => {
     beforeEach(async () => {
       // Mock RestorableStreamableHTTPServerTransport methods for these tests
-      const { RestorableStreamableHTTPServerTransport } = await import(
-        '@src/transport/http/restorableStreamableTransport.js'
-      );
+      const { RestorableStreamableHTTPServerTransport } =
+        await import('@src/transport/http/restorableStreamableTransport.js');
       vi.spyOn(RestorableStreamableHTTPServerTransport.prototype, 'handleRequest').mockResolvedValue(undefined);
       vi.spyOn(RestorableStreamableHTTPServerTransport.prototype, 'markAsRestored').mockImplementation(() => {});
     });
@@ -546,9 +543,8 @@ describe('SessionService', () => {
   describe('integration scenarios', () => {
     beforeEach(async () => {
       // Mock RestorableStreamableHTTPServerTransport methods
-      const { RestorableStreamableHTTPServerTransport } = await import(
-        '@src/transport/http/restorableStreamableTransport.js'
-      );
+      const { RestorableStreamableHTTPServerTransport } =
+        await import('@src/transport/http/restorableStreamableTransport.js');
       vi.spyOn(RestorableStreamableHTTPServerTransport.prototype, 'handleRequest').mockResolvedValue(undefined);
       vi.spyOn(RestorableStreamableHTTPServerTransport.prototype, 'markAsRestored').mockImplementation(() => {});
     });

--- a/src/utils/core/parsing.test.ts
+++ b/src/utils/core/parsing.test.ts
@@ -3,7 +3,7 @@ import { MCP_URI_SEPARATOR } from '@src/constants.js';
 import { describe, expect, it } from 'vitest';
 
 import { InvalidRequestError } from './errorTypes.js';
-import { buildUri, parseUri } from './parsing.js';
+import { buildUri, desanitizeToolName, parseUri, sanitizeToolName } from './parsing.js';
 
 describe('parseUri', () => {
   const separator = MCP_URI_SEPARATOR;
@@ -283,5 +283,41 @@ describe('buildUri', () => {
       expect(parsed.clientName).toBe(clientName);
       expect(parsed.resourceName).toBe(resourceName);
     });
+  });
+});
+
+describe('sanitizeToolName', () => {
+  it('should prepend underscore when name starts with a digit', () => {
+    expect(sanitizeToolName('1mcp_1mcp_mcp_search')).toBe('_1mcp_1mcp_mcp_search');
+    expect(sanitizeToolName('1tool')).toBe('_1tool');
+    expect(sanitizeToolName('9abc')).toBe('_9abc');
+  });
+
+  it('should leave names starting with a letter unchanged', () => {
+    expect(sanitizeToolName('appium-mcp_1mcp_tool')).toBe('appium-mcp_1mcp_tool');
+    expect(sanitizeToolName('filesystem_1mcp_read_file')).toBe('filesystem_1mcp_read_file');
+  });
+
+  it('should leave names starting with an underscore unchanged', () => {
+    expect(sanitizeToolName('_tool')).toBe('_tool');
+  });
+});
+
+describe('desanitizeToolName', () => {
+  it('should strip leading underscore added before a digit', () => {
+    expect(desanitizeToolName('_1mcp_1mcp_mcp_search')).toBe('1mcp_1mcp_mcp_search');
+    expect(desanitizeToolName('_1tool')).toBe('1tool');
+  });
+
+  it('should leave names that did not have a digit-prefix unchanged', () => {
+    expect(desanitizeToolName('appium-mcp_1mcp_tool')).toBe('appium-mcp_1mcp_tool');
+    expect(desanitizeToolName('_tool')).toBe('_tool');
+  });
+
+  it('should round-trip with sanitizeToolName', () => {
+    const names = ['1mcp_1mcp_mcp_search', 'filesystem_1mcp_read', '9abc_1mcp_x'];
+    for (const name of names) {
+      expect(desanitizeToolName(sanitizeToolName(name))).toBe(name);
+    }
   });
 });

--- a/src/utils/core/parsing.ts
+++ b/src/utils/core/parsing.ts
@@ -47,6 +47,33 @@ export function parseUri(uri: string, separator: string): UriParts {
 }
 
 /**
+ * Sanitizes a tool name to comply with AI provider naming rules (e.g. Gemini).
+ * Names must start with a letter or underscore; if the name starts with a digit,
+ * a leading underscore is prepended.
+ * @param name The tool name to sanitize
+ * @returns A valid tool name
+ */
+export function sanitizeToolName(name: string): string {
+  if (/^\d/.test(name)) {
+    return `_${name}`;
+  }
+  return name;
+}
+
+/**
+ * Reverses sanitizeToolName: strips the leading underscore added to names that
+ * originally started with a digit.
+ * @param name The (possibly sanitized) tool name
+ * @returns The original tool name
+ */
+export function desanitizeToolName(name: string): string {
+  if (/^_\d/.test(name)) {
+    return name.slice(1);
+  }
+  return name;
+}
+
+/**
  * Builds a URI by combining client name and resource name with a separator
  * @param clientName The client name
  * @param resourceName The resource name

--- a/test/e2e/internal-tools-mcp-protocol.test.ts
+++ b/test/e2e/internal-tools-mcp-protocol.test.ts
@@ -168,7 +168,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
       // Find internal discovery tools
       const discoveryTools = toolsResponse.tools.filter(
         (tool: any) =>
-          tool.name.startsWith('1mcp_1mcp_') &&
+          tool.name.startsWith('_1mcp_1mcp_') &&
           ['mcp_search', 'mcp_registry_status', 'mcp_registry_info', 'mcp_registry_list', 'mcp_info'].some((name) =>
             tool.name.includes(name),
           ),
@@ -178,7 +178,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
 
       // Verify each discovery tool has proper schema
       for (const tool of discoveryTools) {
-        expect(tool.name).toMatch(/^1mcp_1mcp_/);
+        expect(tool.name).toMatch(/^_1mcp_1mcp_/);
         expect(tool.description).toBeDefined();
         expect(typeof tool.description).toBe('string');
         expect(tool.inputSchema).toBeDefined();
@@ -188,7 +188,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
 
     it('should validate mcp_search tool schema', async () => {
       const toolsResponse = await mcpClient.listTools();
-      const searchTool = toolsResponse.tools.find((tool: any) => tool.name === '1mcp_1mcp_mcp_search');
+      const searchTool = toolsResponse.tools.find((tool: any) => tool.name === '_1mcp_1mcp_mcp_search');
 
       expect(searchTool).toBeDefined();
       expect(searchTool?.inputSchema).toBeDefined();
@@ -209,7 +209,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
 
   describe('MCP Tool Execution - Structured Output Validation', () => {
     it('should execute mcp_search and return structured data', async () => {
-      const result = await mcpClient.callTool('1mcp_1mcp_mcp_search', {
+      const result = await mcpClient.callTool('_1mcp_1mcp_mcp_search', {
         query: 'filesystem',
         limit: 5,
       });
@@ -242,7 +242,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
     });
 
     it('should execute mcp_registry_status and return structured data', async () => {
-      const result = await mcpClient.callTool('1mcp_1mcp_mcp_registry_status', {
+      const result = await mcpClient.callTool('_1mcp_1mcp_mcp_registry_status', {
         registry: 'official',
         includeStats: false, // Set to false to avoid timeout
       });
@@ -268,7 +268,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
     });
 
     it('should execute mcp_registry_info and return structured data', async () => {
-      const result = await mcpClient.callTool('1mcp_1mcp_mcp_registry_info', {
+      const result = await mcpClient.callTool('_1mcp_1mcp_mcp_registry_info', {
         registry: 'official',
       });
 
@@ -295,7 +295,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
     });
 
     it('should execute mcp_registry_list and return structured data', async () => {
-      const result = await mcpClient.callTool('1mcp_1mcp_mcp_registry_list', {
+      const result = await mcpClient.callTool('_1mcp_1mcp_mcp_registry_list', {
         includeStats: false,
       });
 
@@ -331,7 +331,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
     it('should handle mcp_info for non-existent server', async () => {
       // This test may fail if the server info tool has issues, so let's handle it gracefully
       try {
-        const result = await mcpClient.callTool('1mcp_1mcp_mcp_info', {
+        const result = await mcpClient.callTool('_1mcp_1mcp_mcp_info', {
           name: 'non-existent-server-12345',
         });
 
@@ -365,7 +365,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
     it('should handle invalid arguments gracefully', async () => {
       // Test with invalid arguments that should trigger validation errors
       try {
-        const result = await mcpClient.callTool('1mcp_1mcp_mcp_search', {
+        const result = await mcpClient.callTool('_1mcp_1mcp_mcp_search', {
           query: 'test',
           limit: -1, // Invalid negative limit
         });
@@ -382,7 +382,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
     it('should handle network errors in registry operations gracefully', async () => {
       // Mock a network failure by using an invalid registry
       try {
-        const result = await mcpClient.callTool('1mcp_1mcp_mcp_registry_status', {
+        const result = await mcpClient.callTool('_1mcp_1mcp_mcp_registry_status', {
           registry: 'http://invalid-registry-url-that-does-not-exist.com',
         });
 
@@ -405,9 +405,9 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
 
     it('should maintain connection health across multiple calls', async () => {
       // Make multiple calls
-      await mcpClient.callTool('1mcp_1mcp_mcp_registry_status', {});
-      await mcpClient.callTool('1mcp_1mcp_mcp_registry_list', {});
-      await mcpClient.callTool('1mcp_1mcp_mcp_registry_info', {});
+      await mcpClient.callTool('_1mcp_1mcp_mcp_registry_status', {});
+      await mcpClient.callTool('_1mcp_1mcp_mcp_registry_list', {});
+      await mcpClient.callTool('_1mcp_1mcp_mcp_registry_info', {});
 
       // Connection should still be alive by listing tools
       const result = await mcpClient.listTools();
@@ -418,9 +418,9 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
     it('should handle concurrent requests', async () => {
       // Make multiple concurrent calls
       const promises = [
-        mcpClient.callTool('1mcp_1mcp_mcp_search', { query: 'test1' }),
-        mcpClient.callTool('1mcp_1mcp_mcp_search', { query: 'test2' }),
-        mcpClient.callTool('1mcp_1mcp_mcp_registry_status', {}),
+        mcpClient.callTool('_1mcp_1mcp_mcp_search', { query: 'test1' }),
+        mcpClient.callTool('_1mcp_1mcp_mcp_search', { query: 'test2' }),
+        mcpClient.callTool('_1mcp_1mcp_mcp_registry_status', {}),
       ];
 
       const results = await Promise.allSettled(promises);
@@ -435,7 +435,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
 
   describe('Schema Validation Edge Cases', () => {
     it('should validate empty search results structure', async () => {
-      const result = await mcpClient.callTool('1mcp_1mcp_mcp_search', {
+      const result = await mcpClient.callTool('_1mcp_1mcp_mcp_search', {
         query: 'non-existent-server-name-xyz-123',
         limit: 1,
       });
@@ -463,7 +463,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
     it('should validate maximum limits are enforced', async () => {
       // Test with reasonable high limit (avoiding the error that occurs with very high limits)
       try {
-        const result = await mcpClient.callTool('1mcp_1mcp_mcp_search', {
+        const result = await mcpClient.callTool('_1mcp_1mcp_mcp_search', {
           query: 'test',
           limit: 100, // High but reasonable limit
         });

--- a/test/e2e/lazy-loading-preset-filtering-e2e.test.ts
+++ b/test/e2e/lazy-loading-preset-filtering-e2e.test.ts
@@ -259,7 +259,7 @@ describe('Lazy Loading E2E Tests', () => {
         });
 
         // In pure lazy loading mode, these should be the ONLY tools (except internal tools)
-        const nonInternalTools = toolsResponse.tools.filter((t: any) => !t.name.startsWith('1mcp_'));
+        const nonInternalTools = toolsResponse.tools.filter((t: any) => !t.name.startsWith('_1mcp_'));
         expect(nonInternalTools.length).toBe(3);
       } finally {
         await client.disconnect();
@@ -326,15 +326,15 @@ describe('Lazy Loading E2E Tests', () => {
         expect(toolsResponse).toBeDefined();
         expect(Array.isArray(toolsResponse.tools)).toBe(true);
 
-        // Internal tools should be present, prefixed with '1mcp_'
-        const internalTools = toolsResponse.tools.filter((t: any) => t.name.startsWith('1mcp_'));
+        // Internal tools should be present, prefixed with '_1mcp_'
+        const internalTools = toolsResponse.tools.filter((t: any) => t.name.startsWith('_1mcp_'));
 
         // Verify internal tools exist when enabled
         expect(internalTools.length).toBeGreaterThan(0);
 
         // Verify all internal tools have the 1mcp_ prefix
         internalTools.forEach((tool: any) => {
-          expect(tool.name).toMatch(/^1mcp_/);
+          expect(tool.name).toMatch(/^_1mcp_/);
         });
       } finally {
         await client.disconnect();
@@ -852,7 +852,7 @@ describe('Lazy Loading E2E Tests', () => {
 
         // In lazy loading mode, should only have meta-tools (3 tools)
         const lazyTools = (await client.listTools()) as any;
-        const lazyToolCount = lazyTools.tools.filter((t: any) => !t.name.startsWith('1mcp_')).length;
+        const lazyToolCount = lazyTools.tools.filter((t: any) => !t.name.startsWith('_1mcp_')).length;
 
         // Lazy mode should have exactly 3 meta-tools
         expect(lazyToolCount).toBe(3);


### PR DESCRIPTION
## Summary

- Add `sanitizeToolName` and `desanitizeToolName` utility functions in `src/utils/core/parsing.ts`
- Apply `sanitizeToolName` when building tool names to ensure compliance with AI provider naming rules (e.g. Gemini requires names to start with a letter or underscore, not a digit)
- Apply `desanitizeToolName` when parsing incoming tool call names to reverse the sanitization

## Test plan

- [ ] Unit tests added for both `sanitizeToolName` and `desanitizeToolName` in `src/utils/core/parsing.test.ts`
- [ ] E2E tests updated to reflect sanitized tool name format
- [ ] Run `pnpm lint && pnpm typecheck && pnpm build && pnpm test:unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool name sanitization to properly handle names starting with digits.

* **Bug Fixes**
  * Implemented connection timeout support for client connections.

* **Tests**
  * Updated E2E test assertions to reflect revised internal tool naming convention.
  * Added test coverage for tool name sanitization and desanitization functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->