### PR TITLE
feat: add global MCP server defaults

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -1,0 +1,77 @@
+# 1MCP Application Configuration
+# Copy this file to ~/.config/1mcp/config.toml and adjust as needed.
+# CLI arguments and ONE_MCP_* environment variables always take precedence over these values.
+# Changes to this file require a process restart to take effect.
+
+# Transport type: "http" | "sse" | "stdio"
+transport = "http"
+
+# HTTP port to listen on
+port = 3050
+
+# HTTP host to listen on
+host = "127.0.0.1"
+
+# Log level: "debug" | "info" | "warn" | "error"
+logLevel = "info"
+
+# Path to log file (optional)
+# logFile = "/var/log/1mcp.log"
+
+[auth]
+# Enable OAuth 2.1 authentication
+enabled = false
+
+# Session TTL in minutes
+sessionTtl = 1440
+
+# Rate limit window in minutes
+rateLimitWindow = 15
+
+# Maximum requests per rate limit window
+rateLimitMax = 100
+
+# Trust proxy configuration for Express.js
+trustProxy = "loopback"
+
+# Enable tag-based scope validation
+# enableScopeValidation = false
+
+# Enable enhanced security middleware
+# enableEnhancedSecurity = false
+
+[asyncLoading]
+# Enable asynchronous MCP server loading
+enabled = false
+
+# Minimum servers to wait for before accepting requests
+minServers = 1
+
+# Initial load timeout in milliseconds
+timeout = 30000
+
+# Batch capability change notifications
+# batchNotifications = false
+
+# Batch delay in milliseconds
+# batchDelay = 100
+
+[lazyLoading]
+# Enable lazy loading for tools
+enabled = false
+
+# Lazy loading mode: "full" | "metatool" | "hybrid"
+mode = "full"
+
+# Maximum tool schemas to cache
+# cacheMaxEntries = 1000
+
+# Include full tool catalog in initialize template
+# inlineCatalog = false
+
+[configReload]
+# Enable automatic mcp.json hot-reload
+enabled = true
+
+# Debounce delay in milliseconds
+debounce = 500

--- a/docs/en/reference/mcp-servers.md
+++ b/docs/en/reference/mcp-servers.md
@@ -105,13 +105,14 @@ Optional shared defaults inherited by all servers. Allowed keys:
 - `oauth`
 - `headers`
 - `inheritParentEnv`
+- `envFilter`
 
 Merge behavior:
 
 - `env` object values merge with per-server env values (server keys override serverDefaults keys).
 - `oauth` and `headers` are replaced by per-server values (not merged).
 - Primitive values (`timeout`, `connectionTimeout`, `requestTimeout`, `inheritParentEnv`) are inherited only when missing on the server.
-- Transport-specific exclusions apply: global `headers` are ignored for `stdio` transports, and global `inheritParentEnv` is ignored for `http`, `sse`, and `streamableHttp` transports.
+- Transport-specific exclusions apply: global `headers` are ignored for `stdio` transports, and global `inheritParentEnv` and `envFilter` are ignored for `http`, `sse`, and `streamableHttp` transports.
 - When both `serverDefaults.env` and `mcpServers.<name>.env` use array format, the server-specific array wins instead of merging element-by-element.
 
 ### Migration Guide (Per-Server to Shared Defaults)

--- a/docs/en/reference/mcp-servers.md
+++ b/docs/en/reference/mcp-servers.md
@@ -111,6 +111,8 @@ Merge behavior:
 - `env` object values merge with per-server env values (server keys override serverDefaults keys).
 - `oauth` and `headers` are replaced by per-server values (not merged).
 - Primitive values (`timeout`, `connectionTimeout`, `requestTimeout`, `inheritParentEnv`) are inherited only when missing on the server.
+- Transport-specific exclusions apply: global `headers` are ignored for `stdio` transports, and global `inheritParentEnv` is ignored for `http`, `sse`, and `streamableHttp` transports.
+- When both `serverDefaults.env` and `mcpServers.<name>.env` use array format, the server-specific array wins instead of merging element-by-element.
 
 ### Migration Guide (Per-Server to Shared Defaults)
 

--- a/docs/en/reference/mcp-servers.md
+++ b/docs/en/reference/mcp-servers.md
@@ -25,7 +25,7 @@ This document provides comprehensive reference documentation for configuring MCP
 
 ## Overview
 
-The 1MCP Agent manages multiple backend MCP servers through a JSON configuration file. Each server is defined in the `mcpServers` section with specific properties that control its behavior, transport method, and environment.
+The 1MCP Agent manages multiple backend MCP servers through a JSON configuration file. Shared defaults can be defined in `serverDefaults`, and each server is defined in `mcpServers` with specific properties that control its behavior, transport method, and environment.
 
 ---
 
@@ -37,6 +37,9 @@ The agent uses a JSON file (e.g., `mcp.json`) to define backend servers and thei
 
 ```json
 {
+  "serverDefaults": {
+    // Optional shared defaults for all servers
+  },
   "mcpServers": {
     // Server definitions
   }
@@ -91,6 +94,42 @@ This creates a self-contained configuration setup for projects that need isolate
 
 ## MCP Servers Configuration
 
+### `serverDefaults` Section
+
+Optional shared defaults inherited by all servers. Allowed keys:
+
+- `env`
+- `timeout`
+- `connectionTimeout`
+- `requestTimeout`
+- `oauth`
+- `headers`
+- `inheritParentEnv`
+
+Merge behavior:
+
+- `env` object values merge with per-server env values (server keys override serverDefaults keys).
+- `oauth` and `headers` are replaced by per-server values (not merged).
+- Primitive values (`timeout`, `connectionTimeout`, `requestTimeout`, `inheritParentEnv`) are inherited only when missing on the server.
+
+### Migration Guide (Per-Server to Shared Defaults)
+
+You can move repeated settings from each server into `serverDefaults` without changing server behavior:
+
+1. Identify repeated keys across servers (`env`, `connectionTimeout`, `requestTimeout`, `oauth`, `headers`, `inheritParentEnv`).
+2. Move shared values to `serverDefaults`.
+3. Keep server-specific overrides inside each server definition.
+4. Run `1mcp mcp status --verbose` to confirm each server’s effective merged configuration.
+
+### serverDefaults Environment Variables Reference
+
+`serverDefaults.env` supports two formats:
+
+- Object format: `{ "KEY": "value" }`
+- Array format: `["KEY=value"]`
+
+When both `serverDefaults.env` and `mcpServers.<name>.env` are objects, values are merged and server values override serverDefaults values on key conflicts.
+
 ### `mcpServers` Section
 
 This is a dictionary of all the backend MCP servers the agent will manage.
@@ -131,6 +170,14 @@ This is a dictionary of all the backend MCP servers the agent will manage.
 
 ```json
 {
+  "serverDefaults": {
+    "connectionTimeout": 10000,
+    "requestTimeout": 30000,
+    "env": {
+      "HTTP_PROXY": "${HTTP_PROXY}",
+      "API_KEY": "${GLOBAL_API_KEY}"
+    }
+  },
   "mcpServers": {
     "filesystem": {
       "command": "mcp-server-filesystem",
@@ -140,8 +187,10 @@ This is a dictionary of all the backend MCP servers the agent will manage.
     "remote-api": {
       "transport": "http",
       "url": "https://api.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer local-token"
+      },
       "tags": ["api", "prod"],
-      "connectionTimeout": 5000,
       "requestTimeout": 15000
     }
   }

--- a/docs/public/schemas/v1.0.0/mcp-config.json
+++ b/docs/public/schemas/v1.0.0/mcp-config.json
@@ -72,6 +72,10 @@
             "autoRegister": {
               "description": "Automatically register OAuth client if not already registered",
               "type": "boolean"
+            },
+            "redirectUrl": {
+              "description": "OAuth redirect URL used after auth",
+              "type": "string"
             }
           }
         },
@@ -156,6 +160,10 @@
               "autoRegister": {
                 "description": "Automatically register OAuth client if not already registered",
                 "type": "boolean"
+              },
+              "redirectUrl": {
+                "description": "OAuth redirect URL used after auth",
+                "type": "string"
               }
             }
           },
@@ -353,6 +361,10 @@
               "autoRegister": {
                 "description": "Automatically register OAuth client if not already registered",
                 "type": "boolean"
+              },
+              "redirectUrl": {
+                "description": "OAuth redirect URL used after auth",
+                "type": "string"
               }
             }
           },

--- a/docs/public/schemas/v1.0.0/mcp-config.json
+++ b/docs/public/schemas/v1.0.0/mcp-config.json
@@ -14,6 +14,83 @@
       "description": "Version of the configuration format for migration purposes",
       "type": "string"
     },
+    "serverDefaults": {
+      "description": "Shareable defaults inherited by all MCP servers (transport settings only)",
+      "type": "object",
+      "properties": {
+        "env": {
+          "description": "Environment variables as object or array of KEY=VALUE strings",
+          "anyOf": [
+            {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Deprecated: Use connectionTimeout and requestTimeout instead. Fallback timeout in milliseconds",
+          "type": "number"
+        },
+        "connectionTimeout": {
+          "description": "Timeout for establishing initial connection in milliseconds (takes precedence over timeout)",
+          "type": "number"
+        },
+        "requestTimeout": {
+          "description": "Timeout for individual request operations in milliseconds (takes precedence over timeout)",
+          "type": "number"
+        },
+        "oauth": {
+          "description": "OAuth configuration for authentication",
+          "type": "object",
+          "properties": {
+            "clientId": {
+              "description": "OAuth client ID for authentication",
+              "type": "string"
+            },
+            "clientSecret": {
+              "description": "OAuth client secret for authentication",
+              "type": "string"
+            },
+            "scopes": {
+              "description": "OAuth scopes to request",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "autoRegister": {
+              "description": "Automatically register OAuth client if not already registered",
+              "type": "boolean"
+            }
+          }
+        },
+        "headers": {
+          "description": "Custom HTTP headers to send with requests",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "inheritParentEnv": {
+          "description": "Whether to inherit environment variables from parent process",
+          "type": "boolean"
+        }
+      }
+    },
     "mcpServers": {
       "type": "object",
       "propertyNames": {

--- a/docs/public/schemas/v1.0.0/mcp-config.json
+++ b/docs/public/schemas/v1.0.0/mcp-config.json
@@ -92,6 +92,13 @@
         "inheritParentEnv": {
           "description": "Whether to inherit environment variables from parent process",
           "type": "boolean"
+        },
+        "envFilter": {
+          "description": "List of environment variable names to include when inheritParentEnv is true",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/docs/zh/reference/mcp-servers.md
+++ b/docs/zh/reference/mcp-servers.md
@@ -90,6 +90,8 @@ npx -y @1mcp/agent --config-dir ./project-config
 - `env` 对象会与各服务器的 `env` 合并，若键冲突则以服务器自身的值为准。
 - `oauth` 和 `headers` 会被服务器上的值整体替换，不会做深度合并。
 - 基本类型值（`timeout`、`connectionTimeout`、`requestTimeout`、`inheritParentEnv`）仅在服务器未显式设置时继承。
+- 还存在与传输类型相关的排除规则：全局 `headers` 会对 `stdio` 传输忽略，而全局 `inheritParentEnv` 会对 `http`、`sse` 和 `streamableHttp` 传输忽略。
+- 当 `serverDefaults.env` 与 `mcpServers.<name>.env` 都使用数组格式时，不会逐项合并，而是以服务器自己的数组为准。
 
 ### 迁移指南（从每服务器配置迁移到共享默认值）
 

--- a/docs/zh/reference/mcp-servers.md
+++ b/docs/zh/reference/mcp-servers.md
@@ -4,7 +4,7 @@
 
 ## 概述
 
-1MCP 代理通过 JSON 配置文件管理多个后端 MCP 服务器。每个服务器都在 `mcpServers` 部分中定义，具有控制其行为、传输方法和环境的特定属性。
+1MCP 代理通过 JSON 配置文件管理多个后端 MCP 服务器。您可以在 `serverDefaults` 中定义共享默认值，并在 `mcpServers` 部分中为每个服务器定义控制其行为、传输方法和环境的特定属性。
 
 ---
 
@@ -16,6 +16,9 @@
 
 ```json
 {
+  "serverDefaults": {
+    // 所有服务器可选的共享默认值
+  },
   "mcpServers": {
     // 服务器定义
   }
@@ -70,6 +73,42 @@ npx -y @1mcp/agent --config-dir ./project-config
 
 ## MCP 服务器配置
 
+### `serverDefaults` 部分
+
+可选的共享默认值，所有服务器都会继承。允许的键：
+
+- `env`
+- `timeout`
+- `connectionTimeout`
+- `requestTimeout`
+- `oauth`
+- `headers`
+- `inheritParentEnv`
+
+合并行为：
+
+- `env` 对象会与各服务器的 `env` 合并，若键冲突则以服务器自身的值为准。
+- `oauth` 和 `headers` 会被服务器上的值整体替换，不会做深度合并。
+- 基本类型值（`timeout`、`connectionTimeout`、`requestTimeout`、`inheritParentEnv`）仅在服务器未显式设置时继承。
+
+### 迁移指南（从每服务器配置迁移到共享默认值）
+
+您可以把各服务器中重复出现的设置提取到 `serverDefaults`，而不改变实际行为：
+
+1. 找出多个服务器重复使用的键（`env`、`connectionTimeout`、`requestTimeout`、`oauth`、`headers`、`inheritParentEnv`）。
+2. 将共享值移动到 `serverDefaults`。
+3. 将服务器特有的覆盖项保留在各自的服务器定义中。
+4. 运行 `1mcp mcp status --verbose`，确认每个服务器的最终合并配置符合预期。
+
+### `serverDefaults` 环境变量参考
+
+`serverDefaults.env` 支持两种格式：
+
+- 对象格式：`{ "KEY": "value" }`
+- 数组格式：`["KEY=value"]`
+
+当 `serverDefaults.env` 与 `mcpServers.<name>.env` 都使用对象格式时，两者会进行合并；发生键冲突时，以服务器自身的值覆盖共享默认值。
+
 ### `mcpServers` 部分
 
 这是代理将管理的所有后端 MCP 服务器的字典。
@@ -110,6 +149,14 @@ npx -y @1mcp/agent --config-dir ./project-config
 
 ```json
 {
+  "serverDefaults": {
+    "connectionTimeout": 10000,
+    "requestTimeout": 30000,
+    "env": {
+      "HTTP_PROXY": "${HTTP_PROXY}",
+      "API_KEY": "${GLOBAL_API_KEY}"
+    }
+  },
   "mcpServers": {
     "filesystem": {
       "command": "mcp-server-filesystem",
@@ -119,8 +166,10 @@ npx -y @1mcp/agent --config-dir ./project-config
     "remote-api": {
       "transport": "http",
       "url": "https://api.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer local-token"
+      },
       "tags": ["api", "prod"],
-      "connectionTimeout": 5000,
       "requestTimeout": 15000
     }
   }

--- a/docs/zh/reference/mcp-servers.md
+++ b/docs/zh/reference/mcp-servers.md
@@ -84,13 +84,14 @@ npx -y @1mcp/agent --config-dir ./project-config
 - `oauth`
 - `headers`
 - `inheritParentEnv`
+- `envFilter`
 
 合并行为：
 
 - `env` 对象会与各服务器的 `env` 合并，若键冲突则以服务器自身的值为准。
 - `oauth` 和 `headers` 会被服务器上的值整体替换，不会做深度合并。
 - 基本类型值（`timeout`、`connectionTimeout`、`requestTimeout`、`inheritParentEnv`）仅在服务器未显式设置时继承。
-- 还存在与传输类型相关的排除规则：全局 `headers` 会对 `stdio` 传输忽略，而全局 `inheritParentEnv` 会对 `http`、`sse` 和 `streamableHttp` 传输忽略。
+- 还存在与传输类型相关的排除规则：全局 `headers` 会对 `stdio` 传输忽略，而全局 `inheritParentEnv` 和 `envFilter` 会对 `http`、`sse` 和 `streamableHttp` 传输忽略。
 - 当 `serverDefaults.env` 与 `mcpServers.<name>.env` 都使用数组格式时，不会逐项合并，而是以服务器自己的数组为准。
 
 ### 迁移指南（从每服务器配置迁移到共享默认值）

--- a/mcp.json.example
+++ b/mcp.json.example
@@ -6,6 +6,17 @@
     "failureMode": "graceful",
     "cacheContext": true
   },
+  "serverDefaults": {
+    "connectionTimeout": 10000,
+    "requestTimeout": 30000,
+    "env": {
+      "HTTP_PROXY": "${HTTP_PROXY}"
+    },
+    "headers": {
+      "User-Agent": "1mcp"
+    },
+    "inheritParentEnv": true
+  },
   "mcpServers": {
     "filesystem": {
       "command": "npx",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "ora": "^9.0.0",
     "prompts": "^2.4.2",
     "semver": "^7.7.3",
+    "smol-toml": "^1.6.0",
     "source-map-support": "^0.5.21",
     "tiktoken": "^1.0.22",
     "uuid": "^13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       semver:
         specifier: ^7.7.3
         version: 7.7.3
+      smol-toml:
+        specifier: ^1.6.0
+        version: 1.6.0
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -3310,6 +3313,10 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  smol-toml@1.6.0:
+    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+    engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -7081,6 +7088,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  smol-toml@1.6.0: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -311,7 +311,8 @@ export async function addCommand(argv: AddCommandArgs): Promise<void> {
     if (globalConfig.requestTimeout !== undefined) inheritedKeys.push('requestTimeout');
     if (argv.env === undefined && globalConfig.env !== undefined) inheritedKeys.push('env');
     if (type === 'stdio' && globalConfig.inheritParentEnv !== undefined) inheritedKeys.push('inheritParentEnv');
-    if (type !== 'stdio' && globalConfig.headers !== undefined) inheritedKeys.push('headers');
+    if (type !== 'stdio' && argv.headers === undefined && globalConfig.headers !== undefined)
+      inheritedKeys.push('headers');
     if (globalConfig.oauth !== undefined) inheritedKeys.push('oauth');
     if (inheritedKeys.length > 0) {
       printer.keyValue({ Inherits: inheritedKeys.join(', ') });

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -6,6 +6,7 @@ import type { Argv } from 'yargs';
 
 import {
   backupConfig,
+  getGlobalConfig,
   initializeConfigContext,
   parseEnvVars,
   parseHeaders,
@@ -83,7 +84,7 @@ export function buildAddCommand(yargs: Argv) {
       alias: 'g',
     })
     .option('timeout', {
-      describe: 'Connection timeout in milliseconds',
+      describe: 'Connection timeout in milliseconds (inherits from global default when omitted)',
       type: 'number',
     })
     .option('disabled', {
@@ -301,6 +302,19 @@ export async function addCommand(argv: AddCommandArgs): Promise<void> {
 
     if (backupPath) {
       printer.keyValue({ 'Backup created': backupPath });
+    }
+
+    const globalConfig = getGlobalConfig();
+    const inheritedKeys: string[] = [];
+    if (argv.timeout === undefined && globalConfig.timeout !== undefined) inheritedKeys.push('timeout');
+    if (globalConfig.connectionTimeout !== undefined) inheritedKeys.push('connectionTimeout');
+    if (globalConfig.requestTimeout !== undefined) inheritedKeys.push('requestTimeout');
+    if (argv.env === undefined && globalConfig.env !== undefined) inheritedKeys.push('env');
+    if (type === 'stdio' && globalConfig.inheritParentEnv !== undefined) inheritedKeys.push('inheritParentEnv');
+    if (type !== 'stdio' && globalConfig.headers !== undefined) inheritedKeys.push('headers');
+    if (globalConfig.oauth !== undefined) inheritedKeys.push('oauth');
+    if (inheritedKeys.length > 0) {
+      printer.keyValue({ Inherits: inheritedKeys.join(', ') });
     }
 
     printer.blank();

--- a/src/commands/mcp/index.ts
+++ b/src/commands/mcp/index.ts
@@ -1,5 +1,6 @@
 // Import builder functions from command implementations
 import { globalOptions } from '@src/globalOptions.js';
+import { normalizedArgv } from '@src/utils/cli/normalizedArgv.js';
 import printer from '@src/utils/ui/printer.js';
 
 import type { Argv } from 'yargs';
@@ -41,8 +42,8 @@ export function setupMcpCommands(yargs: Argv): Argv {
               await import('./utils/doubleHyphenParser.js');
 
             // Check if " -- " pattern is used
-            if (hasDoubleHyphen(process.argv)) {
-              const doubleHyphenResult = parseDoubleHyphenArgs(process.argv);
+            if (hasDoubleHyphen(normalizedArgv)) {
+              const doubleHyphenResult = parseDoubleHyphenArgs(normalizedArgv);
               const mergedArgv = mergeDoubleHyphenArgs(argv, doubleHyphenResult);
               await addCommand(mergedArgv);
             } else {
@@ -87,8 +88,8 @@ export function setupMcpCommands(yargs: Argv): Argv {
               await import('./utils/doubleHyphenParser.js');
 
             // Check if " -- " pattern is used
-            if (hasDoubleHyphen(process.argv)) {
-              const doubleHyphenResult = parseDoubleHyphenArgs(process.argv);
+            if (hasDoubleHyphen(normalizedArgv)) {
+              const doubleHyphenResult = parseDoubleHyphenArgs(normalizedArgv);
               const mergedArgv = mergeDoubleHyphenArgs(argv, doubleHyphenResult);
               await updateCommand(mergedArgv);
             } else {

--- a/src/commands/mcp/list.test.ts
+++ b/src/commands/mcp/list.test.ts
@@ -4,6 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildListCommand, listCommand } from './list.js';
 
+const mockedFns = vi.hoisted(() => ({
+  mockGetAllServers: vi.fn(() => ({})),
+  mockGetAllEffectiveServers: vi.fn(() => ({})),
+  mockGetGlobalConfig: vi.fn(() => ({})),
+}));
+
 // Mock printer
 vi.mock('@src/utils/ui/printer.js', () => ({
   default: {
@@ -14,14 +20,19 @@ vi.mock('@src/utils/ui/printer.js', () => ({
     blank: vi.fn(),
     raw: vi.fn(),
     title: vi.fn(),
+    subtitle: vi.fn(),
     table: vi.fn(),
+    keyValue: vi.fn(),
+    serverStatus: vi.fn(),
   },
 }));
 
 // Mock dependencies
 vi.mock('./utils/mcpServerConfig.js', () => ({
   initializeConfigContext: vi.fn(),
-  getAllServers: vi.fn(() => ({})),
+  getAllServers: mockedFns.mockGetAllServers,
+  getAllEffectiveServers: mockedFns.mockGetAllEffectiveServers,
+  getGlobalConfig: mockedFns.mockGetGlobalConfig,
   validateConfigPath: vi.fn(),
   parseTags: vi.fn((tags) => tags.split(',')),
 }));
@@ -37,6 +48,9 @@ vi.mock('./utils/validation.js', () => ({
 describe('List Command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedFns.mockGetAllServers.mockReturnValue({});
+    mockedFns.mockGetAllEffectiveServers.mockReturnValue({});
+    mockedFns.mockGetGlobalConfig.mockReturnValue({});
   });
 
   describe('buildListCommand', () => {

--- a/src/commands/mcp/list.ts
+++ b/src/commands/mcp/list.ts
@@ -1,4 +1,4 @@
-import { MCPServerParams } from '@src/core/types/index.js';
+import { GlobalTransportConfig, MCPServerParams } from '@src/core/types/index.js';
 import { createServerInstallationService } from '@src/domains/server-management/serverInstallationService.js';
 import { GlobalOptions } from '@src/globalOptions.js';
 import { inferTransportType } from '@src/transport/transportFactory.js';
@@ -12,7 +12,14 @@ import {
 
 import type { Argv } from 'yargs';
 
-import { getAllServers, initializeConfigContext, parseTags, validateConfigPath } from './utils/mcpServerConfig.js';
+import {
+  getAllEffectiveServers,
+  getAllServers,
+  getGlobalConfig,
+  initializeConfigContext,
+  parseTags,
+  validateConfigPath,
+} from './utils/mcpServerConfig.js';
 import { calculateServerStatus } from './utils/serverUtils.js';
 import { validateTags } from './utils/validation.js';
 
@@ -45,7 +52,7 @@ export function buildListCommand(yargs: Argv) {
       alias: 'g',
     })
     .option('verbose', {
-      describe: 'Show detailed server configuration',
+      describe: 'Show detailed effective server configuration, including inherited global defaults',
       type: 'boolean',
       default: false,
       alias: 'v',
@@ -93,6 +100,8 @@ export async function listCommand(argv: ListCommandArgs): Promise<void> {
 
     // Get all servers
     const allServers = getAllServers();
+    const allEffectiveServers = getAllEffectiveServers();
+    const globalConfig = getGlobalConfig();
 
     if (Object.keys(allServers).length === 0) {
       printer.info('No MCP servers are configured.');
@@ -102,7 +111,7 @@ export async function listCommand(argv: ListCommandArgs): Promise<void> {
     }
 
     // Filter servers (apply outdated filter if requested)
-    let filteredServers = filterServers(allServers, showDisabled, tagsFilter);
+    let filteredServers = filterServers(allEffectiveServers, showDisabled, tagsFilter);
 
     if (outdated) {
       filteredServers = await getOutdatedServers(filteredServers);
@@ -128,12 +137,23 @@ export async function listCommand(argv: ListCommandArgs): Promise<void> {
       .title(`MCP Servers (${serverCount} server${serverCount === 1 ? '' : 's'})`)
       .blank();
 
+    if (Object.keys(globalConfig).length > 0) {
+      printer.subtitle('Global Defaults:');
+      printGlobalSummary(globalConfig);
+      printer.blank();
+    }
+
     // Sort servers by name for consistent output
     const sortedServerNames = Object.keys(filteredServers).sort();
 
     for (const serverName of sortedServerNames) {
-      const config = filteredServers[serverName];
-      displayServer(serverName, config, verbose, showSecrets);
+      const effectiveConfig = filteredServers[serverName];
+      const rawConfig = allServers[serverName];
+      if (!rawConfig) {
+        continue;
+      }
+
+      displayServer(serverName, rawConfig, effectiveConfig, globalConfig, verbose, showSecrets);
       printer.blank();
     }
 
@@ -242,8 +262,15 @@ function filterServers(
 /**
  * Display a single server's information
  */
-function displayServer(name: string, config: MCPServerParams, verbose: boolean, showSecrets: boolean = false): void {
-  const enabled = !config.disabled;
+function displayServer(
+  name: string,
+  rawConfig: MCPServerParams,
+  effectiveConfig: MCPServerParams,
+  globalConfig: GlobalTransportConfig,
+  verbose: boolean,
+  showSecrets: boolean = false,
+): void {
+  const enabled = !effectiveConfig.disabled;
 
   // Get installation metadata
   const version = 'unknown';
@@ -252,7 +279,7 @@ function displayServer(name: string, config: MCPServerParams, verbose: boolean, 
   const serverStatus = calculateServerStatus(version);
 
   // Infer type if missing
-  const inferredConfig = config.type ? config : inferTransportType(config, name);
+  const inferredConfig = effectiveConfig.type ? effectiveConfig : inferTransportType(effectiveConfig, name);
   const displayType = inferredConfig.type || 'unknown';
 
   // Display with installation metadata
@@ -329,4 +356,88 @@ function displayServer(name: string, config: MCPServerParams, verbose: boolean, 
       }
     }
   }
+
+  if (verbose) {
+    const inherited = getInheritedKeys(rawConfig, effectiveConfig, globalConfig);
+    if (inherited.length > 0) {
+      printer.keyValue({ Inherited: inherited.join(', ') });
+    }
+  }
+}
+
+function printGlobalSummary(globalConfig: GlobalTransportConfig): void {
+  if (globalConfig.timeout !== undefined) {
+    printer.keyValue({ timeout: String(globalConfig.timeout) });
+  }
+  if (globalConfig.connectionTimeout !== undefined) {
+    printer.keyValue({ connectionTimeout: String(globalConfig.connectionTimeout) });
+  }
+  if (globalConfig.requestTimeout !== undefined) {
+    printer.keyValue({ requestTimeout: String(globalConfig.requestTimeout) });
+  }
+  if (globalConfig.inheritParentEnv !== undefined) {
+    printer.keyValue({ inheritParentEnv: String(globalConfig.inheritParentEnv) });
+  }
+  if (globalConfig.oauth && typeof globalConfig.oauth === 'object') {
+    printer.keyValue({ oauth: '(configured)' });
+  }
+  if (globalConfig.headers && typeof globalConfig.headers === 'object') {
+    printer.keyValue({ headers: `${Object.keys(globalConfig.headers as Record<string, string>).length} key(s)` });
+  }
+  if (globalConfig.env && typeof globalConfig.env === 'object') {
+    const envCount = Array.isArray(globalConfig.env)
+      ? (globalConfig.env as string[]).length
+      : Object.keys(globalConfig.env as Record<string, string>).length;
+    printer.keyValue({ env: `${envCount} key(s)` });
+  }
+}
+
+function getInheritedKeys(
+  rawConfig: MCPServerParams,
+  effectiveConfig: MCPServerParams,
+  globalConfig: GlobalTransportConfig,
+): string[] {
+  const inherited: string[] = [];
+  const fallbackKeys: Array<keyof MCPServerParams> = [
+    'timeout',
+    'connectionTimeout',
+    'requestTimeout',
+    'oauth',
+    'headers',
+    'inheritParentEnv',
+  ];
+
+  for (const key of fallbackKeys) {
+    if (
+      rawConfig[key] === undefined &&
+      effectiveConfig[key] !== undefined &&
+      globalConfig[key as keyof GlobalTransportConfig] !== undefined
+    ) {
+      inherited.push(String(key));
+    }
+  }
+
+  if (rawConfig.env === undefined && effectiveConfig.env !== undefined && globalConfig.env !== undefined) {
+    inherited.push('env');
+  }
+
+  if (
+    rawConfig.env &&
+    effectiveConfig.env &&
+    typeof rawConfig.env === 'object' &&
+    typeof effectiveConfig.env === 'object' &&
+    !Array.isArray(rawConfig.env) &&
+    !Array.isArray(effectiveConfig.env) &&
+    typeof globalConfig.env === 'object' &&
+    globalConfig.env !== null &&
+    !Array.isArray(globalConfig.env)
+  ) {
+    const rawEnv = rawConfig.env as Record<string, string>;
+    const effectiveEnv = effectiveConfig.env as Record<string, string>;
+    if (Object.keys(effectiveEnv).some((key) => !(key in rawEnv))) {
+      inherited.push('env(merged)');
+    }
+  }
+
+  return inherited;
 }

--- a/src/commands/mcp/list.ts
+++ b/src/commands/mcp/list.ts
@@ -379,6 +379,9 @@ function printGlobalSummary(globalConfig: GlobalTransportConfig): void {
   if (globalConfig.inheritParentEnv !== undefined) {
     printer.keyValue({ inheritParentEnv: String(globalConfig.inheritParentEnv) });
   }
+  if (Array.isArray(globalConfig.envFilter) && globalConfig.envFilter.length > 0) {
+    printer.keyValue({ envFilter: `${globalConfig.envFilter.length} item(s)` });
+  }
   if (globalConfig.oauth && typeof globalConfig.oauth === 'object') {
     printer.keyValue({ oauth: '(configured)' });
   }

--- a/src/commands/mcp/list.ts
+++ b/src/commands/mcp/list.ts
@@ -16,6 +16,7 @@ import {
   getAllEffectiveServers,
   getAllServers,
   getGlobalConfig,
+  getInheritedKeys,
   initializeConfigContext,
   parseTags,
   validateConfigPath,
@@ -390,54 +391,4 @@ function printGlobalSummary(globalConfig: GlobalTransportConfig): void {
       : Object.keys(globalConfig.env as Record<string, string>).length;
     printer.keyValue({ env: `${envCount} key(s)` });
   }
-}
-
-function getInheritedKeys(
-  rawConfig: MCPServerParams,
-  effectiveConfig: MCPServerParams,
-  globalConfig: GlobalTransportConfig,
-): string[] {
-  const inherited: string[] = [];
-  const fallbackKeys: Array<keyof MCPServerParams> = [
-    'timeout',
-    'connectionTimeout',
-    'requestTimeout',
-    'oauth',
-    'headers',
-    'inheritParentEnv',
-  ];
-
-  for (const key of fallbackKeys) {
-    if (
-      rawConfig[key] === undefined &&
-      effectiveConfig[key] !== undefined &&
-      globalConfig[key as keyof GlobalTransportConfig] !== undefined
-    ) {
-      inherited.push(String(key));
-    }
-  }
-
-  if (rawConfig.env === undefined && effectiveConfig.env !== undefined && globalConfig.env !== undefined) {
-    inherited.push('env');
-  }
-
-  if (
-    rawConfig.env &&
-    effectiveConfig.env &&
-    typeof rawConfig.env === 'object' &&
-    typeof effectiveConfig.env === 'object' &&
-    !Array.isArray(rawConfig.env) &&
-    !Array.isArray(effectiveConfig.env) &&
-    typeof globalConfig.env === 'object' &&
-    globalConfig.env !== null &&
-    !Array.isArray(globalConfig.env)
-  ) {
-    const rawEnv = rawConfig.env as Record<string, string>;
-    const effectiveEnv = effectiveConfig.env as Record<string, string>;
-    if (Object.keys(effectiveEnv).some((key) => !(key in rawEnv))) {
-      inherited.push('env(merged)');
-    }
-  }
-
-  return inherited;
 }

--- a/src/commands/mcp/list.ts
+++ b/src/commands/mcp/list.ts
@@ -382,13 +382,11 @@ function printGlobalSummary(globalConfig: GlobalTransportConfig): void {
   if (globalConfig.oauth && typeof globalConfig.oauth === 'object') {
     printer.keyValue({ oauth: '(configured)' });
   }
-  if (globalConfig.headers && typeof globalConfig.headers === 'object') {
-    printer.keyValue({ headers: `${Object.keys(globalConfig.headers as Record<string, string>).length} key(s)` });
+  if (globalConfig.headers && typeof globalConfig.headers === 'object' && !Array.isArray(globalConfig.headers)) {
+    printer.keyValue({ headers: `${Object.keys(globalConfig.headers).length} key(s)` });
   }
   if (globalConfig.env && typeof globalConfig.env === 'object') {
-    const envCount = Array.isArray(globalConfig.env)
-      ? (globalConfig.env as string[]).length
-      : Object.keys(globalConfig.env as Record<string, string>).length;
+    const envCount = Array.isArray(globalConfig.env) ? globalConfig.env.length : Object.keys(globalConfig.env).length;
     printer.keyValue({ env: `${envCount} key(s)` });
   }
 }

--- a/src/commands/mcp/status.ts
+++ b/src/commands/mcp/status.ts
@@ -10,6 +10,7 @@ import {
   getAllServers,
   getEffectiveServerConfig,
   getGlobalConfig,
+  getInheritedKeys,
   getServer,
   initializeConfigContext,
   validateConfigPath,
@@ -325,56 +326,6 @@ function displayDetailedServerStatus(
   printer.info(`   • Remove: server remove ${name}`);
 }
 
-function getInheritedKeys(
-  rawConfig: MCPServerParams,
-  effectiveConfig: MCPServerParams,
-  globalConfig: GlobalTransportConfig,
-): string[] {
-  const inherited: string[] = [];
-  const fallbackKeys: Array<keyof MCPServerParams> = [
-    'timeout',
-    'connectionTimeout',
-    'requestTimeout',
-    'oauth',
-    'headers',
-    'inheritParentEnv',
-  ];
-
-  for (const key of fallbackKeys) {
-    if (
-      rawConfig[key] === undefined &&
-      effectiveConfig[key] !== undefined &&
-      globalConfig[key as keyof GlobalTransportConfig] !== undefined
-    ) {
-      inherited.push(String(key));
-    }
-  }
-
-  if (rawConfig.env === undefined && effectiveConfig.env !== undefined && globalConfig.env !== undefined) {
-    inherited.push('env');
-  }
-
-  if (
-    rawConfig.env &&
-    effectiveConfig.env &&
-    typeof rawConfig.env === 'object' &&
-    typeof effectiveConfig.env === 'object' &&
-    !Array.isArray(rawConfig.env) &&
-    !Array.isArray(effectiveConfig.env) &&
-    typeof globalConfig.env === 'object' &&
-    globalConfig.env !== null &&
-    !Array.isArray(globalConfig.env)
-  ) {
-    const rawEnv = rawConfig.env as Record<string, string>;
-    const effectiveEnv = effectiveConfig.env as Record<string, string>;
-    if (Object.keys(effectiveEnv).some((key) => !(key in rawEnv))) {
-      inherited.push('env(merged)');
-    }
-  }
-
-  return inherited;
-}
-
 /**
  * Validate server configuration
  */
@@ -391,6 +342,7 @@ function validateServerConfiguration(config: MCPServerParams): void {
       break;
     case 'http':
     case 'sse':
+    case 'streamableHttp':
       if (!config.url) {
         throw new Error(`URL is required for ${config.type} servers`);
       }

--- a/src/commands/mcp/status.ts
+++ b/src/commands/mcp/status.ts
@@ -1,11 +1,19 @@
-import { MCPServerParams } from '@src/core/types/index.js';
+import { GlobalTransportConfig, MCPServerParams } from '@src/core/types/index.js';
 import { GlobalOptions } from '@src/globalOptions.js';
 import { inferTransportType } from '@src/transport/transportFactory.js';
 import printer from '@src/utils/ui/printer.js';
 
 import type { Argv } from 'yargs';
 
-import { getAllServers, getServer, initializeConfigContext, validateConfigPath } from './utils/mcpServerConfig.js';
+import {
+  getAllEffectiveServers,
+  getAllServers,
+  getEffectiveServerConfig,
+  getGlobalConfig,
+  getServer,
+  initializeConfigContext,
+  validateConfigPath,
+} from './utils/mcpServerConfig.js';
 import { validateServerName } from './utils/validation.js';
 
 export interface StatusCommandArgs extends GlobalOptions {
@@ -23,7 +31,7 @@ export function buildStatusCommand(yargs: Argv) {
       type: 'string',
     })
     .option('verbose', {
-      describe: 'Show detailed status information',
+      describe: 'Show detailed status information with effective merged configuration',
       type: 'boolean',
       default: false,
       alias: 'v',
@@ -69,8 +77,9 @@ async function showServerStatus(serverName: string, verbose: boolean = false): P
   validateServerName(serverName);
 
   // Get server configuration
-  const serverConfig = getServer(serverName);
-  if (!serverConfig) {
+  const rawServerConfig = getServer(serverName);
+  const effectiveServerConfig = getEffectiveServerConfig(serverName);
+  if (!rawServerConfig || !effectiveServerConfig) {
     throw new Error(`Server '${serverName}' does not exist.`);
   }
 
@@ -78,7 +87,7 @@ async function showServerStatus(serverName: string, verbose: boolean = false): P
   printer.title(`Server Status: ${serverName}`);
   printer.blank();
 
-  displayDetailedServerStatus(serverName, serverConfig, verbose);
+  displayDetailedServerStatus(serverName, rawServerConfig, effectiveServerConfig, getGlobalConfig(), verbose);
 }
 
 /**
@@ -86,8 +95,10 @@ async function showServerStatus(serverName: string, verbose: boolean = false): P
  */
 async function showAllServersStatus(verbose: boolean = false): Promise<void> {
   const allServers = getAllServers();
+  const allEffectiveServers = getAllEffectiveServers();
+  const globalConfig = getGlobalConfig();
 
-  if (Object.keys(allServers).length === 0) {
+  if (Object.keys(allEffectiveServers).length === 0) {
     printer.info('No MCP servers are configured.');
     printer.info('Use "mcp add <name>" to add your first server.');
     return;
@@ -96,25 +107,42 @@ async function showAllServersStatus(verbose: boolean = false): Promise<void> {
   printer
     .blank()
     .title(
-      `MCP Servers Status (${Object.keys(allServers).length} server${Object.keys(allServers).length === 1 ? '' : 's'})`,
+      `MCP Servers Status (${Object.keys(allEffectiveServers).length} server${Object.keys(allEffectiveServers).length === 1 ? '' : 's'})`,
     )
     .blank();
 
+  if (Object.keys(globalConfig).length > 0) {
+    printer.subtitle('Global Defaults:');
+    printer.keyValue({
+      timeout: globalConfig.timeout !== undefined ? `${globalConfig.timeout}ms` : '(none)',
+      connectionTimeout:
+        globalConfig.connectionTimeout !== undefined ? `${globalConfig.connectionTimeout}ms` : '(none)',
+      requestTimeout: globalConfig.requestTimeout !== undefined ? `${globalConfig.requestTimeout}ms` : '(none)',
+    });
+    printer.blank();
+  }
+
   // Sort servers by name for consistent output
-  const sortedServerNames = Object.keys(allServers).sort();
+  const sortedServerNames = Object.keys(allEffectiveServers).sort();
 
   for (const serverName of sortedServerNames) {
-    const config = allServers[serverName];
-    displayServerStatusSummary(serverName, config);
+    const effectiveConfig = allEffectiveServers[serverName];
+    displayServerStatusSummary(serverName, effectiveConfig);
+    if (verbose && allServers[serverName]) {
+      const inherited = getInheritedKeys(allServers[serverName], effectiveConfig, globalConfig);
+      if (inherited.length > 0) {
+        printer.keyValue({ Inherited: inherited.join(', ') });
+      }
+    }
     printer.blank(); // Empty line between servers
   }
 
   // Overall summary
-  const enabledCount = sortedServerNames.filter((name) => !allServers[name].disabled).length;
+  const enabledCount = sortedServerNames.filter((name) => !allEffectiveServers[name].disabled).length;
   const disabledCount = sortedServerNames.length - enabledCount;
-  const stdioCount = sortedServerNames.filter((name) => allServers[name].type === 'stdio').length;
-  const httpCount = sortedServerNames.filter((name) => allServers[name].type === 'http').length;
-  const sseCount = sortedServerNames.filter((name) => allServers[name].type === 'sse').length;
+  const stdioCount = sortedServerNames.filter((name) => allEffectiveServers[name].type === 'stdio').length;
+  const httpCount = sortedServerNames.filter((name) => allEffectiveServers[name].type === 'http').length;
+  const sseCount = sortedServerNames.filter((name) => allEffectiveServers[name].type === 'sse').length;
 
   printer.subtitle('Overall Summary:');
   printer.keyValue({
@@ -130,7 +158,7 @@ async function showAllServersStatus(verbose: boolean = false): Promise<void> {
 
   // Get unique tags
   const allTags = new Set<string>();
-  for (const config of Object.values(allServers)) {
+  for (const config of Object.values(allEffectiveServers)) {
     if (config.tags) {
       config.tags.forEach((tag) => allTags.add(tag));
     }
@@ -177,12 +205,18 @@ function displayServerStatusSummary(name: string, config: MCPServerParams): void
 /**
  * Display detailed status for a server (used in single server view)
  */
-function displayDetailedServerStatus(name: string, config: MCPServerParams, verbose: boolean): void {
-  const statusIcon = config.disabled ? '🔴' : '🟢';
-  const statusText = config.disabled ? 'Disabled' : 'Enabled';
+function displayDetailedServerStatus(
+  name: string,
+  rawConfig: MCPServerParams,
+  effectiveConfig: MCPServerParams,
+  globalConfig: GlobalTransportConfig,
+  verbose: boolean,
+): void {
+  const statusIcon = effectiveConfig.disabled ? '🔴' : '🟢';
+  const statusText = effectiveConfig.disabled ? 'Disabled' : 'Enabled';
 
   // Infer type if missing
-  const inferredConfig = config.type ? config : inferTransportType(config, name);
+  const inferredConfig = effectiveConfig.type ? effectiveConfig : inferTransportType(effectiveConfig, name);
   const displayType = inferredConfig.type || 'unknown';
 
   printer.subtitle('Configuration:');
@@ -224,7 +258,11 @@ function displayDetailedServerStatus(name: string, config: MCPServerParams, verb
   }
 
   // Common configuration
-  printer.keyValue({ Timeout: inferredConfig.timeout ? `${inferredConfig.timeout}ms` : '(default)' });
+  printer.keyValue({
+    Timeout: inferredConfig.timeout ? `${inferredConfig.timeout}ms` : '(default)',
+    'Connection Timeout': inferredConfig.connectionTimeout ? `${inferredConfig.connectionTimeout}ms` : '(default)',
+    'Request Timeout': inferredConfig.requestTimeout ? `${inferredConfig.requestTimeout}ms` : '(default)',
+  });
   printer.keyValue({
     Tags: inferredConfig.tags && inferredConfig.tags.length > 0 ? inferredConfig.tags.join(', ') : '(none)',
   });
@@ -246,12 +284,17 @@ function displayDetailedServerStatus(name: string, config: MCPServerParams, verb
     printer.keyValue({ 'Environment Variables': '(none)' });
   }
 
+  const inherited = getInheritedKeys(rawConfig, effectiveConfig, globalConfig);
+  if (inherited.length > 0) {
+    printer.keyValue({ Inherited: inherited.join(', ') });
+  }
+
   // Runtime status (this would require integration with ServerManager to get actual runtime status)
   printer.blank();
   printer.subtitle('Runtime Information:');
-  printer.keyValue({ 'Configuration File': JSON.stringify(config) });
+  printer.keyValue({ 'Effective Configuration': JSON.stringify(effectiveConfig) });
 
-  if (config.disabled) {
+  if (effectiveConfig.disabled) {
     printer.keyValue({ 'Runtime Status': '⏹️  Not running (disabled)' });
     printer.info(`Use 'mcp enable ${name}' to enable this server.`);
   } else {
@@ -263,7 +306,7 @@ function displayDetailedServerStatus(name: string, config: MCPServerParams, verb
   printer.blank();
   printer.subtitle('Validation:');
   try {
-    validateServerConfiguration(config);
+    validateServerConfiguration(effectiveConfig);
     printer.info('Configuration: Valid ✓');
   } catch (error) {
     printer.error('Configuration: Invalid ❌');
@@ -273,13 +316,63 @@ function displayDetailedServerStatus(name: string, config: MCPServerParams, verb
   // Quick actions
   printer.blank();
   printer.subtitle('Quick Actions:');
-  if (config.disabled) {
+  if (effectiveConfig.disabled) {
     printer.info(`   • Enable: mcp enable ${name}`);
   } else {
     printer.info(`   • Disable: mcp disable ${name}`);
   }
   printer.info(`   • Update: mcp update ${name} [options]`);
   printer.info(`   • Remove: server remove ${name}`);
+}
+
+function getInheritedKeys(
+  rawConfig: MCPServerParams,
+  effectiveConfig: MCPServerParams,
+  globalConfig: GlobalTransportConfig,
+): string[] {
+  const inherited: string[] = [];
+  const fallbackKeys: Array<keyof MCPServerParams> = [
+    'timeout',
+    'connectionTimeout',
+    'requestTimeout',
+    'oauth',
+    'headers',
+    'inheritParentEnv',
+  ];
+
+  for (const key of fallbackKeys) {
+    if (
+      rawConfig[key] === undefined &&
+      effectiveConfig[key] !== undefined &&
+      globalConfig[key as keyof GlobalTransportConfig] !== undefined
+    ) {
+      inherited.push(String(key));
+    }
+  }
+
+  if (rawConfig.env === undefined && effectiveConfig.env !== undefined && globalConfig.env !== undefined) {
+    inherited.push('env');
+  }
+
+  if (
+    rawConfig.env &&
+    effectiveConfig.env &&
+    typeof rawConfig.env === 'object' &&
+    typeof effectiveConfig.env === 'object' &&
+    !Array.isArray(rawConfig.env) &&
+    !Array.isArray(effectiveConfig.env) &&
+    typeof globalConfig.env === 'object' &&
+    globalConfig.env !== null &&
+    !Array.isArray(globalConfig.env)
+  ) {
+    const rawEnv = rawConfig.env as Record<string, string>;
+    const effectiveEnv = effectiveConfig.env as Record<string, string>;
+    if (Object.keys(effectiveEnv).some((key) => !(key in rawEnv))) {
+      inherited.push('env(merged)');
+    }
+  }
+
+  return inherited;
 }
 
 /**

--- a/src/commands/mcp/status.ts
+++ b/src/commands/mcp/status.ts
@@ -1,5 +1,6 @@
 import { GlobalTransportConfig, MCPServerParams } from '@src/core/types/index.js';
 import { GlobalOptions } from '@src/globalOptions.js';
+import { sanitizeForLogging } from '@src/logger/secureLogger.js';
 import { inferTransportType } from '@src/transport/transportFactory.js';
 import printer from '@src/utils/ui/printer.js';
 
@@ -144,6 +145,9 @@ async function showAllServersStatus(verbose: boolean = false): Promise<void> {
   const stdioCount = sortedServerNames.filter((name) => allEffectiveServers[name].type === 'stdio').length;
   const httpCount = sortedServerNames.filter((name) => allEffectiveServers[name].type === 'http').length;
   const sseCount = sortedServerNames.filter((name) => allEffectiveServers[name].type === 'sse').length;
+  const streamableHttpCount = sortedServerNames.filter(
+    (name) => allEffectiveServers[name].type === 'streamableHttp',
+  ).length;
 
   printer.subtitle('Overall Summary:');
   printer.keyValue({
@@ -155,6 +159,7 @@ async function showAllServersStatus(verbose: boolean = false): Promise<void> {
     stdio: stdioCount,
     http: httpCount,
     sse: sseCount,
+    streamableHttp: streamableHttpCount,
   });
 
   // Get unique tags
@@ -194,7 +199,10 @@ function displayServerStatusSummary(name: string, config: MCPServerParams): void
 
   if (inferredConfig.type === 'stdio' && inferredConfig.command) {
     printer.keyValue({ Command: inferredConfig.command });
-  } else if ((inferredConfig.type === 'http' || inferredConfig.type === 'sse') && inferredConfig.url) {
+  } else if (
+    (inferredConfig.type === 'http' || inferredConfig.type === 'sse' || inferredConfig.type === 'streamableHttp') &&
+    inferredConfig.url
+  ) {
     printer.keyValue({ URL: inferredConfig.url });
   }
 
@@ -243,7 +251,11 @@ function displayDetailedServerStatus(
     }
 
     printer.keyValue({ 'Working Directory': inferredConfig.cwd || '(current directory)' });
-  } else if (inferredConfig.type === 'http' || inferredConfig.type === 'sse') {
+  } else if (
+    inferredConfig.type === 'http' ||
+    inferredConfig.type === 'sse' ||
+    inferredConfig.type === 'streamableHttp'
+  ) {
     if (inferredConfig.url) {
       printer.keyValue({ URL: inferredConfig.url });
     }
@@ -260,9 +272,10 @@ function displayDetailedServerStatus(
 
   // Common configuration
   printer.keyValue({
-    Timeout: inferredConfig.timeout ? `${inferredConfig.timeout}ms` : '(default)',
-    'Connection Timeout': inferredConfig.connectionTimeout ? `${inferredConfig.connectionTimeout}ms` : '(default)',
-    'Request Timeout': inferredConfig.requestTimeout ? `${inferredConfig.requestTimeout}ms` : '(default)',
+    Timeout: inferredConfig.timeout !== undefined ? `${inferredConfig.timeout}ms` : '(default)',
+    'Connection Timeout':
+      inferredConfig.connectionTimeout !== undefined ? `${inferredConfig.connectionTimeout}ms` : '(default)',
+    'Request Timeout': inferredConfig.requestTimeout !== undefined ? `${inferredConfig.requestTimeout}ms` : '(default)',
   });
   printer.keyValue({
     Tags: inferredConfig.tags && inferredConfig.tags.length > 0 ? inferredConfig.tags.join(', ') : '(none)',
@@ -293,7 +306,7 @@ function displayDetailedServerStatus(
   // Runtime status (this would require integration with ServerManager to get actual runtime status)
   printer.blank();
   printer.subtitle('Runtime Information:');
-  printer.keyValue({ 'Effective Configuration': JSON.stringify(effectiveConfig) });
+  printer.keyValue({ 'Effective Configuration': JSON.stringify(sanitizeForLogging(effectiveConfig)) });
 
   if (effectiveConfig.disabled) {
     printer.keyValue({ 'Runtime Status': '⏹️  Not running (disabled)' });

--- a/src/commands/serve/index.test.ts
+++ b/src/commands/serve/index.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import yargs from 'yargs';
+
+import { setupServeCommand } from './index.js';
+
+const serveCommandMock = vi.fn();
+const configureGlobalLoggerMock = vi.fn();
+
+vi.mock('./serve.js', () => ({
+  serveCommand: serveCommandMock,
+}));
+
+vi.mock('@src/logger/configureGlobalLogger.js', () => ({
+  configureGlobalLogger: configureGlobalLoggerMock,
+}));
+
+describe('setupServeCommand', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not inject an HTTP transport when no CLI transport flag is passed', async () => {
+    await setupServeCommand(yargs([]).exitProcess(false).help(false).version(false)).parseAsync(['serve']);
+
+    expect(configureGlobalLoggerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: undefined,
+        'config-dir': undefined,
+        'log-file': undefined,
+      }),
+      undefined,
+    );
+    expect(serveCommandMock).toHaveBeenCalledTimes(1);
+    expect(serveCommandMock.mock.calls[0]?.[0]).not.toHaveProperty('transport');
+  });
+
+  it('passes the CLI transport through when explicitly provided', async () => {
+    await setupServeCommand(yargs([]).exitProcess(false).help(false).version(false)).parseAsync([
+      'serve',
+      '--transport=stdio',
+    ]);
+
+    expect(configureGlobalLoggerMock).toHaveBeenCalledWith(expect.any(Object), 'stdio');
+    expect(serveCommandMock).toHaveBeenCalledWith(expect.objectContaining({ transport: 'stdio' }));
+  });
+});

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -1,4 +1,3 @@
-import { HOST, PORT } from '@src/constants.js';
 import { globalOptions } from '@src/globalOptions.js';
 
 import type { Argv } from 'yargs';
@@ -16,19 +15,16 @@ export const serverOptions = {
     describe: 'Transport type to use (stdio or http, sse is deprecated)',
     type: 'string' as const,
     choices: ['stdio', 'http', 'sse'] as const,
-    default: 'http',
   },
   port: {
     alias: 'P',
     describe: 'HTTP port to listen on, applicable when transport is http',
     type: 'number' as const,
-    default: PORT,
   },
   host: {
     alias: 'H',
     describe: 'HTTP host to listen on, applicable when transport is http',
     type: 'string' as const,
-    default: HOST,
   },
   'external-url': {
     alias: 'u',

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -47,27 +47,22 @@ export const serverOptions = {
   auth: {
     describe: 'Enable authentication (OAuth 2.1) - deprecated, use --enable-auth',
     type: 'boolean' as const,
-    default: false,
   },
   'enable-auth': {
     describe: 'Enable authentication (OAuth 2.1)',
     type: 'boolean' as const,
-    default: false,
   },
   'enable-scope-validation': {
     describe: 'Enable tag-based scope validation',
     type: 'boolean' as const,
-    default: true,
   },
   'enable-enhanced-security': {
     describe: 'Enable enhanced security middleware',
     type: 'boolean' as const,
-    default: false,
   },
   'session-ttl': {
     describe: 'Session expiry time in minutes',
     type: 'number' as const,
-    default: 24 * 60, // 24 hours
   },
   'session-storage-path': {
     describe: 'Custom session storage directory path',
@@ -77,18 +72,15 @@ export const serverOptions = {
   'rate-limit-window': {
     describe: 'OAuth rate limit window in minutes',
     type: 'number' as const,
-    default: 15,
   },
   'rate-limit-max': {
     describe: 'Maximum requests per OAuth rate limit window',
     type: 'number' as const,
-    default: 100,
   },
   'trust-proxy': {
     describe:
       'Trust proxy configuration for Express.js (boolean, IP address, subnet, or preset: loopback, linklocal, uniquelocal)',
     type: 'string' as const,
-    default: 'loopback',
   },
   'health-info-level': {
     describe: 'Health endpoint information detail level (full, basic, minimal)',
@@ -99,27 +91,22 @@ export const serverOptions = {
   'enable-async-loading': {
     describe: 'Enable asynchronous MCP server loading with listChanged notifications',
     type: 'boolean' as const,
-    default: false,
   },
   'async-min-servers': {
     describe: 'Minimum number of servers to wait for before accepting requests (when async loading enabled)',
     type: 'number' as const,
-    default: 1,
   },
   'async-timeout': {
     describe: 'Initial load timeout in milliseconds (when async loading enabled)',
     type: 'number' as const,
-    default: 30000,
   },
   'async-batch-notifications': {
     describe: 'Batch capability change notifications (when async loading enabled)',
     type: 'boolean' as const,
-    default: true,
   },
   'async-batch-delay': {
     describe: 'Batch delay in milliseconds for notifications (when async loading enabled)',
     type: 'number' as const,
-    default: 100,
   },
   'async-notify-on-ready': {
     describe: 'Notify clients when servers become ready (when async loading enabled)',
@@ -129,18 +116,15 @@ export const serverOptions = {
   'enable-lazy-loading': {
     describe: 'Enable lazy loading for tools (tools loaded on-demand, reduces token usage by ~95%)',
     type: 'boolean' as const,
-    default: false,
   },
   'lazy-mode': {
     describe: 'Lazy loading mode (metatool: 3 meta-tools only, hybrid: direct + meta-tools, full: disabled)',
     type: 'string' as const,
     choices: ['metatool', 'hybrid', 'full'] as const,
-    default: 'full',
   },
   'lazy-cache-max-entries': {
     describe: 'Maximum number of tool schemas to cache in LRU cache (when lazy loading enabled)',
     type: 'number' as const,
-    default: 1000,
   },
   'lazy-preload': {
     describe: 'Comma-separated list of tool patterns to preload at startup (when lazy loading enabled)',
@@ -155,7 +139,6 @@ export const serverOptions = {
   'lazy-inline-catalog': {
     describe: 'Include full tool catalog in initialize template (when lazy loading enabled)',
     type: 'boolean' as const,
-    default: false,
   },
   'lazy-catalog-format': {
     describe: 'Format for inline tool catalog (flat, grouped, categorized)',
@@ -187,12 +170,10 @@ export const serverOptions = {
   'enable-config-reload': {
     describe: 'Enable automatic configuration hot-reload on file changes',
     type: 'boolean' as const,
-    default: true,
   },
   'config-reload-debounce': {
     describe: 'Debounce delay in milliseconds for config reload',
     type: 'number' as const,
-    default: 500,
   },
   'enable-env-substitution': {
     describe: 'Enable environment variable substitution in config (${VAR_NAME} pattern)',

--- a/src/commands/serve/serve.test.ts
+++ b/src/commands/serve/serve.test.ts
@@ -298,4 +298,98 @@ describe('serveCommand - config-dir session isolation', () => {
       expect(typeof cleanupPidFileOnExit).toBe('function');
     });
   });
+
+  describe('appConfig transport/port/host precedence', () => {
+    const baseOptions: Omit<ServeOptions, 'transport' | 'port' | 'host'> = {
+      pagination: false,
+      auth: false,
+      'enable-auth': false,
+      'enable-scope-validation': true,
+      'enable-enhanced-security': false,
+      'session-ttl': 1440,
+      'trust-proxy': 'loopback',
+      'health-info-level': 'minimal',
+      'rate-limit-window': 15,
+      'rate-limit-max': 100,
+      'enable-async-loading': false,
+      'async-min-servers': 1,
+      'async-timeout': 30000,
+      'async-batch-notifications': true,
+      'async-batch-delay': 100,
+      'async-notify-on-ready': true,
+      'enable-lazy-loading': false,
+      'lazy-mode': 'full',
+      'lazy-inline-catalog': false,
+      'lazy-catalog-format': 'grouped',
+      'lazy-cache-max-entries': 1000,
+      'enable-config-reload': true,
+      'config-reload-debounce': 500,
+      'enable-env-substitution': true,
+      'enable-session-persistence': true,
+      'session-persist-requests': 100,
+      'session-persist-interval': 5,
+      'session-background-flush': 60,
+      'enable-client-notifications': true,
+      'enable-jsonrpc-error-logging': true,
+      'enable-internal-tools': false,
+    };
+
+    it('uses appConfig.transport when CLI transport is absent', async () => {
+      const { ConfigManager } = await import('@src/config/configManager.js');
+      vi.mocked(ConfigManager.getInstance).mockReturnValue({
+        getTransportConfig: vi.fn().mockReturnValue({}),
+        getAppConfig: vi.fn().mockReturnValue({ transport: 'stdio' }),
+        initialize: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      } as any);
+
+      const configManager = AgentConfigManager.getInstance();
+      const updateConfigSpy = vi.mocked(configManager.updateConfig);
+
+      const options: ServeOptions = {
+        ...baseOptions,
+        transport: undefined as any,
+        port: undefined as any,
+        host: undefined as any,
+      };
+
+      try {
+        await serveCommand(options);
+      } catch {
+        // ignore mock errors
+      }
+
+      // effectiveTransport should have been 'stdio' from appConfig
+      expect(updateConfigSpy).toHaveBeenCalled();
+    });
+
+    it('CLI transport overrides appConfig.transport', async () => {
+      const { ConfigManager } = await import('@src/config/configManager.js');
+      vi.mocked(ConfigManager.getInstance).mockReturnValue({
+        getTransportConfig: vi.fn().mockReturnValue({}),
+        getAppConfig: vi.fn().mockReturnValue({ transport: 'stdio' }),
+        initialize: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      } as any);
+
+      const configManager = AgentConfigManager.getInstance();
+      const updateConfigSpy = vi.mocked(configManager.updateConfig);
+
+      const options: ServeOptions = { ...baseOptions, transport: 'http', port: 3050, host: '127.0.0.1' };
+
+      try {
+        await serveCommand(options);
+      } catch {
+        // ignore mock errors
+      }
+
+      // updateConfig should have been called (http path taken)
+      expect(updateConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          port: 3050,
+          host: '127.0.0.1',
+        }),
+      );
+    });
+  });
 });

--- a/src/commands/serve/serve.test.ts
+++ b/src/commands/serve/serve.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
+import { displayLogo } from '@src/utils/ui/logo.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -359,8 +360,13 @@ describe('serveCommand - config-dir session isolation', () => {
         // ignore mock errors
       }
 
-      // effectiveTransport should have been 'stdio' from appConfig
-      expect(updateConfigSpy).toHaveBeenCalled();
+      expect(updateConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          port: 3050,
+          host: '127.0.0.1',
+        }),
+      );
+      expect(displayLogo).not.toHaveBeenCalled();
     });
 
     it('CLI transport overrides appConfig.transport', async () => {
@@ -386,6 +392,13 @@ describe('serveCommand - config-dir session isolation', () => {
       // updateConfig should have been called (http path taken)
       expect(updateConfigSpy).toHaveBeenCalledWith(
         expect.objectContaining({
+          port: 3050,
+          host: '127.0.0.1',
+        }),
+      );
+      expect(displayLogo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transport: 'http',
           port: 3050,
           host: '127.0.0.1',
         }),

--- a/src/commands/serve/serve.test.ts
+++ b/src/commands/serve/serve.test.ts
@@ -12,6 +12,7 @@ vi.mock('@src/config/configManager.js', () => ({
   ConfigManager: {
     getInstance: vi.fn().mockReturnValue({
       getTransportConfig: vi.fn().mockReturnValue({}),
+      getAppConfig: vi.fn().mockReturnValue({}),
       initialize: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
     }),

--- a/src/commands/serve/serve.test.ts
+++ b/src/commands/serve/serve.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
+import { configureGlobalLogger } from '@src/logger/configureGlobalLogger.js';
 import { displayLogo } from '@src/utils/ui/logo.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -401,6 +402,193 @@ describe('serveCommand - config-dir session isolation', () => {
           transport: 'http',
           port: 3050,
           host: '127.0.0.1',
+        }),
+      );
+    });
+
+    it('uses config.toml app settings when matching CLI flags are omitted', async () => {
+      const { ConfigManager } = await import('@src/config/configManager.js');
+      vi.mocked(ConfigManager.getInstance).mockReturnValue({
+        getTransportConfig: vi.fn().mockReturnValue({}),
+        getAppConfig: vi.fn().mockReturnValue({
+          transport: 'http',
+          port: 4180,
+          host: '0.0.0.0',
+          logLevel: 'debug',
+          logFile: '/tmp/1mcp.log',
+          auth: {
+            enabled: true,
+            sessionTtl: 60,
+            rateLimitWindow: 2,
+            rateLimitMax: 7,
+            trustProxy: 'uniquelocal',
+            enableScopeValidation: false,
+            enableEnhancedSecurity: true,
+          },
+          asyncLoading: {
+            enabled: true,
+            minServers: 3,
+            timeout: 1234,
+            batchNotifications: false,
+            batchDelay: 55,
+          },
+          lazyLoading: {
+            enabled: true,
+            cacheMaxEntries: 42,
+            inlineCatalog: true,
+          },
+          configReload: {
+            enabled: false,
+            debounce: 250,
+          },
+        }),
+        initialize: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      } as any);
+
+      const configManager = AgentConfigManager.getInstance();
+      const updateConfigSpy = vi.mocked(configManager.updateConfig);
+
+      const options: ServeOptions = {
+        pagination: false,
+        'health-info-level': 'minimal',
+        'async-notify-on-ready': true,
+        'lazy-catalog-format': 'grouped',
+        'enable-env-substitution': true,
+        'enable-session-persistence': true,
+        'session-persist-requests': 100,
+        'session-persist-interval': 5,
+        'session-background-flush': 60,
+        'enable-client-notifications': true,
+        'enable-jsonrpc-error-logging': true,
+        'enable-internal-tools': false,
+      };
+
+      try {
+        await serveCommand(options);
+      } catch {
+        // ignore mock errors
+      }
+
+      expect(configureGlobalLogger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'log-level': 'debug',
+          'log-file': '/tmp/1mcp.log',
+        }),
+        'http',
+      );
+      expect(displayLogo).not.toHaveBeenCalled();
+      expect(updateConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: '0.0.0.0',
+          port: 4180,
+          trustProxy: 'uniquelocal',
+          auth: expect.objectContaining({
+            enabled: true,
+            sessionTtlMinutes: 60,
+            oauthTokenTtlMs: 60 * 60 * 1000,
+          }),
+          rateLimit: {
+            windowMs: 2 * 60 * 1000,
+            max: 7,
+          },
+          features: expect.objectContaining({
+            auth: true,
+            scopeValidation: false,
+            enhancedSecurity: true,
+            configReload: false,
+          }),
+          asyncLoading: expect.objectContaining({
+            enabled: true,
+            waitForMinimumServers: 3,
+            initialLoadTimeoutMs: 1234,
+            batchNotifications: false,
+            batchDelayMs: 55,
+          }),
+          lazyLoading: expect.objectContaining({
+            enabled: true,
+            inlineCatalog: true,
+            cache: expect.objectContaining({
+              maxEntries: 42,
+            }),
+          }),
+          configReload: {
+            debounceMs: 250,
+          },
+        }),
+      );
+    });
+
+    it('CLI flags override config.toml app settings', async () => {
+      const { ConfigManager } = await import('@src/config/configManager.js');
+      vi.mocked(ConfigManager.getInstance).mockReturnValue({
+        getTransportConfig: vi.fn().mockReturnValue({}),
+        getAppConfig: vi.fn().mockReturnValue({
+          transport: 'stdio',
+          port: 4180,
+          host: '0.0.0.0',
+          logLevel: 'debug',
+          logFile: '/tmp/1mcp.log',
+          auth: {
+            enabled: true,
+            sessionTtl: 60,
+            rateLimitWindow: 2,
+            rateLimitMax: 7,
+            trustProxy: 'uniquelocal',
+          },
+        }),
+        initialize: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      } as any);
+
+      const configManager = AgentConfigManager.getInstance();
+      const updateConfigSpy = vi.mocked(configManager.updateConfig);
+
+      const options: ServeOptions = {
+        pagination: false,
+        transport: 'http',
+        port: 3051,
+        host: '127.0.0.2',
+        'log-level': 'warn',
+        'log-file': '/tmp/cli.log',
+        'enable-auth': false,
+        'session-ttl': 15,
+        'rate-limit-window': 9,
+        'rate-limit-max': 99,
+        'trust-proxy': 'loopback',
+        'health-info-level': 'minimal',
+        'async-notify-on-ready': true,
+        'lazy-catalog-format': 'grouped',
+        'enable-env-substitution': true,
+        'enable-session-persistence': true,
+        'session-persist-requests': 100,
+        'session-persist-interval': 5,
+        'session-background-flush': 60,
+        'enable-client-notifications': true,
+        'enable-jsonrpc-error-logging': true,
+        'enable-internal-tools': false,
+      };
+
+      try {
+        await serveCommand(options);
+      } catch {
+        // ignore mock errors
+      }
+
+      expect(configureGlobalLogger).toHaveBeenCalledWith(expect.objectContaining({ 'log-level': 'warn' }), 'http');
+      expect(updateConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: '127.0.0.2',
+          port: 3051,
+          trustProxy: 'loopback',
+          auth: expect.objectContaining({
+            enabled: false,
+            sessionTtlMinutes: 15,
+          }),
+          rateLimit: {
+            windowMs: 9 * 60 * 1000,
+            max: 99,
+          },
         }),
       );
     });

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -6,7 +6,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import ConfigContext from '@src/config/configContext.js';
 import { ConfigManager } from '@src/config/configManager.js';
 import { getDefaultInstructionsTemplatePath } from '@src/constants.js';
-import { getConfigDir } from '@src/constants.js';
+import { getConfigDir, HOST, PORT } from '@src/constants.js';
 import { FlagManager } from '@src/core/flags/flagManager.js';
 import { InstructionAggregator } from '@src/core/instructions/instructionAggregator.js';
 import { formatValidationError, validateTemplateContent } from '@src/core/instructions/templateValidator.js';
@@ -27,9 +27,9 @@ export interface ServeOptions {
   'config-dir'?: string;
   'log-level'?: string;
   'log-file'?: string;
-  transport: string;
-  port: number;
-  host: string;
+  transport?: string;
+  port?: number;
+  host?: string;
   'external-url'?: string;
   filter?: string;
   pagination: boolean;
@@ -272,8 +272,8 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
 
     // Display logo with runtime information (skip for stdio or when logging to file)
     const effectiveTransport = parsedArgv.transport ?? appConfig.transport ?? 'http';
-    const effectivePort = parsedArgv.port ?? appConfig.port ?? parsedArgv.port;
-    const effectiveHost = parsedArgv.host ?? appConfig.host ?? parsedArgv.host;
+    const effectivePort = parsedArgv.port ?? appConfig.port ?? PORT;
+    const effectiveHost = parsedArgv.host ?? appConfig.host ?? HOST;
     if (effectiveTransport !== 'stdio' && !parsedArgv['log-file']) {
       displayLogo({
         transport: effectiveTransport,
@@ -543,8 +543,8 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
         writePidFile(configDir, {
           pid: process.pid,
           url: `${serverUrl}/mcp`,
-          port: parsedArgv.port,
-          host: parsedArgv.host,
+          port: effectivePort,
+          host: effectiveHost,
           transport: 'http',
           startedAt: new Date().toISOString(),
           configDir,

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -260,19 +260,25 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
     const configFilePath = configContext.getResolvedConfigPath();
     const mcpConfigManager = ConfigManager.getInstance(configFilePath);
 
+    // Load app-level config from config.toml (CLI args take precedence)
+    const appConfig = mcpConfigManager.getAppConfig();
+
     // Get server count for logo display
     const transportConfig = mcpConfigManager.getTransportConfig();
     const serverCount = Object.keys(transportConfig).length;
 
     // Handle backward compatibility for auth flag
-    const authEnabled = parsedArgv['enable-auth'] ?? parsedArgv['auth'] ?? false;
+    const authEnabled = parsedArgv['enable-auth'] ?? parsedArgv['auth'] ?? appConfig.auth?.enabled ?? false;
 
     // Display logo with runtime information (skip for stdio or when logging to file)
-    if (parsedArgv.transport !== 'stdio' && !parsedArgv['log-file']) {
+    const effectiveTransport = parsedArgv.transport ?? appConfig.transport ?? 'http';
+    const effectivePort = parsedArgv.port ?? appConfig.port ?? parsedArgv.port;
+    const effectiveHost = parsedArgv.host ?? appConfig.host ?? parsedArgv.host;
+    if (effectiveTransport !== 'stdio' && !parsedArgv['log-file']) {
       displayLogo({
-        transport: parsedArgv.transport,
-        port: parsedArgv.port,
-        host: parsedArgv.host,
+        transport: effectiveTransport,
+        port: effectivePort,
+        host: effectiveHost,
         serverCount,
         authEnabled,
         logLevel: parsedArgv['log-level'],
@@ -280,10 +286,12 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
       });
     }
 
-    // Configure server settings from CLI arguments
+    // Configure server settings from CLI arguments (CLI args take precedence over appConfig)
     const serverConfigManager = AgentConfigManager.getInstance();
-    const scopeValidationEnabled = parsedArgv['enable-scope-validation'] ?? authEnabled;
-    const enhancedSecurityEnabled = parsedArgv['enable-enhanced-security'] ?? false;
+    const scopeValidationEnabled =
+      parsedArgv['enable-scope-validation'] ?? appConfig.auth?.enableScopeValidation ?? authEnabled;
+    const enhancedSecurityEnabled =
+      parsedArgv['enable-enhanced-security'] ?? appConfig.auth?.enableEnhancedSecurity ?? false;
 
     // Handle trust proxy configuration (convert 'true'/'false' strings to boolean)
     const trustProxyValue = parsedArgv['trust-proxy'];
@@ -298,26 +306,26 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
     }
 
     serverConfigManager.updateConfig({
-      host: parsedArgv.host,
-      port: parsedArgv.port,
+      host: effectiveHost,
+      port: effectivePort,
       externalUrl: parsedArgv['external-url'],
       trustProxy,
       auth: {
         enabled: authEnabled,
-        sessionTtlMinutes: parsedArgv['session-ttl'],
+        sessionTtlMinutes: parsedArgv['session-ttl'] ?? appConfig.auth?.sessionTtl,
         sessionStoragePath,
         oauthCodeTtlMs: 60 * 1000, // 1 minute
-        oauthTokenTtlMs: parsedArgv['session-ttl'] * 60 * 1000, // Convert minutes to milliseconds
+        oauthTokenTtlMs: (parsedArgv['session-ttl'] ?? appConfig.auth?.sessionTtl ?? 1440) * 60 * 1000,
       },
       rateLimit: {
-        windowMs: parsedArgv['rate-limit-window'] * 60 * 1000, // Convert minutes to milliseconds
-        max: parsedArgv['rate-limit-max'],
+        windowMs: (parsedArgv['rate-limit-window'] ?? appConfig.auth?.rateLimitWindow ?? 15) * 60 * 1000,
+        max: parsedArgv['rate-limit-max'] ?? appConfig.auth?.rateLimitMax ?? 100,
       },
       features: {
         auth: authEnabled,
         scopeValidation: scopeValidationEnabled,
         enhancedSecurity: enhancedSecurityEnabled,
-        configReload: parsedArgv['enable-config-reload'],
+        configReload: parsedArgv['enable-config-reload'] ?? appConfig.configReload?.enabled ?? true,
         envSubstitution: parsedArgv['enable-env-substitution'],
         sessionPersistence: parsedArgv['enable-session-persistence'],
         clientNotifications: parsedArgv['enable-client-notifications'],
@@ -342,22 +350,22 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
         detailLevel: parsedArgv['health-info-level'] as 'full' | 'basic' | 'minimal',
       },
       asyncLoading: {
-        enabled: parsedArgv['enable-async-loading'],
+        enabled: parsedArgv['enable-async-loading'] ?? appConfig.asyncLoading?.enabled ?? false,
         notifyOnServerReady: parsedArgv['async-notify-on-ready'],
-        waitForMinimumServers: parsedArgv['async-min-servers'],
-        initialLoadTimeoutMs: parsedArgv['async-timeout'],
-        batchNotifications: parsedArgv['async-batch-notifications'],
-        batchDelayMs: parsedArgv['async-batch-delay'],
+        waitForMinimumServers: parsedArgv['async-min-servers'] ?? appConfig.asyncLoading?.minServers,
+        initialLoadTimeoutMs: parsedArgv['async-timeout'] ?? appConfig.asyncLoading?.timeout,
+        batchNotifications: parsedArgv['async-batch-notifications'] ?? appConfig.asyncLoading?.batchNotifications,
+        batchDelayMs: parsedArgv['async-batch-delay'] ?? appConfig.asyncLoading?.batchDelay,
       },
       lazyLoading: {
-        enabled: parsedArgv['enable-lazy-loading'],
-        inlineCatalog: parsedArgv['lazy-inline-catalog'],
+        enabled: parsedArgv['enable-lazy-loading'] ?? appConfig.lazyLoading?.enabled ?? false,
+        inlineCatalog: parsedArgv['lazy-inline-catalog'] ?? appConfig.lazyLoading?.inlineCatalog ?? false,
         catalogFormat: (parsedArgv['lazy-catalog-format'] || 'grouped') as 'flat' | 'grouped' | 'categorized',
         directExpose: parsedArgv['lazy-direct-expose']
           ? parsedArgv['lazy-direct-expose'].split(',').map((s) => s.trim())
           : [],
         cache: {
-          maxEntries: parsedArgv['lazy-cache-max-entries'],
+          maxEntries: parsedArgv['lazy-cache-max-entries'] ?? appConfig.lazyLoading?.cacheMaxEntries ?? 1000,
           strategy: 'lru' as const,
           ttlMs: parsedArgv['lazy-cache-ttl'],
         },
@@ -373,7 +381,7 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
         },
       },
       configReload: {
-        debounceMs: parsedArgv['config-reload-debounce'],
+        debounceMs: parsedArgv['config-reload-debounce'] ?? appConfig.configReload?.debounce ?? 500,
       },
       sessionPersistence: {
         persistRequests: parsedArgv['session-persist-requests'],
@@ -396,7 +404,7 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
 
     let expressServer: ExpressServer | undefined;
 
-    switch (parsedArgv.transport) {
+    switch (effectiveTransport) {
       case 'stdio': {
         // DEPRECATION WARNING
         logger.warn('⚠️  DEPRECATION WARNING: `serve --transport stdio` is deprecated');

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -17,6 +17,7 @@ import { cleanupPidFileOnExit, registerPidFileCleanup, writePidFile } from '@src
 import { ServerManager } from '@src/core/server/serverManager.js';
 import { TagExpression, TagQueryParser } from '@src/domains/preset/parsers/tagQueryParser.js';
 import type { TagQuery } from '@src/domains/preset/types/presetTypes.js';
+import { configureGlobalLogger } from '@src/logger/configureGlobalLogger.js';
 import logger, { debugIf } from '@src/logger/logger.js';
 import { setupServer } from '@src/server.js';
 import { ExpressServer } from '@src/transport/http/server.js';
@@ -25,7 +26,7 @@ import { displayLogo } from '@src/utils/ui/logo.js';
 export interface ServeOptions {
   config?: string;
   'config-dir'?: string;
-  'log-level'?: string;
+  'log-level'?: 'debug' | 'info' | 'warn' | 'error';
   'log-file'?: string;
   transport?: string;
   port?: number;
@@ -33,35 +34,35 @@ export interface ServeOptions {
   'external-url'?: string;
   filter?: string;
   pagination: boolean;
-  auth: boolean;
-  'enable-auth': boolean;
-  'enable-scope-validation': boolean;
-  'enable-enhanced-security': boolean;
-  'session-ttl': number;
+  auth?: boolean;
+  'enable-auth'?: boolean;
+  'enable-scope-validation'?: boolean;
+  'enable-enhanced-security'?: boolean;
+  'session-ttl'?: number;
   'session-storage-path'?: string;
-  'rate-limit-window': number;
-  'rate-limit-max': number;
-  'trust-proxy': string;
+  'rate-limit-window'?: number;
+  'rate-limit-max'?: number;
+  'trust-proxy'?: string;
   'health-info-level': string;
-  'enable-async-loading': boolean;
-  'async-min-servers': number;
-  'async-timeout': number;
-  'async-batch-notifications': boolean;
-  'async-batch-delay': number;
+  'enable-async-loading'?: boolean;
+  'async-min-servers'?: number;
+  'async-timeout'?: number;
+  'async-batch-notifications'?: boolean;
+  'async-batch-delay'?: number;
   'async-notify-on-ready': boolean;
-  'enable-lazy-loading': boolean;
-  'lazy-mode': string;
-  'lazy-inline-catalog': boolean;
+  'enable-lazy-loading'?: boolean;
+  'lazy-mode'?: string;
+  'lazy-inline-catalog'?: boolean;
   'lazy-catalog-format': string;
   'lazy-direct-expose'?: string;
-  'lazy-cache-max-entries': number;
+  'lazy-cache-max-entries'?: number;
   'lazy-cache-ttl'?: number;
   'lazy-preload'?: string;
   'lazy-preload-keywords'?: string;
   'lazy-fallback-on-error'?: string;
   'lazy-fallback-timeout'?: number;
-  'enable-config-reload': boolean;
-  'config-reload-debounce': number;
+  'enable-config-reload'?: boolean;
+  'config-reload-debounce'?: number;
   'enable-env-substitution': boolean;
   'enable-session-persistence': boolean;
   'session-persist-requests': number;
@@ -274,14 +275,23 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
     const effectiveTransport = parsedArgv.transport ?? appConfig.transport ?? 'http';
     const effectivePort = parsedArgv.port ?? appConfig.port ?? PORT;
     const effectiveHost = parsedArgv.host ?? appConfig.host ?? HOST;
-    if (effectiveTransport !== 'stdio' && !parsedArgv['log-file']) {
+    configureGlobalLogger(
+      {
+        ...parsedArgv,
+        'log-level': parsedArgv['log-level'] ?? appConfig.logLevel,
+        'log-file': parsedArgv['log-file'] ?? appConfig.logFile,
+      },
+      effectiveTransport,
+    );
+    const effectiveLogFile = parsedArgv['log-file'] ?? appConfig.logFile;
+    if (effectiveTransport !== 'stdio' && !effectiveLogFile) {
       displayLogo({
         transport: effectiveTransport,
         port: effectivePort,
         host: effectiveHost,
         serverCount,
         authEnabled,
-        logLevel: parsedArgv['log-level'],
+        logLevel: parsedArgv['log-level'] ?? appConfig.logLevel,
         configDir: getConfigDir(parsedArgv['config-dir']),
       });
     }
@@ -289,12 +299,12 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
     // Configure server settings from CLI arguments (CLI args take precedence over appConfig)
     const serverConfigManager = AgentConfigManager.getInstance();
     const scopeValidationEnabled =
-      parsedArgv['enable-scope-validation'] ?? appConfig.auth?.enableScopeValidation ?? authEnabled;
+      parsedArgv['enable-scope-validation'] ?? appConfig.auth?.enableScopeValidation ?? true;
     const enhancedSecurityEnabled =
       parsedArgv['enable-enhanced-security'] ?? appConfig.auth?.enableEnhancedSecurity ?? false;
 
     // Handle trust proxy configuration (convert 'true'/'false' strings to boolean)
-    const trustProxyValue = parsedArgv['trust-proxy'];
+    const trustProxyValue = parsedArgv['trust-proxy'] ?? appConfig.auth?.trustProxy ?? 'loopback';
     const trustProxy = trustProxyValue === 'true' ? true : trustProxyValue === 'false' ? false : trustProxyValue;
 
     // Derive session storage path: explicit option > config-dir/sessions > global default
@@ -312,7 +322,7 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
       trustProxy,
       auth: {
         enabled: authEnabled,
-        sessionTtlMinutes: parsedArgv['session-ttl'] ?? appConfig.auth?.sessionTtl,
+        sessionTtlMinutes: parsedArgv['session-ttl'] ?? appConfig.auth?.sessionTtl ?? 1440,
         sessionStoragePath,
         oauthCodeTtlMs: 60 * 1000, // 1 minute
         oauthTokenTtlMs: (parsedArgv['session-ttl'] ?? appConfig.auth?.sessionTtl ?? 1440) * 60 * 1000,
@@ -352,10 +362,11 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
       asyncLoading: {
         enabled: parsedArgv['enable-async-loading'] ?? appConfig.asyncLoading?.enabled ?? false,
         notifyOnServerReady: parsedArgv['async-notify-on-ready'],
-        waitForMinimumServers: parsedArgv['async-min-servers'] ?? appConfig.asyncLoading?.minServers,
-        initialLoadTimeoutMs: parsedArgv['async-timeout'] ?? appConfig.asyncLoading?.timeout,
-        batchNotifications: parsedArgv['async-batch-notifications'] ?? appConfig.asyncLoading?.batchNotifications,
-        batchDelayMs: parsedArgv['async-batch-delay'] ?? appConfig.asyncLoading?.batchDelay,
+        waitForMinimumServers: parsedArgv['async-min-servers'] ?? appConfig.asyncLoading?.minServers ?? 1,
+        initialLoadTimeoutMs: parsedArgv['async-timeout'] ?? appConfig.asyncLoading?.timeout ?? 30000,
+        batchNotifications:
+          parsedArgv['async-batch-notifications'] ?? appConfig.asyncLoading?.batchNotifications ?? true,
+        batchDelayMs: parsedArgv['async-batch-delay'] ?? appConfig.asyncLoading?.batchDelay ?? 100,
       },
       lazyLoading: {
         enabled: parsedArgv['enable-lazy-loading'] ?? appConfig.lazyLoading?.enabled ?? false,

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -76,6 +76,23 @@ export interface ServeOptions {
   'instructions-template'?: string;
 }
 
+function parseCommaSeparatedList(value?: string): string[] {
+  return value ? value.split(',').map((entry) => entry.trim()) : [];
+}
+
+function parseInternalToolsList(value?: string): string[] {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    return FlagManager.getInstance().parseToolsList(value);
+  } catch (error) {
+    logger.error(`Failed to parse internal-tools list: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}
+
 /**
  * Load custom instructions template from file with validation
  * @param templatePath Path to template file (CLI option or default)
@@ -315,6 +332,11 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
       sessionStoragePath = path.join(parsedArgv['config-dir'], 'sessions');
     }
 
+    const internalToolsList = parseInternalToolsList(parsedArgv['internal-tools']);
+    const directExpose = parseCommaSeparatedList(parsedArgv['lazy-direct-expose']);
+    const preloadPatterns = parseCommaSeparatedList(parsedArgv['lazy-preload']);
+    const preloadKeywords = parseCommaSeparatedList(parsedArgv['lazy-preload-keywords']);
+
     serverConfigManager.updateConfig({
       host: effectiveHost,
       port: effectivePort,
@@ -342,19 +364,7 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
         jsonRpcErrorLogging: parsedArgv['enable-jsonrpc-error-logging'],
         // Internal tool configuration from CLI flags
         internalTools: parsedArgv['enable-internal-tools'],
-        internalToolsList: parsedArgv['internal-tools']
-          ? (() => {
-              try {
-                const flagManager = FlagManager.getInstance();
-                return flagManager.parseToolsList(parsedArgv['internal-tools']);
-              } catch (error) {
-                logger.error(
-                  `Failed to parse internal-tools list: ${error instanceof Error ? error.message : String(error)}`,
-                );
-                process.exit(1);
-              }
-            })()
-          : [],
+        internalToolsList,
       },
       health: {
         detailLevel: parsedArgv['health-info-level'] as 'full' | 'basic' | 'minimal',
@@ -372,19 +382,15 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
         enabled: parsedArgv['enable-lazy-loading'] ?? appConfig.lazyLoading?.enabled ?? false,
         inlineCatalog: parsedArgv['lazy-inline-catalog'] ?? appConfig.lazyLoading?.inlineCatalog ?? false,
         catalogFormat: (parsedArgv['lazy-catalog-format'] || 'grouped') as 'flat' | 'grouped' | 'categorized',
-        directExpose: parsedArgv['lazy-direct-expose']
-          ? parsedArgv['lazy-direct-expose'].split(',').map((s) => s.trim())
-          : [],
+        directExpose,
         cache: {
           maxEntries: parsedArgv['lazy-cache-max-entries'] ?? appConfig.lazyLoading?.cacheMaxEntries ?? 1000,
           strategy: 'lru' as const,
           ttlMs: parsedArgv['lazy-cache-ttl'],
         },
         preload: {
-          patterns: parsedArgv['lazy-preload'] ? parsedArgv['lazy-preload'].split(',').map((s) => s.trim()) : [],
-          keywords: parsedArgv['lazy-preload-keywords']
-            ? parsedArgv['lazy-preload-keywords'].split(',').map((s) => s.trim())
-            : [],
+          patterns: preloadPatterns,
+          keywords: preloadKeywords,
         },
         fallback: {
           onError: (parsedArgv['lazy-fallback-on-error'] || 'skip') as 'skip' | 'full',

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -556,7 +556,7 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
         break;
       }
       default:
-        logger.error(`Invalid transport: ${parsedArgv.transport}`);
+        logger.error(`Invalid transport: ${effectiveTransport}`);
         process.exit(1);
     }
 

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -5,8 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 
 import ConfigContext from '@src/config/configContext.js';
 import { ConfigManager } from '@src/config/configManager.js';
-import { getDefaultInstructionsTemplatePath } from '@src/constants.js';
-import { getConfigDir, HOST, PORT } from '@src/constants.js';
+import { getConfigDir, getDefaultInstructionsTemplatePath, HOST, PORT } from '@src/constants.js';
 import { FlagManager } from '@src/core/flags/flagManager.js';
 import { InstructionAggregator } from '@src/core/instructions/instructionAggregator.js';
 import { formatValidationError, validateTemplateContent } from '@src/core/instructions/templateValidator.js';
@@ -336,6 +335,7 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
     const directExpose = parseCommaSeparatedList(parsedArgv['lazy-direct-expose']);
     const preloadPatterns = parseCommaSeparatedList(parsedArgv['lazy-preload']);
     const preloadKeywords = parseCommaSeparatedList(parsedArgv['lazy-preload-keywords']);
+    const sessionTtlMinutes = parsedArgv['session-ttl'] ?? appConfig.auth?.sessionTtl ?? 1440;
 
     serverConfigManager.updateConfig({
       host: effectiveHost,
@@ -344,10 +344,10 @@ export async function serveCommand(parsedArgv: ServeOptions): Promise<void> {
       trustProxy,
       auth: {
         enabled: authEnabled,
-        sessionTtlMinutes: parsedArgv['session-ttl'] ?? appConfig.auth?.sessionTtl ?? 1440,
+        sessionTtlMinutes,
         sessionStoragePath,
         oauthCodeTtlMs: 60 * 1000, // 1 minute
-        oauthTokenTtlMs: (parsedArgv['session-ttl'] ?? appConfig.auth?.sessionTtl ?? 1440) * 60 * 1000,
+        oauthTokenTtlMs: sessionTtlMinutes * 60 * 1000,
       },
       rateLimit: {
         windowMs: (parsedArgv['rate-limit-window'] ?? appConfig.auth?.rateLimitWindow ?? 15) * 60 * 1000,

--- a/src/commands/shared/baseConfigUtils.test.ts
+++ b/src/commands/shared/baseConfigUtils.test.ts
@@ -3,7 +3,12 @@ import { promises as fsPromises } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { getAllEffectiveServers, getEffectiveServerConfig, loadConfig } from '@src/commands/shared/baseConfigUtils.js';
+import {
+  getAllEffectiveServers,
+  getEffectiveServerConfig,
+  getInheritedKeys,
+  loadConfig,
+} from '@src/commands/shared/baseConfigUtils.js';
 import ConfigContext from '@src/config/configContext.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -201,5 +206,24 @@ describe('baseConfigUtils', () => {
         },
       },
     });
+  });
+
+  it('reports inherited envFilter for stdio servers', () => {
+    expect(
+      getInheritedKeys(
+        {
+          type: 'stdio',
+          command: 'node',
+        },
+        {
+          type: 'stdio',
+          command: 'node',
+          envFilter: ['PATH'],
+        },
+        {
+          envFilter: ['PATH'],
+        },
+      ),
+    ).toContain('envFilter');
   });
 });

--- a/src/commands/shared/baseConfigUtils.test.ts
+++ b/src/commands/shared/baseConfigUtils.test.ts
@@ -1,0 +1,205 @@
+import { randomBytes } from 'crypto';
+import { promises as fsPromises } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { getAllEffectiveServers, getEffectiveServerConfig, loadConfig } from '@src/commands/shared/baseConfigUtils.js';
+import ConfigContext from '@src/config/configContext.js';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAgentConfig = {
+  get: vi.fn().mockImplementation((key: string) => {
+    const config = {
+      features: {
+        configReload: true,
+        envSubstitution: true,
+      },
+    };
+    return key.split('.').reduce((obj: any, k: string) => obj?.[k], config);
+  }),
+};
+
+vi.mock('@src/core/server/agentConfig.js', () => ({
+  AgentConfigManager: {
+    getInstance: () => mockAgentConfig,
+  },
+}));
+
+describe('baseConfigUtils', () => {
+  let tempConfigDir: string;
+  let configFilePath: string;
+
+  beforeEach(async () => {
+    tempConfigDir = join(tmpdir(), `base-config-utils-test-${randomBytes(4).toString('hex')}`);
+    await fsPromises.mkdir(tempConfigDir, { recursive: true });
+    configFilePath = join(tempConfigDir, 'mcp.json');
+    ConfigContext.getInstance().setConfigPath(configFilePath);
+  });
+
+  afterEach(async () => {
+    ConfigContext.getInstance().reset();
+    delete process.env.TEST_RAW_VALUE;
+    vi.clearAllMocks();
+
+    try {
+      await fsPromises.rm(tempConfigDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('preserves missing config behavior', () => {
+    expect(() => loadConfig()).toThrow(`Configuration file not found: ${configFilePath}`);
+  });
+
+  it('preserves malformed JSON behavior', async () => {
+    await fsPromises.writeFile(configFilePath, '{ invalid json');
+
+    expect(() => loadConfig()).toThrow(`Invalid JSON in configuration file: ${configFilePath}`);
+  });
+
+  it('returns validated global defaults while preserving raw server entries', async () => {
+    process.env.TEST_RAW_VALUE = 'substituted';
+
+    await fsPromises.writeFile(
+      configFilePath,
+      JSON.stringify(
+        {
+          serverDefaults: {
+            timeout: 5000,
+            env: { SHARED: 'global' },
+          },
+          mcpServers: {
+            stdioServer: {
+              type: 'stdio',
+              command: 'node',
+              args: ['${TEST_RAW_VALUE}'],
+              env: { LOCAL: 'server' },
+            },
+            ignoredServer: 'not-an-object',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const config = loadConfig();
+
+    expect(config.serverDefaults).toEqual({
+      timeout: 5000,
+      env: { SHARED: 'global' },
+    });
+    expect(config.mcpServers).toEqual({
+      stdioServer: {
+        type: 'stdio',
+        command: 'node',
+        args: ['${TEST_RAW_VALUE}'],
+        env: { LOCAL: 'server' },
+      },
+    });
+  });
+
+  it('preserves effective merge semantics across transport types', async () => {
+    await fsPromises.writeFile(
+      configFilePath,
+      JSON.stringify(
+        {
+          serverDefaults: {
+            timeout: 3000,
+            headers: { Authorization: 'Bearer global' },
+            inheritParentEnv: true,
+            envFilter: ['PATH'],
+            env: { SHARED: 'global', KEEP: 'global-only' },
+          },
+          mcpServers: {
+            stdioServer: {
+              type: 'stdio',
+              command: 'node',
+              env: { SHARED: 'server' },
+            },
+            httpServer: {
+              type: 'http',
+              url: 'https://example.com/mcp',
+            },
+            streamableServer: {
+              type: 'streamableHttp',
+              url: 'https://example.com/stream',
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(getEffectiveServerConfig('stdioServer')).toEqual({
+      type: 'stdio',
+      command: 'node',
+      timeout: 3000,
+      inheritParentEnv: true,
+      envFilter: ['PATH'],
+      env: {
+        SHARED: 'server',
+        KEEP: 'global-only',
+      },
+    });
+
+    expect(getEffectiveServerConfig('httpServer')).toEqual({
+      type: 'http',
+      url: 'https://example.com/mcp',
+      timeout: 3000,
+      headers: { Authorization: 'Bearer global' },
+      env: {
+        SHARED: 'global',
+        KEEP: 'global-only',
+      },
+    });
+
+    expect(getEffectiveServerConfig('streamableServer')).toEqual({
+      type: 'streamableHttp',
+      url: 'https://example.com/stream',
+      timeout: 3000,
+      headers: { Authorization: 'Bearer global' },
+      env: {
+        SHARED: 'global',
+        KEEP: 'global-only',
+      },
+    });
+
+    expect(getAllEffectiveServers()).toEqual({
+      stdioServer: {
+        type: 'stdio',
+        command: 'node',
+        timeout: 3000,
+        inheritParentEnv: true,
+        envFilter: ['PATH'],
+        env: {
+          SHARED: 'server',
+          KEEP: 'global-only',
+        },
+      },
+      httpServer: {
+        type: 'http',
+        url: 'https://example.com/mcp',
+        timeout: 3000,
+        headers: { Authorization: 'Bearer global' },
+        env: {
+          SHARED: 'global',
+          KEEP: 'global-only',
+        },
+      },
+      streamableServer: {
+        type: 'streamableHttp',
+        url: 'https://example.com/stream',
+        timeout: 3000,
+        headers: { Authorization: 'Bearer global' },
+        env: {
+          SHARED: 'global',
+          KEEP: 'global-only',
+        },
+      },
+    });
+  });
+});

--- a/src/commands/shared/baseConfigUtils.ts
+++ b/src/commands/shared/baseConfigUtils.ts
@@ -3,7 +3,12 @@ import path from 'path';
 
 import ConfigContext from '@src/config/configContext.js';
 import { McpConfigManager } from '@src/config/mcpConfigManager.js';
-import { MCPServerParams } from '@src/core/types/index.js';
+import {
+  getUnknownGlobalConfigKeys,
+  mergeGlobalAndServerConfig,
+  mergeGlobalWithServers,
+} from '@src/config/mcpConfigMerge.js';
+import { GlobalTransportConfig, globalTransportConfigSchema, MCPServerParams } from '@src/core/types/index.js';
 import logger from '@src/logger/logger.js';
 
 /**
@@ -55,6 +60,7 @@ function getExplicitCliOptionValue(flags: string[]): string | undefined {
 }
 
 export interface ServerConfig {
+  serverDefaults?: GlobalTransportConfig;
   mcpServers: Record<string, MCPServerParams>;
 }
 
@@ -79,6 +85,14 @@ export function loadConfig(configPath?: string): ServerConfig {
     }
 
     const configObj = configData as Record<string, unknown>;
+
+    if (configObj.serverDefaults !== undefined) {
+      const unknownGlobalKeys = getUnknownGlobalConfigKeys(configObj.serverDefaults);
+      if (unknownGlobalKeys.length > 0) {
+        logger.warn(`Unknown properties in global MCP configuration were ignored: ${unknownGlobalKeys.join(', ')}`);
+      }
+      configObj.serverDefaults = globalTransportConfigSchema.parse(configObj.serverDefaults);
+    }
 
     // Ensure mcpServers exists and is properly typed
     if (!configObj.mcpServers || typeof configObj.mcpServers !== 'object') {
@@ -161,6 +175,34 @@ export function getServer(serverName: string): MCPServerParams | null {
 }
 
 /**
+ * Get global MCP configuration from file.
+ */
+export function getGlobalConfig(): GlobalTransportConfig {
+  try {
+    const config = loadConfig();
+    return config.serverDefaults || {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+/**
+ * Get effective merged configuration for a specific server.
+ */
+export function getEffectiveServerConfig(serverName: string): MCPServerParams | null {
+  try {
+    const config = loadConfig();
+    const server = config.mcpServers[serverName];
+    if (!server) {
+      return null;
+    }
+    return mergeGlobalAndServerConfig(config.serverDefaults, server);
+  } catch (_error) {
+    return null;
+  }
+}
+
+/**
  * Add or update a server in the configuration
  */
 export function setServer(serverName: string, serverConfig: MCPServerParams): void {
@@ -209,6 +251,18 @@ export function getAllServers(): Record<string, MCPServerParams> {
   try {
     const config = loadConfig();
     return config.mcpServers;
+  } catch (_error) {
+    return {};
+  }
+}
+
+/**
+ * Get all effective server configurations after applying global inheritance.
+ */
+export function getAllEffectiveServers(): Record<string, MCPServerParams> {
+  try {
+    const config = loadConfig();
+    return mergeGlobalWithServers(config.serverDefaults, config.mcpServers);
   } catch (_error) {
     return {};
   }

--- a/src/commands/shared/baseConfigUtils.ts
+++ b/src/commands/shared/baseConfigUtils.ts
@@ -7,6 +7,7 @@ import { McpConfigManager } from '@src/config/mcpConfigManager.js';
 import { mergeGlobalAndServerConfig, mergeGlobalWithServers } from '@src/config/mcpConfigMerge.js';
 import { GlobalTransportConfig, MCPServerParams } from '@src/core/types/index.js';
 import logger from '@src/logger/logger.js';
+import { normalizedArgv } from '@src/utils/cli/normalizedArgv.js';
 
 /**
  * Configuration file utilities for server management commands
@@ -35,8 +36,8 @@ export function initializeConfigContext(configPath?: string, configDir?: string)
 }
 
 function getExplicitCliOptionValue(flags: string[]): string | undefined {
-  for (let index = 0; index < process.argv.length; index += 1) {
-    const arg = process.argv[index];
+  for (let index = 0; index < normalizedArgv.length; index += 1) {
+    const arg = normalizedArgv[index];
     if (!flags.includes(arg)) {
       const matchingFlag = flags.find((flag) => arg.startsWith(`${flag}=`));
       if (!matchingFlag) {
@@ -47,7 +48,7 @@ function getExplicitCliOptionValue(flags: string[]): string | undefined {
       return value || undefined;
     }
 
-    const value = process.argv[index + 1];
+    const value = normalizedArgv[index + 1];
     if (value && !value.startsWith('-')) {
       return value;
     }
@@ -94,12 +95,7 @@ function loadSharedConfigState(configPath?: string): {
       effectiveServers: mergeGlobalWithServers(loadedConfig.globalConfig, loadedConfig.rawServers),
     };
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.cause instanceof SyntaxError ||
-        error.message.includes('Unexpected token') ||
-        error.message.includes('JSON'))
-    ) {
+    if (error instanceof Error && error.cause instanceof SyntaxError) {
       throw new Error(`Invalid JSON in configuration file: ${filePath}`);
     }
     throw error;
@@ -505,6 +501,16 @@ export function getInheritedKeys(
 
   if (rawConfig.env === undefined && effectiveConfig.env !== undefined && globalConfig.env !== undefined) {
     inherited.push('env');
+  }
+
+  if (
+    rawConfig.envFilter === undefined &&
+    Array.isArray(effectiveConfig.envFilter) &&
+    effectiveConfig.envFilter.length > 0 &&
+    Array.isArray(globalConfig.envFilter) &&
+    globalConfig.envFilter.length > 0
+  ) {
+    inherited.push('envFilter');
   }
 
   if (

--- a/src/commands/shared/baseConfigUtils.ts
+++ b/src/commands/shared/baseConfigUtils.ts
@@ -2,13 +2,10 @@ import fs from 'fs';
 import path from 'path';
 
 import ConfigContext from '@src/config/configContext.js';
+import { ConfigLoader } from '@src/config/configLoader.js';
 import { McpConfigManager } from '@src/config/mcpConfigManager.js';
-import {
-  getUnknownGlobalConfigKeys,
-  mergeGlobalAndServerConfig,
-  mergeGlobalWithServers,
-} from '@src/config/mcpConfigMerge.js';
-import { GlobalTransportConfig, globalTransportConfigSchema, MCPServerParams } from '@src/core/types/index.js';
+import { mergeGlobalAndServerConfig, mergeGlobalWithServers } from '@src/config/mcpConfigMerge.js';
+import { GlobalTransportConfig, MCPServerParams } from '@src/core/types/index.js';
 import logger from '@src/logger/logger.js';
 
 /**
@@ -64,65 +61,57 @@ export interface ServerConfig {
   mcpServers: Record<string, MCPServerParams>;
 }
 
+function createCommandConfigLoader(configPath: string): ConfigLoader {
+  return new ConfigLoader(configPath, { ensureConfigExists: false });
+}
+
+function loadSharedConfigState(configPath?: string): {
+  config: ServerConfig & Record<string, unknown>;
+  effectiveServers: Record<string, MCPServerParams>;
+} {
+  const configContext = ConfigContext.getInstance();
+  const filePath = configPath || configContext.getResolvedConfigPath();
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Configuration file not found: ${filePath}`);
+  }
+
+  try {
+    const loader = createCommandConfigLoader(filePath);
+    const loadedConfig = loader.loadParsedConfig({ substituteEnv: false, includeAppConfig: false });
+    const config = {
+      ...loadedConfig.processedConfig,
+      serverDefaults: loadedConfig.globalConfig,
+      mcpServers: loadedConfig.rawServers,
+    } as ServerConfig & Record<string, unknown>;
+
+    if (loadedConfig.schemaInjected) {
+      delete config.$schema;
+    }
+
+    return {
+      config,
+      effectiveServers: mergeGlobalWithServers(loadedConfig.globalConfig, loadedConfig.rawServers),
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.cause instanceof SyntaxError ||
+        error.message.includes('Unexpected token') ||
+        error.message.includes('JSON'))
+    ) {
+      throw new Error(`Invalid JSON in configuration file: ${filePath}`);
+    }
+    throw error;
+  }
+}
+
 /**
  * Load the MCP configuration from a file
  * Uses ConfigContext to resolve the appropriate config file path
  */
 export function loadConfig(configPath?: string): ServerConfig {
-  const configContext = ConfigContext.getInstance();
-  const filePath = configPath || configContext.getResolvedConfigPath();
-
-  try {
-    if (!fs.existsSync(filePath)) {
-      throw new Error(`Configuration file not found: ${filePath}`);
-    }
-
-    const configData = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
-
-    // Type guard to ensure configData has proper structure
-    if (!configData || typeof configData !== 'object') {
-      throw new Error(`Invalid configuration format: ${filePath}`);
-    }
-
-    const configObj = configData as Record<string, unknown>;
-
-    if (configObj.serverDefaults !== undefined) {
-      const unknownGlobalKeys = getUnknownGlobalConfigKeys(configObj.serverDefaults);
-      if (unknownGlobalKeys.length > 0) {
-        logger.warn(`Unknown properties in global MCP configuration were ignored: ${unknownGlobalKeys.join(', ')}`);
-      }
-      configObj.serverDefaults = globalTransportConfigSchema.parse(configObj.serverDefaults);
-    }
-
-    // Ensure mcpServers exists and is properly typed
-    if (!configObj.mcpServers || typeof configObj.mcpServers !== 'object') {
-      configObj.mcpServers = {} as Record<string, MCPServerParams>;
-    }
-
-    // Validate that mcpServers is properly structured
-    if (typeof configObj.mcpServers === 'object' && configObj.mcpServers !== null) {
-      // Ensure mcpServers is a Record<string, MCPServerParams>
-      const mcpServers = configObj.mcpServers as Record<string, unknown>;
-      const validatedMcpServers: Record<string, MCPServerParams> = {};
-
-      for (const [key, value] of Object.entries(mcpServers)) {
-        if (value && typeof value === 'object') {
-          // Basic validation - ensure it has at least a type property
-          const serverConfig = value as MCPServerParams;
-          validatedMcpServers[key] = serverConfig;
-        }
-      }
-
-      configObj.mcpServers = validatedMcpServers;
-    }
-
-    return configObj as unknown as ServerConfig;
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      throw new Error(`Invalid JSON in configuration file: ${filePath}`);
-    }
-    throw error;
-  }
+  return loadSharedConfigState(configPath).config;
 }
 
 function isMissingConfigError(error: unknown): boolean {
@@ -206,12 +195,13 @@ export function getGlobalConfig(): GlobalTransportConfig {
  */
 export function getEffectiveServerConfig(serverName: string): MCPServerParams | null {
   try {
-    const config = loadConfig();
-    const server = config.mcpServers[serverName];
-    if (!server) {
+    const { config, effectiveServers } = loadSharedConfigState();
+    if (!config.mcpServers[serverName]) {
       return null;
     }
-    return mergeGlobalAndServerConfig(config.serverDefaults, server);
+    return (
+      effectiveServers[serverName] || mergeGlobalAndServerConfig(config.serverDefaults, config.mcpServers[serverName])
+    );
   } catch (error) {
     logger.warn(
       `Failed to get effective server config for '${serverName}': ${error instanceof Error ? error.message : String(error)}`,
@@ -286,8 +276,7 @@ export function getAllServers(): Record<string, MCPServerParams> {
  */
 export function getAllEffectiveServers(): Record<string, MCPServerParams> {
   try {
-    const config = loadConfig();
-    return mergeGlobalWithServers(config.serverDefaults, config.mcpServers);
+    return loadSharedConfigState().effectiveServers;
   } catch (error) {
     logger.warn(`Failed to get all effective servers: ${error instanceof Error ? error.message : String(error)}`);
     if (isMissingConfigError(error)) {

--- a/src/commands/shared/baseConfigUtils.ts
+++ b/src/commands/shared/baseConfigUtils.ts
@@ -125,6 +125,13 @@ export function loadConfig(configPath?: string): ServerConfig {
   }
 }
 
+function isMissingConfigError(error: unknown): boolean {
+  return (
+    (error instanceof Error && error.message.includes('Configuration file not found')) ||
+    (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'ENOENT')
+  );
+}
+
 /**
  * Save the MCP configuration to a file
  * Uses ConfigContext to resolve the appropriate config file path
@@ -171,7 +178,10 @@ export function getServer(serverName: string): MCPServerParams | null {
     return config.mcpServers[serverName] || null;
   } catch (error) {
     logger.warn(`Failed to get server '${serverName}': ${error instanceof Error ? error.message : String(error)}`);
-    return null;
+    if (isMissingConfigError(error)) {
+      return null;
+    }
+    throw error;
   }
 }
 
@@ -183,8 +193,11 @@ export function getGlobalConfig(): GlobalTransportConfig {
     const config = loadConfig();
     return config.serverDefaults || {};
   } catch (error) {
-    logger.error(`Failed to get global config: ${error instanceof Error ? error.message : String(error)}`);
-    return {};
+    logger.warn(`Failed to get global config: ${error instanceof Error ? error.message : String(error)}`);
+    if (isMissingConfigError(error)) {
+      return {};
+    }
+    throw error;
   }
 }
 
@@ -200,10 +213,13 @@ export function getEffectiveServerConfig(serverName: string): MCPServerParams | 
     }
     return mergeGlobalAndServerConfig(config.serverDefaults, server);
   } catch (error) {
-    logger.error(
+    logger.warn(
       `Failed to get effective server config for '${serverName}': ${error instanceof Error ? error.message : String(error)}`,
     );
-    return null;
+    if (isMissingConfigError(error)) {
+      return null;
+    }
+    throw error;
   }
 }
 
@@ -257,8 +273,11 @@ export function getAllServers(): Record<string, MCPServerParams> {
     const config = loadConfig();
     return config.mcpServers;
   } catch (error) {
-    logger.error(`Failed to get all servers: ${error instanceof Error ? error.message : String(error)}`);
-    return {};
+    logger.warn(`Failed to get all servers: ${error instanceof Error ? error.message : String(error)}`);
+    if (isMissingConfigError(error)) {
+      return {};
+    }
+    throw error;
   }
 }
 
@@ -270,8 +289,11 @@ export function getAllEffectiveServers(): Record<string, MCPServerParams> {
     const config = loadConfig();
     return mergeGlobalWithServers(config.serverDefaults, config.mcpServers);
   } catch (error) {
-    logger.error(`Failed to get all effective servers: ${error instanceof Error ? error.message : String(error)}`);
-    return {};
+    logger.warn(`Failed to get all effective servers: ${error instanceof Error ? error.message : String(error)}`);
+    if (isMissingConfigError(error)) {
+      return {};
+    }
+    throw error;
   }
 }
 

--- a/src/commands/shared/baseConfigUtils.ts
+++ b/src/commands/shared/baseConfigUtils.ts
@@ -169,7 +169,8 @@ export function getServer(serverName: string): MCPServerParams | null {
   try {
     const config = loadConfig();
     return config.mcpServers[serverName] || null;
-  } catch (_error) {
+  } catch (error) {
+    logger.warn(`Failed to get server '${serverName}': ${error instanceof Error ? error.message : String(error)}`);
     return null;
   }
 }
@@ -181,7 +182,8 @@ export function getGlobalConfig(): GlobalTransportConfig {
   try {
     const config = loadConfig();
     return config.serverDefaults || {};
-  } catch (_error) {
+  } catch (error) {
+    logger.error(`Failed to get global config: ${error instanceof Error ? error.message : String(error)}`);
     return {};
   }
 }
@@ -197,7 +199,10 @@ export function getEffectiveServerConfig(serverName: string): MCPServerParams | 
       return null;
     }
     return mergeGlobalAndServerConfig(config.serverDefaults, server);
-  } catch (_error) {
+  } catch (error) {
+    logger.error(
+      `Failed to get effective server config for '${serverName}': ${error instanceof Error ? error.message : String(error)}`,
+    );
     return null;
   }
 }
@@ -251,7 +256,8 @@ export function getAllServers(): Record<string, MCPServerParams> {
   try {
     const config = loadConfig();
     return config.mcpServers;
-  } catch (_error) {
+  } catch (error) {
+    logger.error(`Failed to get all servers: ${error instanceof Error ? error.message : String(error)}`);
     return {};
   }
 }
@@ -263,7 +269,8 @@ export function getAllEffectiveServers(): Record<string, MCPServerParams> {
   try {
     const config = loadConfig();
     return mergeGlobalWithServers(config.serverDefaults, config.mcpServers);
-  } catch (_error) {
+  } catch (error) {
+    logger.error(`Failed to get all effective servers: ${error instanceof Error ? error.message : String(error)}`);
     return {};
   }
 }
@@ -406,6 +413,7 @@ export function validateServerConfig(serverConfig: MCPServerParams): void {
 
     case 'http':
     case 'sse':
+    case 'streamableHttp':
       if (!serverConfig.url) {
         throw new Error(`URL is required for ${serverConfig.type} servers`);
       }
@@ -455,6 +463,56 @@ export function reloadMcpConfig(): void {
     configManager.reloadConfig();
     logger.info('MCP configuration reloaded');
   } catch (error) {
-    logger.warn(`Failed to reload MCP configuration: ${error}`);
+    logger.warn(`Failed to reload MCP configuration: ${error instanceof Error ? error.message : String(error)}`);
   }
+}
+
+export function getInheritedKeys(
+  rawConfig: MCPServerParams,
+  effectiveConfig: MCPServerParams,
+  globalConfig: GlobalTransportConfig,
+): string[] {
+  const inherited: string[] = [];
+  const fallbackKeys: Array<keyof MCPServerParams> = [
+    'timeout',
+    'connectionTimeout',
+    'requestTimeout',
+    'oauth',
+    'headers',
+    'inheritParentEnv',
+  ];
+
+  for (const key of fallbackKeys) {
+    if (
+      rawConfig[key] === undefined &&
+      effectiveConfig[key] !== undefined &&
+      globalConfig[key as keyof GlobalTransportConfig] !== undefined
+    ) {
+      inherited.push(String(key));
+    }
+  }
+
+  if (rawConfig.env === undefined && effectiveConfig.env !== undefined && globalConfig.env !== undefined) {
+    inherited.push('env');
+  }
+
+  if (
+    rawConfig.env &&
+    effectiveConfig.env &&
+    typeof rawConfig.env === 'object' &&
+    typeof effectiveConfig.env === 'object' &&
+    !Array.isArray(rawConfig.env) &&
+    !Array.isArray(effectiveConfig.env) &&
+    typeof globalConfig.env === 'object' &&
+    globalConfig.env !== null &&
+    !Array.isArray(globalConfig.env)
+  ) {
+    const rawEnv = rawConfig.env as Record<string, string>;
+    const effectiveEnv = effectiveConfig.env as Record<string, string>;
+    if (Object.keys(effectiveEnv).some((key) => !(key in rawEnv))) {
+      inherited.push('env(merged)');
+    }
+  }
+
+  return inherited;
 }

--- a/src/config/configLoader.test.ts
+++ b/src/config/configLoader.test.ts
@@ -226,6 +226,7 @@ describe('ConfigLoader', () => {
             KEEP: 'global-only',
           },
           inheritParentEnv: true,
+          envFilter: ['PATH', 'NODE_*'],
         },
         mcpServers: {
           'test-server': {
@@ -244,10 +245,29 @@ describe('ConfigLoader', () => {
       expect(config['test-server'].connectionTimeout).toBe(5000);
       expect(config['test-server'].requestTimeout).toBe(10000);
       expect(config['test-server'].inheritParentEnv).toBe(true);
+      expect(config['test-server'].envFilter).toEqual(['PATH', 'NODE_*']);
       expect(config['test-server'].env).toEqual({
         SHARED: 'server',
         KEEP: 'global-only',
       });
+    });
+
+    it('should allow envFilter in serverDefaults but ignore it for http servers', async () => {
+      const configWithGlobal = {
+        serverDefaults: {
+          envFilter: ['PATH'],
+        },
+        mcpServers: {
+          'test-server': {
+            type: 'http',
+            url: 'https://example.com/mcp',
+          },
+        },
+      };
+      await fsPromises.writeFile(configFilePath, JSON.stringify(configWithGlobal, null, 2));
+
+      const config = loader.loadConfigWithEnvSubstitution();
+      expect(config['test-server'].envFilter).toBeUndefined();
     });
 
     it('should reject invalid serverDefaults configuration', async () => {

--- a/src/config/configLoader.test.ts
+++ b/src/config/configLoader.test.ts
@@ -198,6 +198,74 @@ describe('ConfigLoader', () => {
 
       expect(() => loader.loadConfigWithEnvSubstitution()).toThrow();
     });
+
+    it('maintains backward compatibility when global section is absent', async () => {
+      const legacyConfig = {
+        mcpServers: {
+          'legacy-server': {
+            type: 'stdio',
+            command: 'node',
+            timeout: 1234,
+          },
+        },
+      };
+      await fsPromises.writeFile(configFilePath, JSON.stringify(legacyConfig, null, 2));
+
+      const config = loader.loadConfigWithEnvSubstitution();
+      expect(config['legacy-server']).toEqual(legacyConfig.mcpServers['legacy-server']);
+    });
+
+    it('should apply serverDefaults and merge env for servers', async () => {
+      const configWithGlobal = {
+        serverDefaults: {
+          timeout: 3000,
+          connectionTimeout: 5000,
+          requestTimeout: 10000,
+          env: {
+            SHARED: 'global',
+            KEEP: 'global-only',
+          },
+          inheritParentEnv: true,
+        },
+        mcpServers: {
+          'test-server': {
+            type: 'stdio',
+            command: 'node',
+            env: {
+              SHARED: 'server',
+            },
+          },
+        },
+      };
+      await fsPromises.writeFile(configFilePath, JSON.stringify(configWithGlobal, null, 2));
+
+      const config = loader.loadConfigWithEnvSubstitution();
+      expect(config['test-server'].timeout).toBe(3000);
+      expect(config['test-server'].connectionTimeout).toBe(5000);
+      expect(config['test-server'].requestTimeout).toBe(10000);
+      expect(config['test-server'].inheritParentEnv).toBe(true);
+      expect(config['test-server'].env).toEqual({
+        SHARED: 'server',
+        KEEP: 'global-only',
+      });
+    });
+
+    it('should reject invalid serverDefaults configuration', async () => {
+      const invalidGlobalConfig = {
+        serverDefaults: {
+          timeout: 'invalid-timeout',
+        },
+        mcpServers: {
+          'test-server': {
+            type: 'stdio',
+            command: 'node',
+          },
+        },
+      };
+      await fsPromises.writeFile(configFilePath, JSON.stringify(invalidGlobalConfig, null, 2));
+
+      expect(() => loader.loadConfigWithEnvSubstitution()).toThrow(/Invalid global configuration/);
+    });
   });
 
   describe('validateServerConfig', () => {
@@ -464,6 +532,86 @@ describe('ConfigLoader', () => {
   describe('getConfigFilePath', () => {
     it('should return the config file path', () => {
       expect(loader.getConfigFilePath()).toBe(configFilePath);
+    });
+  });
+
+  describe('loadAppConfigFromToml', () => {
+    it('should return empty object when config.toml does not exist', () => {
+      const result = loader.loadAppConfigFromToml();
+      expect(result).toEqual({});
+    });
+
+    it('should load valid app config from config.toml', async () => {
+      const tomlContent = `
+transport = "http"
+port = 3051
+host = "0.0.0.0"
+logLevel = "debug"
+`;
+      await fsPromises.writeFile(join(tempConfigDir, 'config.toml'), tomlContent);
+
+      const result = loader.loadAppConfigFromToml();
+      expect(result.transport).toBe('http');
+      expect(result.port).toBe(3051);
+      expect(result.host).toBe('0.0.0.0');
+      expect(result.logLevel).toBe('debug');
+    });
+
+    it('should load nested app config sections from config.toml', async () => {
+      const tomlContent = `
+[auth]
+enabled = true
+sessionTtl = 720
+
+[asyncLoading]
+enabled = true
+minServers = 2
+`;
+      await fsPromises.writeFile(join(tempConfigDir, 'config.toml'), tomlContent);
+
+      const result = loader.loadAppConfigFromToml();
+      expect(result.auth?.enabled).toBe(true);
+      expect(result.auth?.sessionTtl).toBe(720);
+      expect(result.asyncLoading?.enabled).toBe(true);
+      expect(result.asyncLoading?.minServers).toBe(2);
+    });
+
+    it('should return empty object and warn on invalid TOML', async () => {
+      await fsPromises.writeFile(join(tempConfigDir, 'config.toml'), 'invalid = [toml');
+
+      const result = loader.loadAppConfigFromToml();
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object and warn on schema validation failure', async () => {
+      const tomlContent = `port = "not-a-number"`;
+      await fsPromises.writeFile(join(tempConfigDir, 'config.toml'), tomlContent);
+
+      const result = loader.loadAppConfigFromToml();
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('loadAppConfig', () => {
+    it('should warn when app key is present in mcp.json', async () => {
+      const config = {
+        app: { port: 3050 },
+        mcpServers: {},
+      };
+      await fsPromises.writeFile(configFilePath, JSON.stringify(config, null, 2));
+
+      // Should not throw, just warn
+      const result = loader.loadAppConfig();
+      expect(result).toEqual({});
+    });
+
+    it('should load from config.toml when present', async () => {
+      const tomlContent = `port = 9999\ntransport = "stdio"\n`;
+      await fsPromises.writeFile(join(tempConfigDir, 'config.toml'), tomlContent);
+
+      const result = loader.loadAppConfig();
+      expect(result.port).toBe(9999);
+      expect(result.transport).toBe('stdio');
     });
   });
 });

--- a/src/config/configLoader.test.ts
+++ b/src/config/configLoader.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 
 import { ConfigLoader } from '@src/config/configLoader.js';
 import { MCP_CONFIG_SCHEMA_URL } from '@src/constants/schema.js';
+import logger from '@src/logger/logger.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -270,7 +271,7 @@ describe('ConfigLoader', () => {
       expect(config['test-server'].envFilter).toBeUndefined();
     });
 
-    it('should reject invalid serverDefaults configuration', async () => {
+    it('should ignore invalid serverDefaults configuration and keep valid servers', async () => {
       const invalidGlobalConfig = {
         serverDefaults: {
           timeout: 'invalid-timeout',
@@ -284,7 +285,19 @@ describe('ConfigLoader', () => {
       };
       await fsPromises.writeFile(configFilePath, JSON.stringify(invalidGlobalConfig, null, 2));
 
-      expect(() => loader.loadConfigWithEnvSubstitution()).toThrow(/Invalid global configuration/);
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+      const config = loader.loadConfigWithEnvSubstitution();
+
+      expect(config['test-server']).toEqual({
+        type: 'stdio',
+        command: 'node',
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Ignoring invalid serverDefaults configuration: Invalid global configuration: timeout: Invalid input: expected number, received string',
+        ),
+      );
     });
   });
 

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -282,7 +282,16 @@ export class ConfigLoader {
     const configObj = processedConfig as Record<string, unknown>;
     const rawGlobal = configObj.serverDefaults;
     warnForUnknownGlobalConfigKeys(rawGlobal);
-    const globalConfig = rawGlobal !== undefined ? this.validateGlobalConfig(rawGlobal) : {};
+    let globalConfig: GlobalTransportConfig = {};
+    if (rawGlobal !== undefined) {
+      try {
+        globalConfig = this.validateGlobalConfig(rawGlobal);
+      } catch (error) {
+        logger.warn(
+          `Ignoring invalid serverDefaults configuration: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
 
     warnIfLegacyAppConfig(configObj, this.configFilePath);
     const appConfig = options?.includeAppConfig === false ? {} : this.loadAppConfigFromToml();

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -1,12 +1,22 @@
 import fs from 'fs';
+import path from 'path';
 
 import { substituteEnvVarsInConfig } from '@src/config/envProcessor.js';
+import { getUnknownGlobalConfigKeys, mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
 import { DEFAULT_CONFIG, getGlobalConfigDir, getGlobalConfigPath } from '@src/constants.js';
 import { MCP_CONFIG_SCHEMA_URL } from '@src/constants/schema.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
-import { MCPServerParams, transportConfigSchema } from '@src/core/types/transport.js';
+import {
+  ApplicationConfig,
+  applicationConfigSchema,
+  GlobalTransportConfig,
+  globalTransportConfigSchema,
+  MCPServerParams,
+  transportConfigSchema,
+} from '@src/core/types/transport.js';
 import logger, { debugIf } from '@src/logger/logger.js';
 
+import { parse as parseToml } from 'smol-toml';
 import { ZodError } from 'zod';
 
 interface ErrnoException extends Error {
@@ -113,6 +123,68 @@ export class ConfigLoader {
     }
   }
 
+  public validateGlobalConfig(config: unknown): GlobalTransportConfig {
+    try {
+      return globalTransportConfigSchema.parse(config);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const fieldErrors = error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');
+        throw new Error(`Invalid global configuration: ${fieldErrors}`);
+      }
+      throw new Error(`Invalid global configuration: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  public validateAppConfig(config: unknown): ApplicationConfig {
+    try {
+      return applicationConfigSchema.parse(config);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const fieldErrors = error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');
+        throw new Error(`Invalid app configuration: ${fieldErrors}`);
+      }
+      throw new Error(`Invalid app configuration: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  public loadAppConfig(): ApplicationConfig {
+    // Check for legacy app key in mcp.json and warn
+    try {
+      const rawConfig = this.loadRawConfig();
+      if (rawConfig && typeof rawConfig === 'object') {
+        const configObj = rawConfig as Record<string, unknown>;
+        if (configObj.app !== undefined) {
+          const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
+          logger.warn(
+            `The "app" key in mcp.json is deprecated. Please move your app settings to ${tomlPath}. ` +
+              `The "app" key in mcp.json will be ignored.`,
+          );
+        }
+      }
+    } catch {
+      // Ignore errors from legacy check
+    }
+
+    return this.loadAppConfigFromToml();
+  }
+
+  public loadAppConfigFromToml(): ApplicationConfig {
+    const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
+    try {
+      if (!fs.existsSync(tomlPath)) {
+        return {};
+      }
+      const raw = fs.readFileSync(tomlPath, 'utf8');
+      const parsed = parseToml(raw);
+      return this.validateAppConfig(parsed);
+    } catch (error) {
+      logger.warn(
+        `Failed to load app configuration from ${tomlPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {};
+    }
+  }
+
   public loadConfigWithEnvSubstitution(): Record<string, MCPServerParams> {
     let rawConfig: unknown;
     try {
@@ -135,6 +207,18 @@ export class ConfigLoader {
     }
 
     const configObj = processedConfig as Record<string, unknown>;
+    let globalConfig: GlobalTransportConfig | undefined;
+    const rawGlobal = configObj.serverDefaults;
+    const unknownGlobalKeys = getUnknownGlobalConfigKeys(rawGlobal);
+    if (unknownGlobalKeys.length > 0) {
+      logger.warn(
+        `Unknown properties in global MCP configuration were ignored: ${unknownGlobalKeys.sort().join(', ')}`,
+      );
+    }
+    if (rawGlobal !== undefined) {
+      globalConfig = this.validateGlobalConfig(rawGlobal);
+    }
+
     const mcpServersConfig = (configObj.mcpServers as Record<string, unknown>) || {};
     const mcpTemplatesConfig = (configObj.mcpTemplates as Record<string, unknown>) || {};
     const templateServerNames = new Set(Object.keys(mcpTemplatesConfig));
@@ -142,7 +226,9 @@ export class ConfigLoader {
     const validatedConfig: Record<string, MCPServerParams> = {};
     for (const [serverName, serverConfig] of Object.entries(mcpServersConfig)) {
       try {
-        validatedConfig[serverName] = this.validateServerConfig(serverName, serverConfig);
+        const validatedServerConfig = this.validateServerConfig(serverName, serverConfig);
+        const mergedConfig = mergeGlobalAndServerConfig(globalConfig, validatedServerConfig);
+        validatedConfig[serverName] = this.validateServerConfig(serverName, mergedConfig);
         debugIf(() => ({
           message: `Validated configuration for server: ${serverName}`,
           meta: { serverName },

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -161,8 +161,8 @@ export class ConfigLoader {
           );
         }
       }
-    } catch {
-      // Ignore errors from legacy check
+    } catch (error) {
+      logger.debug(`Could not check for legacy "app" key: ${error instanceof Error ? error.message : String(error)}`);
     }
 
     return this.loadAppConfigFromToml();
@@ -178,7 +178,7 @@ export class ConfigLoader {
       const parsed = parseToml(raw);
       return this.validateAppConfig(parsed);
     } catch (error) {
-      logger.warn(
+      logger.error(
         `Failed to load app configuration from ${tomlPath}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {};

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { substituteEnvVarsInConfig } from '@src/config/envProcessor.js';
 import { getUnknownGlobalConfigKeys, mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
-import { DEFAULT_CONFIG, getGlobalConfigDir, getGlobalConfigPath } from '@src/constants.js';
+import { DEFAULT_CONFIG, getGlobalConfigPath } from '@src/constants.js';
 import { MCP_CONFIG_SCHEMA_URL } from '@src/constants/schema.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
 import {
@@ -23,6 +23,86 @@ interface ErrnoException extends Error {
   code?: string;
 }
 
+interface RawConfigLoadResult {
+  config: unknown;
+  lastModified: number;
+  schemaInjected: boolean;
+}
+
+export interface LoadedMcpConfig {
+  rawConfig: Record<string, unknown>;
+  processedConfig: Record<string, unknown>;
+  globalConfig: GlobalTransportConfig;
+  appConfig: ApplicationConfig;
+  rawServers: Record<string, MCPServerParams>;
+  validatedServers: Record<string, MCPServerParams>;
+  lastModified: number;
+  schemaInjected: boolean;
+}
+
+interface ConfigLoaderOptions {
+  ensureConfigExists?: boolean;
+}
+
+interface LoadParsedConfigOptions {
+  substituteEnv?: boolean;
+  includeAppConfig?: boolean;
+}
+
+function formatZodIssues(error: ZodError): string {
+  return error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
+}
+
+function getValidationErrorMessage(context: string, error: unknown): string {
+  if (error instanceof ZodError) {
+    return `${context}: ${formatZodIssues(error)}`;
+  }
+
+  return `${context}: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+function warnIfLegacyAppConfig(rawConfig: unknown, configFilePath: string): void {
+  if (!rawConfig || typeof rawConfig !== 'object') {
+    return;
+  }
+
+  const configObj = rawConfig as Record<string, unknown>;
+  if (configObj.app === undefined) {
+    return;
+  }
+
+  const tomlPath = path.join(path.dirname(configFilePath), 'config.toml');
+  logger.warn(
+    `The "app" key in mcp.json is deprecated. Please move your app settings to ${tomlPath}. ` +
+      `The "app" key in mcp.json will be ignored.`,
+  );
+}
+
+function warnForUnknownGlobalConfigKeys(rawGlobal: unknown): void {
+  const unknownGlobalKeys = getUnknownGlobalConfigKeys(rawGlobal);
+  if (unknownGlobalKeys.length === 0) {
+    return;
+  }
+
+  logger.warn(`Unknown properties in global MCP configuration were ignored: ${unknownGlobalKeys.join(', ')}`);
+}
+
+function normalizeRawServerConfigs(rawServers: unknown): Record<string, MCPServerParams> {
+  if (!rawServers || typeof rawServers !== 'object') {
+    return {};
+  }
+
+  const normalizedServers: Record<string, MCPServerParams> = {};
+
+  for (const [serverName, serverConfig] of Object.entries(rawServers)) {
+    if (serverConfig && typeof serverConfig === 'object') {
+      normalizedServers[serverName] = serverConfig as MCPServerParams;
+    }
+  }
+
+  return normalizedServers;
+}
+
 export function loadAppConfigFromTomlPath(tomlPath: string): ApplicationConfig {
   try {
     if (!fs.existsSync(tomlPath)) {
@@ -33,8 +113,7 @@ export function loadAppConfigFromTomlPath(tomlPath: string): ApplicationConfig {
     return applicationConfigSchema.parse(parsed);
   } catch (error) {
     if (error instanceof ZodError) {
-      const fieldErrors = error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');
-      logger.error(`Invalid app configuration in config.toml (ignored): ${fieldErrors}`);
+      logger.error(`Invalid app configuration in config.toml (ignored): ${formatZodIssues(error)}`);
     } else {
       logger.error(
         `Failed to load app configuration from ${tomlPath}: ${error instanceof Error ? error.message : String(error)}`,
@@ -48,14 +127,16 @@ export class ConfigLoader {
   private configFilePath: string;
   private lastModified = 0;
 
-  constructor(configFilePath?: string) {
+  constructor(configFilePath?: string, options?: ConfigLoaderOptions) {
     this.configFilePath = configFilePath || getGlobalConfigPath();
-    this.ensureConfigExists();
+    if (options?.ensureConfigExists !== false) {
+      this.ensureConfigExists();
+    }
   }
 
   private ensureConfigExists(): void {
     try {
-      const configDir = getGlobalConfigDir();
+      const configDir = path.dirname(this.configFilePath);
       if (!fs.existsSync(configDir)) {
         fs.mkdirSync(configDir, { recursive: true });
         logger.info(`Created config directory: ${configDir}`);
@@ -98,16 +179,19 @@ export class ConfigLoader {
     }
   }
 
-  public loadRawConfig(): unknown {
+  private loadRawConfigResult(): RawConfigLoadResult {
     try {
       const stats = fs.statSync(this.configFilePath);
-      this.lastModified = stats.mtime.getTime();
+      const lastModified = stats.mtime.getTime();
+      this.lastModified = lastModified;
       const rawConfigData = fs.readFileSync(this.configFilePath, 'utf8');
       const config = JSON.parse(rawConfigData) as Record<string, unknown>;
+      let schemaInjected = false;
 
       // Ensure $schema field is present for IDE autocompletion
       if (config && typeof config === 'object' && !('$schema' in config)) {
         config.$schema = MCP_CONFIG_SCHEMA_URL;
+        schemaInjected = true;
 
         // Log the enhancement for debugging and transparency
         debugIf(() => ({
@@ -119,7 +203,7 @@ export class ConfigLoader {
         }));
       }
 
-      return config;
+      return { config, lastModified, schemaInjected };
     } catch (error) {
       const message = `Failed to load configuration from '${this.configFilePath}': ${error instanceof Error ? error.message : String(error)}`;
       logger.error(message, {
@@ -130,17 +214,15 @@ export class ConfigLoader {
     }
   }
 
+  public loadRawConfig(): unknown {
+    return this.loadRawConfigResult().config;
+  }
+
   public validateServerConfig(serverName: string, config: unknown): MCPServerParams {
     try {
       return transportConfigSchema.parse(config);
     } catch (error) {
-      if (error instanceof ZodError) {
-        const fieldErrors = error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');
-        throw new Error(`Invalid configuration for server '${serverName}': ${fieldErrors}`);
-      }
-      throw new Error(
-        `Invalid configuration for server '${serverName}': ${error instanceof Error ? error.message : String(error)}`,
-      );
+      throw new Error(getValidationErrorMessage(`Invalid configuration for server '${serverName}'`, error));
     }
   }
 
@@ -148,11 +230,7 @@ export class ConfigLoader {
     try {
       return globalTransportConfigSchema.parse(config);
     } catch (error) {
-      if (error instanceof ZodError) {
-        const fieldErrors = error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');
-        throw new Error(`Invalid global configuration: ${fieldErrors}`);
-      }
-      throw new Error(`Invalid global configuration: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(getValidationErrorMessage('Invalid global configuration', error));
     }
   }
 
@@ -160,28 +238,14 @@ export class ConfigLoader {
     try {
       return applicationConfigSchema.parse(config);
     } catch (error) {
-      if (error instanceof ZodError) {
-        const fieldErrors = error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');
-        throw new Error(`Invalid app configuration: ${fieldErrors}`);
-      }
-      throw new Error(`Invalid app configuration: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(getValidationErrorMessage('Invalid app configuration', error));
     }
   }
 
   public loadAppConfig(): ApplicationConfig {
     // Check for legacy app key in mcp.json and warn
     try {
-      const rawConfig = this.loadRawConfig();
-      if (rawConfig && typeof rawConfig === 'object') {
-        const configObj = rawConfig as Record<string, unknown>;
-        if (configObj.app !== undefined) {
-          const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
-          logger.warn(
-            `The "app" key in mcp.json is deprecated. Please move your app settings to ${tomlPath}. ` +
-              `The "app" key in mcp.json will be ignored.`,
-          );
-        }
-      }
+      warnIfLegacyAppConfig(this.loadRawConfig(), this.configFilePath);
     } catch (error) {
       logger.debug(`Could not check for legacy "app" key: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -194,20 +258,20 @@ export class ConfigLoader {
     return loadAppConfigFromTomlPath(tomlPath);
   }
 
-  public loadConfigWithEnvSubstitution(): Record<string, MCPServerParams> {
-    let rawConfig: unknown;
+  public loadParsedConfig(options?: LoadParsedConfigOptions): LoadedMcpConfig {
+    let rawResult: RawConfigLoadResult;
     try {
-      rawConfig = this.loadRawConfig();
+      rawResult = this.loadRawConfigResult();
     } catch (error) {
       const errorMsg = `Failed to load raw configuration: ${error instanceof Error ? error.message : String(error)}`;
       logger.error(errorMsg);
-      throw new Error(errorMsg);
+      throw new Error(errorMsg, { cause: error });
     }
 
     const agentConfig = AgentConfigManager.getInstance();
     const features = agentConfig.get('features');
-
-    const processedConfig = features.envSubstitution ? substituteEnvVarsInConfig(rawConfig) : rawConfig;
+    const substituteEnv = options?.substituteEnv ?? features.envSubstitution;
+    const processedConfig = substituteEnv ? substituteEnvVarsInConfig(rawResult.config) : rawResult.config;
 
     if (!processedConfig || typeof processedConfig !== 'object') {
       const errorMsg = 'Invalid configuration format';
@@ -216,45 +280,38 @@ export class ConfigLoader {
     }
 
     const configObj = processedConfig as Record<string, unknown>;
-    let globalConfig: GlobalTransportConfig | undefined;
     const rawGlobal = configObj.serverDefaults;
-    const unknownGlobalKeys = getUnknownGlobalConfigKeys(rawGlobal);
-    if (unknownGlobalKeys.length > 0) {
-      logger.warn(
-        `Unknown properties in global MCP configuration were ignored: ${unknownGlobalKeys.sort().join(', ')}`,
-      );
-    }
-    if (rawGlobal !== undefined) {
-      globalConfig = this.validateGlobalConfig(rawGlobal);
-    }
+    warnForUnknownGlobalConfigKeys(rawGlobal);
+    const globalConfig = rawGlobal !== undefined ? this.validateGlobalConfig(rawGlobal) : {};
 
-    const mcpServersConfig = (configObj.mcpServers as Record<string, unknown>) || {};
-    const mcpTemplatesConfig = (configObj.mcpTemplates as Record<string, unknown>) || {};
-    const templateServerNames = new Set(Object.keys(mcpTemplatesConfig));
+    warnIfLegacyAppConfig(configObj, this.configFilePath);
+    const appConfig = options?.includeAppConfig === false ? {} : this.loadAppConfigFromToml();
 
-    const validatedConfig: Record<string, MCPServerParams> = {};
-    for (const [serverName, serverConfig] of Object.entries(mcpServersConfig)) {
+    const rawServers = normalizeRawServerConfigs(configObj.mcpServers);
+    const templateServerNames = new Set(Object.keys(normalizeRawServerConfigs(configObj.mcpTemplates)));
+    const validatedServers: Record<string, MCPServerParams> = {};
+
+    for (const [serverName, serverConfig] of Object.entries(rawServers)) {
       try {
         // Validate the raw server first, then re-validate after applying serverDefaults
         // so merged config errors are surfaced instead of silently accepted.
         const validatedServerConfig = this.validateServerConfig(serverName, serverConfig);
         const mergedConfig = mergeGlobalAndServerConfig(globalConfig, validatedServerConfig);
-        validatedConfig[serverName] = this.validateServerConfig(serverName, mergedConfig);
+        validatedServers[serverName] = this.validateServerConfig(serverName, mergedConfig);
         debugIf(() => ({
           message: `Validated configuration for server: ${serverName}`,
           meta: { serverName },
         }));
       } catch (error) {
         logger.error(`Configuration validation failed: ${error instanceof Error ? error.message : String(error)}`);
-        continue;
       }
     }
 
     const conflictingServers: string[] = [];
-    for (const serverName of Object.keys(validatedConfig)) {
+    for (const serverName of Object.keys(validatedServers)) {
       if (templateServerNames.has(serverName)) {
         conflictingServers.push(serverName);
-        delete validatedConfig[serverName];
+        delete validatedServers[serverName];
       }
     }
 
@@ -264,7 +321,24 @@ export class ConfigLoader {
       );
     }
 
-    return validatedConfig;
+    return {
+      rawConfig: rawResult.config as Record<string, unknown>,
+      processedConfig: configObj,
+      globalConfig,
+      appConfig,
+      rawServers,
+      validatedServers,
+      lastModified: rawResult.lastModified,
+      schemaInjected: rawResult.schemaInjected,
+    };
+  }
+
+  public loadParsedConfigWithEnvSubstitution(): LoadedMcpConfig {
+    return this.loadParsedConfig();
+  }
+
+  public loadConfigWithEnvSubstitution(): Record<string, MCPServerParams> {
+    return this.loadParsedConfigWithEnvSubstitution().validatedServers;
   }
 
   public getTransportConfig(transportConfig: Record<string, MCPServerParams>): Record<string, MCPServerParams> {

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -23,6 +23,27 @@ interface ErrnoException extends Error {
   code?: string;
 }
 
+export function loadAppConfigFromTomlPath(tomlPath: string): ApplicationConfig {
+  try {
+    if (!fs.existsSync(tomlPath)) {
+      return {};
+    }
+    const raw = fs.readFileSync(tomlPath, 'utf8');
+    const parsed = parseToml(raw);
+    return applicationConfigSchema.parse(parsed);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const fieldErrors = error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');
+      logger.error(`Invalid app configuration in config.toml (ignored): ${fieldErrors}`);
+    } else {
+      logger.error(
+        `Failed to load app configuration from ${tomlPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return {};
+  }
+}
+
 export class ConfigLoader {
   private configFilePath: string;
   private lastModified = 0;
@@ -170,19 +191,7 @@ export class ConfigLoader {
 
   public loadAppConfigFromToml(): ApplicationConfig {
     const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
-    try {
-      if (!fs.existsSync(tomlPath)) {
-        return {};
-      }
-      const raw = fs.readFileSync(tomlPath, 'utf8');
-      const parsed = parseToml(raw);
-      return this.validateAppConfig(parsed);
-    } catch (error) {
-      logger.error(
-        `Failed to load app configuration from ${tomlPath}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {};
-    }
+    return loadAppConfigFromTomlPath(tomlPath);
   }
 
   public loadConfigWithEnvSubstitution(): Record<string, MCPServerParams> {
@@ -226,6 +235,8 @@ export class ConfigLoader {
     const validatedConfig: Record<string, MCPServerParams> = {};
     for (const [serverName, serverConfig] of Object.entries(mcpServersConfig)) {
       try {
+        // Validate the raw server first, then re-validate after applying serverDefaults
+        // so merged config errors are surfaced instead of silently accepted.
         const validatedServerConfig = this.validateServerConfig(serverName, serverConfig);
         const mergedConfig = mergeGlobalAndServerConfig(globalConfig, validatedServerConfig);
         validatedConfig[serverName] = this.validateServerConfig(serverName, mergedConfig);

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 
+import { mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
 import {
   mcpServerConfigSchema,
@@ -123,11 +124,13 @@ export class ConfigManager extends EventEmitter {
       };
     }
 
-    // Process static servers (existing logic)
+    // Process static servers
     const staticServers: Record<string, MCPServerParams> = {};
+    const serverDefaults = config.serverDefaults;
     for (const [serverName, serverConfig] of Object.entries(config.mcpServers)) {
       try {
-        staticServers[serverName] = this.validateServerConfig(serverName, serverConfig);
+        const mergedConfig = mergeGlobalAndServerConfig(serverDefaults, serverConfig);
+        staticServers[serverName] = this.validateServerConfig(serverName, mergedConfig);
       } catch (error) {
         logger.error(
           `Static server validation failed for ${serverName}: ${error instanceof Error ? error.message : String(error)}`,
@@ -156,7 +159,13 @@ export class ConfigManager extends EventEmitter {
         } else {
           // Process templates with validation
           const result = await this.processTemplates(config.mcpTemplates, context, config.templateSettings);
-          templateServers = result.servers;
+          templateServers = {};
+          for (const [serverName, templateConfig] of Object.entries(result.servers)) {
+            templateServers[serverName] = this.validateServerConfig(
+              serverName,
+              mergeGlobalAndServerConfig(serverDefaults, templateConfig),
+            );
+          }
           errors = result.errors;
 
           // Cache results if caching is enabled
@@ -417,6 +426,10 @@ export class ConfigManager extends EventEmitter {
 
   public getAvailableTags(): string[] {
     return this.loader.getAvailableTags(this.transportConfig);
+  }
+
+  public getAppConfig() {
+    return this.loader.loadAppConfig();
   }
 }
 

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -160,13 +160,19 @@ export class ConfigManager extends EventEmitter {
           // Process templates with validation
           const result = await this.processTemplates(config.mcpTemplates, context, config.templateSettings);
           templateServers = {};
+          errors = [...result.errors];
           for (const [serverName, templateConfig] of Object.entries(result.servers)) {
-            templateServers[serverName] = this.validateServerConfig(
-              serverName,
-              mergeGlobalAndServerConfig(serverDefaults, templateConfig),
-            );
+            try {
+              templateServers[serverName] = this.validateServerConfig(
+                serverName,
+                mergeGlobalAndServerConfig(serverDefaults, templateConfig),
+              );
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              logger.error(`Template server validation failed for ${serverName}: ${message}`);
+              errors.push(`${serverName}: ${message}`);
+            }
           }
-          errors = result.errors;
 
           // Cache results if caching is enabled
           if (config.templateSettings?.cacheContext) {

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import { mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
 import {
+  ApplicationConfig,
   mcpServerConfigSchema,
   MCPServerConfiguration,
   MCPServerParams,
@@ -434,7 +435,7 @@ export class ConfigManager extends EventEmitter {
     return this.loader.getAvailableTags(this.transportConfig);
   }
 
-  public getAppConfig() {
+  public getAppConfig(): ApplicationConfig {
     return this.loader.loadAppConfig();
   }
 }

--- a/src/config/mcpConfigManager.test.ts
+++ b/src/config/mcpConfigManager.test.ts
@@ -175,7 +175,7 @@ describe('McpConfigManager', () => {
         JSON.stringify({
           serverDefaults: {
             timeout: 5000,
-            env: { SHARED: 'global' },
+            env: { SHARED: 'global', KEEP: 'global-only' },
           },
           mcpServers: {
             server1: {
@@ -190,15 +190,18 @@ describe('McpConfigManager', () => {
       const instance = McpConfigManager.getInstance(testConfigPath);
       expect(instance.getGlobalConfig()).toEqual({
         timeout: 5000,
-        env: { SHARED: 'global' },
+        env: { SHARED: 'global', KEEP: 'global-only' },
       });
 
-      expect(instance.getEffectiveServerConfig('server1')).toEqual({
+      const effective = instance.getEffectiveServerConfig('server1');
+      expect(effective).toEqual({
         type: 'stdio',
         command: 'node',
         timeout: 5000,
-        env: { SHARED: 'server' },
+        env: { SHARED: 'server', KEEP: 'global-only' },
       });
+      // Verify global-only key is present in effective config (merge, not override)
+      expect((effective?.env as Record<string, string>)?.KEEP).toBe('global-only');
     });
   });
 

--- a/src/config/mcpConfigManager.test.ts
+++ b/src/config/mcpConfigManager.test.ts
@@ -44,7 +44,7 @@ vi.mock('fs', async () => {
 // Mock constants
 vi.mock('@src/constants.js', () => ({
   __esModule: true,
-  DEFAULT_CONFIG: { global: {}, mcpServers: {} },
+  DEFAULT_CONFIG: { serverDefaults: {}, mcpServers: {} },
   HOST: '127.0.0.1',
   PORT: 3050,
   AUTH_CONFIG: {
@@ -268,23 +268,61 @@ describe('McpConfigManager', () => {
       );
     });
 
-    it('should keep invalid global config warning text unchanged', () => {
-      const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    it('should ignore invalid global config and keep loading valid servers', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
       (fs.readFileSync as unknown as MockInstance).mockReturnValueOnce(
         JSON.stringify({
           serverDefaults: { timeout: 'invalid-timeout' },
-          mcpServers: {},
+          mcpServers: {
+            server1: {
+              type: 'stdio',
+              command: 'node',
+            },
+          },
         }),
       );
 
       const instance = McpConfigManager.getInstance(testConfigPath);
 
       expect(instance.getGlobalConfig()).toEqual({});
-      expect(errorSpy).toHaveBeenCalledWith(
+      expect(instance.getTransportConfig()).toEqual({
+        server1: {
+          type: 'stdio',
+          command: 'node',
+        },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          'Failed to load configuration: Invalid global configuration: timeout: Invalid input: expected number, received string',
+          'Ignoring invalid serverDefaults configuration: Invalid global configuration: timeout: Invalid input: expected number, received string',
         ),
       );
+    });
+
+    it('should not emit a transport config change when reload fails to parse', () => {
+      (fs.existsSync as unknown as MockInstance).mockImplementation((p: string) => {
+        if (String(p).endsWith('config.toml')) return false;
+        return true;
+      });
+      (fs.readFileSync as unknown as MockInstance)
+        .mockReturnValueOnce(
+          JSON.stringify({
+            mcpServers: {
+              server1: {
+                type: 'stdio',
+                command: 'node',
+              },
+            },
+          }),
+        )
+        .mockReturnValueOnce('{ invalid json');
+
+      const instance = McpConfigManager.getInstance(testConfigPath);
+      const emitSpy = createEventEmitterSpy(instance);
+
+      instance.reloadConfig();
+
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(instance.getTransportConfig()).toEqual({});
     });
   });
 });

--- a/src/config/mcpConfigManager.test.ts
+++ b/src/config/mcpConfigManager.test.ts
@@ -43,7 +43,7 @@ vi.mock('fs', async () => {
 // Mock constants
 vi.mock('@src/constants.js', () => ({
   __esModule: true,
-  DEFAULT_CONFIG: { mcpServers: {} },
+  DEFAULT_CONFIG: { global: {}, mcpServers: {} },
   HOST: '127.0.0.1',
   PORT: 3050,
   AUTH_CONFIG: {
@@ -166,6 +166,65 @@ describe('McpConfigManager', () => {
 
       expect(config).toEqual(testConfig.mcpServers);
       expect(config).not.toBe(instance['transportConfig']); // Should be a copy
+    });
+  });
+
+  describe('global config support', () => {
+    it('should expose serverDefaults config and effective merged server config', () => {
+      (fs.readFileSync as unknown as MockInstance).mockReturnValueOnce(
+        JSON.stringify({
+          serverDefaults: {
+            timeout: 5000,
+            env: { SHARED: 'global' },
+          },
+          mcpServers: {
+            server1: {
+              type: 'stdio',
+              command: 'node',
+              env: { SHARED: 'server' },
+            },
+          },
+        }),
+      );
+
+      const instance = McpConfigManager.getInstance(testConfigPath);
+      expect(instance.getGlobalConfig()).toEqual({
+        timeout: 5000,
+        env: { SHARED: 'global' },
+      });
+
+      expect(instance.getEffectiveServerConfig('server1')).toEqual({
+        type: 'stdio',
+        command: 'node',
+        timeout: 5000,
+        env: { SHARED: 'server' },
+      });
+    });
+  });
+
+  describe('app config from config.toml', () => {
+    it('should return empty app config when config.toml does not exist', () => {
+      (fs.existsSync as unknown as MockInstance).mockImplementation((p: string) => {
+        if (String(p).endsWith('config.toml')) return false;
+        return true;
+      });
+
+      const instance = McpConfigManager.getInstance(testConfigPath);
+      expect(instance.getAppConfig()).toEqual({});
+    });
+
+    it('should warn when app key is present in mcp.json', () => {
+      (fs.readFileSync as unknown as MockInstance).mockReturnValueOnce(
+        JSON.stringify({ app: { port: 3050 }, mcpServers: {} }),
+      );
+      (fs.existsSync as unknown as MockInstance).mockImplementation((p: string) => {
+        if (String(p).endsWith('config.toml')) return false;
+        return true;
+      });
+
+      // Should not throw
+      const instance = McpConfigManager.getInstance(testConfigPath);
+      expect(instance.getAppConfig()).toEqual({});
     });
   });
 });

--- a/src/config/mcpConfigManager.test.ts
+++ b/src/config/mcpConfigManager.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { DEFAULT_CONFIG } from '@src/constants.js';
+import logger from '@src/logger/logger.js';
 
 import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 
@@ -217,6 +218,7 @@ describe('McpConfigManager', () => {
     });
 
     it('should warn when app key is present in mcp.json', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
       (fs.readFileSync as unknown as MockInstance).mockReturnValueOnce(
         JSON.stringify({ app: { port: 3050 }, mcpServers: {} }),
       );
@@ -228,6 +230,7 @@ describe('McpConfigManager', () => {
       // Should not throw
       const instance = McpConfigManager.getInstance(testConfigPath);
       expect(instance.getAppConfig()).toEqual({});
+      expect(warnSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/config/mcpConfigManager.test.ts
+++ b/src/config/mcpConfigManager.test.ts
@@ -263,7 +263,28 @@ describe('McpConfigManager', () => {
       // Should not throw
       const instance = McpConfigManager.getInstance(testConfigPath);
       expect(instance.getAppConfig()).toEqual({});
-      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        `The "app" key in mcp.json is deprecated. Please move your app settings to ${path.join(path.dirname(testConfigPath), 'config.toml')}. The "app" key in mcp.json will be ignored.`,
+      );
+    });
+
+    it('should keep invalid global config warning text unchanged', () => {
+      const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+      (fs.readFileSync as unknown as MockInstance).mockReturnValueOnce(
+        JSON.stringify({
+          serverDefaults: { timeout: 'invalid-timeout' },
+          mcpServers: {},
+        }),
+      );
+
+      const instance = McpConfigManager.getInstance(testConfigPath);
+
+      expect(instance.getGlobalConfig()).toEqual({});
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Failed to load configuration: Invalid global configuration: timeout: Invalid input: expected number, received string',
+        ),
+      );
     });
   });
 });

--- a/src/config/mcpConfigManager.test.ts
+++ b/src/config/mcpConfigManager.test.ts
@@ -66,12 +66,24 @@ vi.mock('@src/constants.js', () => ({
   getGlobalConfigDir: vi.fn().mockReturnValue('/test'),
 }));
 
+const getResolvedConfigPathMock = vi.fn(() => '/test/mcp.json');
+
+vi.mock('@src/config/configContext.js', () => ({
+  __esModule: true,
+  default: {
+    getInstance: vi.fn(() => ({
+      getResolvedConfigPath: getResolvedConfigPathMock,
+    })),
+  },
+}));
+
 describe('McpConfigManager', () => {
   const testConfigPath = '/test/config.json';
 
   beforeEach(() => {
     // Reset singleton instance
     (McpConfigManager as any).instance = undefined;
+    getResolvedConfigPathMock.mockReturnValue('/test/mcp.json');
     // Default mock implementations
     (fs.existsSync as unknown as MockInstance).mockReturnValue(true);
     (fs.readFileSync as unknown as MockInstance).mockReturnValue(JSON.stringify({ mcpServers: {} }));
@@ -88,6 +100,24 @@ describe('McpConfigManager', () => {
     it('should use provided config path', () => {
       const instance = McpConfigManager.getInstance(testConfigPath);
       expect((instance as any).configFilePath).toBe(testConfigPath);
+    });
+
+    it('should use ConfigContext resolved path when no config path is provided', () => {
+      getResolvedConfigPathMock.mockReturnValue('/tmp/runtime/mcp.json');
+
+      const instance = McpConfigManager.getInstance();
+
+      expect((instance as any).configFilePath).toBe('/tmp/runtime/mcp.json');
+    });
+
+    it('should recreate singleton when config path changes', () => {
+      const defaultConfigPath = '/test/default-mcp.json';
+
+      const instance1 = McpConfigManager.getInstance(defaultConfigPath);
+      const instance2 = McpConfigManager.getInstance(testConfigPath);
+
+      expect(instance2).not.toBe(instance1);
+      expect((instance2 as any).configFilePath).toBe(testConfigPath);
     });
   });
 
@@ -177,6 +207,7 @@ describe('McpConfigManager', () => {
           serverDefaults: {
             timeout: 5000,
             env: { SHARED: 'global', KEEP: 'global-only' },
+            envFilter: ['PATH', 'NODE_*'],
           },
           mcpServers: {
             server1: {
@@ -192,6 +223,7 @@ describe('McpConfigManager', () => {
       expect(instance.getGlobalConfig()).toEqual({
         timeout: 5000,
         env: { SHARED: 'global', KEEP: 'global-only' },
+        envFilter: ['PATH', 'NODE_*'],
       });
 
       const effective = instance.getEffectiveServerConfig('server1');
@@ -200,6 +232,7 @@ describe('McpConfigManager', () => {
         command: 'node',
         timeout: 5000,
         env: { SHARED: 'server', KEEP: 'global-only' },
+        envFilter: ['PATH', 'NODE_*'],
       });
       // Verify global-only key is present in effective config (merge, not override)
       expect((effective?.env as Record<string, string>)?.KEEP).toBe('global-only');

--- a/src/config/mcpConfigManager.ts
+++ b/src/config/mcpConfigManager.ts
@@ -2,13 +2,13 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
 
+import { loadAppConfigFromTomlPath } from '@src/config/configLoader.js';
 import { substituteEnvVarsInConfig } from '@src/config/envProcessor.js';
 import { getUnknownGlobalConfigKeys, mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
 import { DEFAULT_CONFIG, getGlobalConfigDir, getGlobalConfigPath } from '@src/constants.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
 import {
   ApplicationConfig,
-  applicationConfigSchema,
   GlobalTransportConfig,
   globalTransportConfigSchema,
   MCPServerParams,
@@ -16,7 +16,6 @@ import {
 } from '@src/core/types/index.js';
 import logger, { debugIf } from '@src/logger/logger.js';
 
-import { parse as parseToml } from 'smol-toml';
 import { ZodError } from 'zod';
 
 /**
@@ -331,24 +330,7 @@ export class McpConfigManager extends EventEmitter {
    */
   private loadAppConfigFromToml(): ApplicationConfig {
     const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
-    try {
-      if (!fs.existsSync(tomlPath)) {
-        return {};
-      }
-      const raw = fs.readFileSync(tomlPath, 'utf8');
-      const parsed = parseToml(raw);
-      return applicationConfigSchema.parse(parsed);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const fieldErrors = error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
-        logger.error(`Invalid app configuration in config.toml (ignored): ${fieldErrors}`);
-      } else {
-        logger.error(
-          `Failed to load app configuration from ${tomlPath}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-      return {};
-    }
+    return loadAppConfigFromTomlPath(tomlPath);
   }
 
   /**

--- a/src/config/mcpConfigManager.ts
+++ b/src/config/mcpConfigManager.ts
@@ -3,10 +3,21 @@ import fs from 'fs';
 import path from 'path';
 
 import { substituteEnvVarsInConfig } from '@src/config/envProcessor.js';
+import { getUnknownGlobalConfigKeys, mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
 import { DEFAULT_CONFIG, getGlobalConfigDir, getGlobalConfigPath } from '@src/constants.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
-import { MCPServerParams } from '@src/core/types/index.js';
+import {
+  ApplicationConfig,
+  applicationConfigSchema,
+  GlobalTransportConfig,
+  globalTransportConfigSchema,
+  MCPServerParams,
+  transportConfigSchema,
+} from '@src/core/types/index.js';
 import logger, { debugIf } from '@src/logger/logger.js';
+
+import { parse as parseToml } from 'smol-toml';
+import { ZodError } from 'zod';
 
 /**
  * Configuration change event types
@@ -22,6 +33,8 @@ export class McpConfigManager extends EventEmitter {
   private static instance: McpConfigManager;
   private configWatcher: fs.FSWatcher | null = null;
   private transportConfig: Record<string, MCPServerParams> = {};
+  private globalConfig: GlobalTransportConfig = {};
+  private appConfig: ApplicationConfig = {};
   private configFilePath: string;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastModified: number = 0;
@@ -95,11 +108,60 @@ export class McpConfigManager extends EventEmitter {
       }
 
       const configObj = processedConfig as Record<string, unknown>;
-      this.transportConfig = (configObj.mcpServers as Record<string, MCPServerParams>) || {};
+      const rawGlobal = configObj.serverDefaults;
+      const unknownGlobalKeys = getUnknownGlobalConfigKeys(rawGlobal);
+      if (unknownGlobalKeys.length > 0) {
+        logger.warn(`Unknown properties in global MCP configuration were ignored: ${unknownGlobalKeys.join(', ')}`);
+      }
+
+      let validatedGlobalConfig: GlobalTransportConfig = {};
+      if (rawGlobal !== undefined) {
+        try {
+          validatedGlobalConfig = globalTransportConfigSchema.parse(rawGlobal);
+        } catch (error) {
+          if (error instanceof ZodError) {
+            const fieldErrors = error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
+            throw new Error(`Invalid global configuration: ${fieldErrors}`);
+          }
+          throw error;
+        }
+      }
+
+      // Warn if legacy app key is present in mcp.json
+      if (configObj.app !== undefined) {
+        const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
+        logger.warn(
+          `The "app" key in mcp.json is deprecated. Please move your app settings to ${tomlPath}. ` +
+            `The "app" key in mcp.json will be ignored.`,
+        );
+      }
+
+      const validatedAppConfig: ApplicationConfig = this.loadAppConfigFromToml();
+
+      const servers = (configObj.mcpServers as Record<string, unknown>) || {};
+      const validatedServers: Record<string, MCPServerParams> = {};
+      for (const [serverName, serverConfig] of Object.entries(servers)) {
+        try {
+          const parsedServerConfig = transportConfigSchema.parse(serverConfig);
+          validatedServers[serverName] = transportConfigSchema.parse(
+            mergeGlobalAndServerConfig(validatedGlobalConfig, parsedServerConfig),
+          );
+        } catch (error) {
+          logger.error(
+            `Invalid configuration for server '${serverName}': ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+
+      this.globalConfig = validatedGlobalConfig;
+      this.appConfig = validatedAppConfig;
+      this.transportConfig = validatedServers;
       const substitutionStatus = features.envSubstitution ? 'with' : 'without';
       logger.info(`Configuration loaded successfully ${substitutionStatus} environment variable substitution`);
     } catch (error) {
       logger.error(`Failed to load configuration: ${error instanceof Error ? error.message : String(error)}`);
+      this.globalConfig = {};
+      this.appConfig = {};
       this.transportConfig = {};
     }
   }
@@ -254,6 +316,53 @@ export class McpConfigManager extends EventEmitter {
    */
   public getTransportConfig(): Record<string, MCPServerParams> {
     return { ...this.transportConfig };
+  }
+
+  /**
+   * Get the current global MCP configuration.
+   */
+  public getGlobalConfig(): GlobalTransportConfig {
+    return { ...this.globalConfig };
+  }
+
+  /**
+   * Load app configuration from config.toml in the same directory as mcp.json.
+   */
+  private loadAppConfigFromToml(): ApplicationConfig {
+    const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
+    try {
+      if (!fs.existsSync(tomlPath)) {
+        return {};
+      }
+      const raw = fs.readFileSync(tomlPath, 'utf8');
+      const parsed = parseToml(raw);
+      return applicationConfigSchema.parse(parsed);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const fieldErrors = error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
+        logger.warn(`Invalid app configuration in config.toml (ignored): ${fieldErrors}`);
+      } else {
+        logger.warn(
+          `Failed to load app configuration from ${tomlPath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      return {};
+    }
+  }
+
+  /**
+   * Get the application-level configuration from config.toml.
+   * CLI args always take precedence over these values.
+   */
+  public getAppConfig(): ApplicationConfig {
+    return { ...this.appConfig };
+  }
+
+  /**
+   * Get the effective merged configuration for a specific server.
+   */
+  public getEffectiveServerConfig(serverName: string): MCPServerParams | undefined {
+    return this.transportConfig[serverName] ? { ...this.transportConfig[serverName] } : undefined;
   }
 
   /**

--- a/src/config/mcpConfigManager.ts
+++ b/src/config/mcpConfigManager.ts
@@ -25,6 +25,7 @@ export class McpConfigManager extends EventEmitter {
   private globalConfig: GlobalTransportConfig = {};
   private appConfig: ApplicationConfig = {};
   private configFilePath: string;
+  private loader: ConfigLoader;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastModified: number = 0;
 
@@ -43,7 +44,7 @@ export class McpConfigManager extends EventEmitter {
   private constructor(configFilePath?: string) {
     super();
     this.configFilePath = McpConfigManager.resolveConfigFilePath(configFilePath);
-    new ConfigLoader(this.configFilePath);
+    this.loader = new ConfigLoader(this.configFilePath);
     this.loadConfig();
   }
 
@@ -70,10 +71,9 @@ export class McpConfigManager extends EventEmitter {
   /**
    * Load the configuration from the config file
    */
-  private loadConfig(): void {
+  private loadConfig(): boolean {
     try {
-      const loader = new ConfigLoader(this.configFilePath);
-      const loadedConfig = loader.loadParsedConfigWithEnvSubstitution();
+      const loadedConfig = this.loader.loadParsedConfigWithEnvSubstitution();
       const features = AgentConfigManager.getInstance().get('features');
 
       this.lastModified = loadedConfig.lastModified;
@@ -82,12 +82,13 @@ export class McpConfigManager extends EventEmitter {
       this.transportConfig = loadedConfig.validatedServers;
       const substitutionStatus = features.envSubstitution ? 'with' : 'without';
       logger.info(`Configuration loaded successfully ${substitutionStatus} environment variable substitution`);
+      return true;
     } catch (error) {
       logger.error(`Failed to load configuration: ${error instanceof Error ? error.message : String(error)}`);
       this.globalConfig = {};
       this.appConfig = {};
       this.transportConfig = {};
-      this.emit(ConfigChangeEvent.TRANSPORT_CONFIG_CHANGED, this.transportConfig);
+      return false;
     }
   }
 
@@ -223,10 +224,10 @@ export class McpConfigManager extends EventEmitter {
     const oldConfig = { ...this.transportConfig };
 
     try {
-      this.loadConfig();
+      const loadedSuccessfully = this.loadConfig();
 
       // Emit event for transport configuration changes
-      if (JSON.stringify(oldConfig) !== JSON.stringify(this.transportConfig)) {
+      if (loadedSuccessfully && JSON.stringify(oldConfig) !== JSON.stringify(this.transportConfig)) {
         logger.info('Transport configuration changed, emitting event');
         this.emit(ConfigChangeEvent.TRANSPORT_CONFIG_CHANGED, this.transportConfig);
       }

--- a/src/config/mcpConfigManager.ts
+++ b/src/config/mcpConfigManager.ts
@@ -3,21 +3,10 @@ import fs from 'fs';
 import path from 'path';
 
 import ConfigContext from '@src/config/configContext.js';
-import { loadAppConfigFromTomlPath } from '@src/config/configLoader.js';
-import { substituteEnvVarsInConfig } from '@src/config/envProcessor.js';
-import { getUnknownGlobalConfigKeys, mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
-import { DEFAULT_CONFIG } from '@src/constants.js';
+import { ConfigLoader } from '@src/config/configLoader.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
-import {
-  ApplicationConfig,
-  GlobalTransportConfig,
-  globalTransportConfigSchema,
-  MCPServerParams,
-  transportConfigSchema,
-} from '@src/core/types/index.js';
+import { ApplicationConfig, GlobalTransportConfig, MCPServerParams } from '@src/core/types/index.js';
 import logger, { debugIf } from '@src/logger/logger.js';
-
-import { ZodError } from 'zod';
 
 /**
  * Configuration change event types
@@ -54,7 +43,7 @@ export class McpConfigManager extends EventEmitter {
   private constructor(configFilePath?: string) {
     super();
     this.configFilePath = McpConfigManager.resolveConfigFilePath(configFilePath);
-    this.ensureConfigExists();
+    new ConfigLoader(this.configFilePath);
     this.loadConfig();
   }
 
@@ -79,100 +68,18 @@ export class McpConfigManager extends EventEmitter {
   }
 
   /**
-   * Ensure the config directory and file exist
-   */
-  private ensureConfigExists(): void {
-    try {
-      const configDir = path.dirname(this.configFilePath);
-      if (!fs.existsSync(configDir)) {
-        fs.mkdirSync(configDir, { recursive: true });
-        logger.info(`Created config directory: ${configDir}`);
-      }
-
-      if (!fs.existsSync(this.configFilePath)) {
-        fs.writeFileSync(this.configFilePath, JSON.stringify(DEFAULT_CONFIG, null, 2));
-        logger.info(`Created default config file: ${this.configFilePath}`);
-      }
-    } catch (error) {
-      logger.error(`Failed to ensure config exists: ${error instanceof Error ? error.message : String(error)}`);
-      throw error;
-    }
-  }
-
-  /**
    * Load the configuration from the config file
    */
   private loadConfig(): void {
     try {
-      const stats = fs.statSync(this.configFilePath);
-      this.lastModified = stats.mtime.getTime();
+      const loader = new ConfigLoader(this.configFilePath);
+      const loadedConfig = loader.loadParsedConfigWithEnvSubstitution();
+      const features = AgentConfigManager.getInstance().get('features');
 
-      const rawConfigData = fs.readFileSync(this.configFilePath, 'utf8');
-
-      // Parse JSON and apply environment variable substitution
-      const configData = JSON.parse(rawConfigData) as unknown;
-
-      // Apply environment variable substitution if enabled
-      const agentConfig = AgentConfigManager.getInstance();
-      const features = agentConfig.get('features');
-      const processedConfig = features.envSubstitution ? substituteEnvVarsInConfig(configData) : configData;
-
-      // Type guard to ensure processedConfig has proper structure
-      if (!processedConfig || typeof processedConfig !== 'object') {
-        logger.error('Invalid configuration format');
-        this.transportConfig = {};
-        return;
-      }
-
-      const configObj = processedConfig as Record<string, unknown>;
-      const rawGlobal = configObj.serverDefaults;
-      const unknownGlobalKeys = getUnknownGlobalConfigKeys(rawGlobal);
-      if (unknownGlobalKeys.length > 0) {
-        logger.warn(`Unknown properties in global MCP configuration were ignored: ${unknownGlobalKeys.join(', ')}`);
-      }
-
-      let validatedGlobalConfig: GlobalTransportConfig = {};
-      if (rawGlobal !== undefined) {
-        try {
-          validatedGlobalConfig = globalTransportConfigSchema.parse(rawGlobal);
-        } catch (error) {
-          if (error instanceof ZodError) {
-            const fieldErrors = error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
-            throw new Error(`Invalid global configuration: ${fieldErrors}`);
-          }
-          throw error;
-        }
-      }
-
-      // Warn if legacy app key is present in mcp.json
-      if (configObj.app !== undefined) {
-        const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
-        logger.warn(
-          `The "app" key in mcp.json is deprecated. Please move your app settings to ${tomlPath}. ` +
-            `The "app" key in mcp.json will be ignored.`,
-        );
-      }
-
-      const validatedAppConfig: ApplicationConfig = this.loadAppConfigFromToml();
-
-      const servers = (configObj.mcpServers as Record<string, unknown>) || {};
-      const validatedServers: Record<string, MCPServerParams> = {};
-      for (const [serverName, serverConfig] of Object.entries(servers)) {
-        try {
-          const parsedServerConfig = transportConfigSchema.parse(serverConfig);
-          validatedServers[serverName] = transportConfigSchema.parse(
-            mergeGlobalAndServerConfig(validatedGlobalConfig, parsedServerConfig),
-          );
-        } catch (error) {
-          logger.error(
-            `Invalid configuration for server '${serverName}': ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      }
-
-      this.globalConfig = validatedGlobalConfig;
-      this.appConfig = validatedAppConfig;
-      this.transportConfig = validatedServers;
+      this.lastModified = loadedConfig.lastModified;
+      this.globalConfig = loadedConfig.globalConfig;
+      this.appConfig = loadedConfig.appConfig;
+      this.transportConfig = loadedConfig.validatedServers;
       const substitutionStatus = features.envSubstitution ? 'with' : 'without';
       logger.info(`Configuration loaded successfully ${substitutionStatus} environment variable substitution`);
     } catch (error) {
@@ -341,14 +248,6 @@ export class McpConfigManager extends EventEmitter {
    */
   public getGlobalConfig(): GlobalTransportConfig {
     return { ...this.globalConfig };
-  }
-
-  /**
-   * Load app configuration from config.toml in the same directory as mcp.json.
-   */
-  private loadAppConfigFromToml(): ApplicationConfig {
-    const tomlPath = path.join(path.dirname(this.configFilePath), 'config.toml');
-    return loadAppConfigFromTomlPath(tomlPath);
   }
 
   /**

--- a/src/config/mcpConfigManager.ts
+++ b/src/config/mcpConfigManager.ts
@@ -163,6 +163,7 @@ export class McpConfigManager extends EventEmitter {
       this.globalConfig = {};
       this.appConfig = {};
       this.transportConfig = {};
+      this.emit(ConfigChangeEvent.TRANSPORT_CONFIG_CHANGED, this.transportConfig);
     }
   }
 
@@ -340,9 +341,9 @@ export class McpConfigManager extends EventEmitter {
     } catch (error) {
       if (error instanceof ZodError) {
         const fieldErrors = error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
-        logger.warn(`Invalid app configuration in config.toml (ignored): ${fieldErrors}`);
+        logger.error(`Invalid app configuration in config.toml (ignored): ${fieldErrors}`);
       } else {
-        logger.warn(
+        logger.error(
           `Failed to load app configuration from ${tomlPath}: ${error instanceof Error ? error.message : String(error)}`,
         );
       }

--- a/src/config/mcpConfigManager.ts
+++ b/src/config/mcpConfigManager.ts
@@ -2,10 +2,11 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
 
+import ConfigContext from '@src/config/configContext.js';
 import { loadAppConfigFromTomlPath } from '@src/config/configLoader.js';
 import { substituteEnvVarsInConfig } from '@src/config/envProcessor.js';
 import { getUnknownGlobalConfigKeys, mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
-import { DEFAULT_CONFIG, getGlobalConfigDir, getGlobalConfigPath } from '@src/constants.js';
+import { DEFAULT_CONFIG } from '@src/constants.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
 import {
   ApplicationConfig,
@@ -38,13 +39,21 @@ export class McpConfigManager extends EventEmitter {
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastModified: number = 0;
 
+  private static resolveConfigFilePath(configFilePath?: string): string {
+    if (configFilePath) {
+      return configFilePath;
+    }
+
+    return ConfigContext.getInstance().getResolvedConfigPath();
+  }
+
   /**
    * Private constructor to enforce singleton pattern
    * @param configFilePath - Optional path to the config file. If not provided, uses global config path
    */
   private constructor(configFilePath?: string) {
     super();
-    this.configFilePath = configFilePath || getGlobalConfigPath();
+    this.configFilePath = McpConfigManager.resolveConfigFilePath(configFilePath);
     this.ensureConfigExists();
     this.loadConfig();
   }
@@ -54,9 +63,18 @@ export class McpConfigManager extends EventEmitter {
    * @param configFilePath - Optional path to the config file
    */
   public static getInstance(configFilePath?: string): McpConfigManager {
+    const resolvedConfigFilePath = McpConfigManager.resolveConfigFilePath(configFilePath);
+
     if (!McpConfigManager.instance) {
-      McpConfigManager.instance = new McpConfigManager(configFilePath);
+      McpConfigManager.instance = new McpConfigManager(resolvedConfigFilePath);
+      return McpConfigManager.instance;
     }
+
+    if (McpConfigManager.instance.configFilePath !== resolvedConfigFilePath) {
+      McpConfigManager.instance.stopWatching();
+      McpConfigManager.instance = new McpConfigManager(resolvedConfigFilePath);
+    }
+
     return McpConfigManager.instance;
   }
 
@@ -65,7 +83,7 @@ export class McpConfigManager extends EventEmitter {
    */
   private ensureConfigExists(): void {
     try {
-      const configDir = getGlobalConfigDir();
+      const configDir = path.dirname(this.configFilePath);
       if (!fs.existsSync(configDir)) {
         fs.mkdirSync(configDir, { recursive: true });
         logger.info(`Created config directory: ${configDir}`);

--- a/src/config/mcpConfigMerge.test.ts
+++ b/src/config/mcpConfigMerge.test.ts
@@ -29,6 +29,7 @@ describe('mcpConfigMerge', () => {
       connectionTimeout: 2000,
       requestTimeout: 3000,
       inheritParentEnv: true,
+      envFilter: ['PATH', 'NODE_*'],
     };
     const serverConfig: MCPServerParams = {
       type: 'stdio',
@@ -41,6 +42,7 @@ describe('mcpConfigMerge', () => {
     expect(merged.connectionTimeout).toBe(2000);
     expect(merged.requestTimeout).toBe(3000);
     expect(merged.inheritParentEnv).toBe(true);
+    expect(merged.envFilter).toEqual(['PATH', 'NODE_*']);
   });
 
   it('replaces oauth and headers with server-specific values', () => {
@@ -78,6 +80,7 @@ describe('mcpConfigMerge', () => {
   it('ignores global inheritParentEnv for http transports', () => {
     const globalConfig: GlobalTransportConfig = {
       inheritParentEnv: true,
+      envFilter: ['PATH'],
     };
     const serverConfig: MCPServerParams = {
       type: 'http',
@@ -87,6 +90,7 @@ describe('mcpConfigMerge', () => {
     const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
 
     expect(merged.inheritParentEnv).toBeUndefined();
+    expect(merged.envFilter).toBeUndefined();
   });
 
   it('merges global config into all servers', () => {

--- a/src/config/mcpConfigMerge.test.ts
+++ b/src/config/mcpConfigMerge.test.ts
@@ -109,4 +109,54 @@ describe('mcpConfigMerge', () => {
 
     expect(unknown.sort()).toEqual(['command', 'disabled']);
   });
+
+  it('server primitive overrides global primitive', () => {
+    const globalConfig: GlobalTransportConfig = { timeout: 9999 };
+    const serverConfig: MCPServerParams = { type: 'stdio', command: 'node', timeout: 500 };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.timeout).toBe(500);
+  });
+
+  it('handles undefined globalConfig gracefully', () => {
+    const serverConfig: MCPServerParams = { type: 'stdio', command: 'node', timeout: 1000 };
+
+    const merged = mergeGlobalAndServerConfig(undefined, serverConfig);
+
+    expect(merged).toEqual(serverConfig);
+  });
+
+  it('ignores global inheritParentEnv for sse transports', () => {
+    const globalConfig: GlobalTransportConfig = { inheritParentEnv: true };
+    const serverConfig: MCPServerParams = { type: 'sse', url: 'https://example.com/mcp' };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.inheritParentEnv).toBeUndefined();
+  });
+
+  it('ignores global inheritParentEnv for streamableHttp transports', () => {
+    const globalConfig: GlobalTransportConfig = { inheritParentEnv: true };
+    const serverConfig: MCPServerParams = { type: 'streamableHttp', url: 'https://example.com/mcp' };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.inheritParentEnv).toBeUndefined();
+  });
+
+  it('keeps server env object when global env is an array', () => {
+    const globalConfig: GlobalTransportConfig = {
+      env: ['GLOBAL_VAR=value'] as unknown as Record<string, string>,
+    };
+    const serverConfig: MCPServerParams = {
+      type: 'stdio',
+      command: 'node',
+      env: { SERVER_VAR: 'server-value' },
+    };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.env).toEqual({ SERVER_VAR: 'server-value' });
+  });
 });

--- a/src/config/mcpConfigMerge.test.ts
+++ b/src/config/mcpConfigMerge.test.ts
@@ -159,4 +159,19 @@ describe('mcpConfigMerge', () => {
 
     expect(merged.env).toEqual({ SERVER_VAR: 'server-value' });
   });
+
+  it('keeps the server env array when both global and server env use array format', () => {
+    const globalConfig: GlobalTransportConfig = {
+      env: ['GLOBAL_VAR=value'] as unknown as Record<string, string>,
+    };
+    const serverConfig: MCPServerParams = {
+      type: 'stdio',
+      command: 'node',
+      env: ['SERVER_VAR=server-value'] as unknown as Record<string, string>,
+    };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.env).toEqual(['SERVER_VAR=server-value']);
+  });
 });

--- a/src/config/mcpConfigMerge.test.ts
+++ b/src/config/mcpConfigMerge.test.ts
@@ -1,0 +1,112 @@
+import { GlobalTransportConfig, MCPServerParams } from '@src/core/types/transport.js';
+
+import { describe, expect, it } from 'vitest';
+
+import { getUnknownGlobalConfigKeys, mergeGlobalAndServerConfig, mergeGlobalWithServers } from './mcpConfigMerge.js';
+
+describe('mcpConfigMerge', () => {
+  it('merges env objects with server values taking precedence', () => {
+    const globalConfig: GlobalTransportConfig = {
+      env: { SHARED: 'from-global', KEEP: 'global-only' },
+    };
+    const serverConfig: MCPServerParams = {
+      type: 'stdio',
+      command: 'node',
+      env: { SHARED: 'from-server' },
+    };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.env).toEqual({
+      SHARED: 'from-server',
+      KEEP: 'global-only',
+    });
+  });
+
+  it('uses global primitive values when server values are missing', () => {
+    const globalConfig: GlobalTransportConfig = {
+      timeout: 1000,
+      connectionTimeout: 2000,
+      requestTimeout: 3000,
+      inheritParentEnv: true,
+    };
+    const serverConfig: MCPServerParams = {
+      type: 'stdio',
+      command: 'node',
+    };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.timeout).toBe(1000);
+    expect(merged.connectionTimeout).toBe(2000);
+    expect(merged.requestTimeout).toBe(3000);
+    expect(merged.inheritParentEnv).toBe(true);
+  });
+
+  it('replaces oauth and headers with server-specific values', () => {
+    const globalConfig: GlobalTransportConfig = {
+      oauth: { clientId: 'global-client' },
+      headers: { Authorization: 'Bearer global-token' },
+    };
+    const serverConfig: MCPServerParams = {
+      type: 'http',
+      url: 'https://example.com/mcp',
+      oauth: { clientId: 'server-client' },
+      headers: { Authorization: 'Bearer server-token' },
+    };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.oauth).toEqual({ clientId: 'server-client' });
+    expect(merged.headers).toEqual({ Authorization: 'Bearer server-token' });
+  });
+
+  it('ignores global headers for stdio transports', () => {
+    const globalConfig: GlobalTransportConfig = {
+      headers: { Authorization: 'Bearer global-token' },
+    };
+    const serverConfig: MCPServerParams = {
+      type: 'stdio',
+      command: 'node',
+    };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.headers).toBeUndefined();
+  });
+
+  it('ignores global inheritParentEnv for http transports', () => {
+    const globalConfig: GlobalTransportConfig = {
+      inheritParentEnv: true,
+    };
+    const serverConfig: MCPServerParams = {
+      type: 'http',
+      url: 'https://example.com/mcp',
+    };
+
+    const merged = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+
+    expect(merged.inheritParentEnv).toBeUndefined();
+  });
+
+  it('merges global config into all servers', () => {
+    const globalConfig: GlobalTransportConfig = {
+      timeout: 5000,
+    };
+    const servers: Record<string, MCPServerParams> = {
+      stdio: { type: 'stdio', command: 'node' },
+      http: { type: 'http', url: 'https://example.com/mcp' },
+    };
+
+    const merged = mergeGlobalWithServers(globalConfig, servers);
+
+    expect(merged.stdio.timeout).toBe(5000);
+    expect(merged.http.timeout).toBe(5000);
+  });
+
+  it('returns unknown global keys for warning output', () => {
+    const unknown = getUnknownGlobalConfigKeys({ env: { A: '1' }, command: 'node', disabled: true });
+
+    expect(unknown.sort()).toEqual(['command', 'disabled']);
+  });
+});

--- a/src/config/mcpConfigMerge.ts
+++ b/src/config/mcpConfigMerge.ts
@@ -1,0 +1,102 @@
+import { GLOBAL_TRANSPORT_CONFIG_KEYS, GlobalTransportConfig, MCPServerParams } from '@src/core/types/transport.js';
+
+const GLOBAL_KEY_SET = new Set<string>(GLOBAL_TRANSPORT_CONFIG_KEYS);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return Object.values(value).every((entry) => typeof entry === 'string');
+}
+
+/**
+ * Return unknown keys defined under the raw global section.
+ */
+export function getUnknownGlobalConfigKeys(rawGlobal: unknown): string[] {
+  if (!isRecord(rawGlobal)) {
+    return [];
+  }
+
+  return Object.keys(rawGlobal).filter((key) => !GLOBAL_KEY_SET.has(key));
+}
+
+/**
+ * Merge global shareable settings with a single server configuration.
+ * Server-specific values always take precedence.
+ */
+export function mergeGlobalAndServerConfig(
+  globalConfig: GlobalTransportConfig | undefined,
+  serverConfig: MCPServerParams,
+): MCPServerParams {
+  if (!globalConfig) {
+    return { ...serverConfig };
+  }
+
+  const merged: MCPServerParams = { ...serverConfig };
+
+  // Primitive fallback values
+  if (merged.timeout === undefined && globalConfig.timeout !== undefined) {
+    merged.timeout = globalConfig.timeout;
+  }
+  if (merged.connectionTimeout === undefined && globalConfig.connectionTimeout !== undefined) {
+    merged.connectionTimeout = globalConfig.connectionTimeout;
+  }
+  if (merged.requestTimeout === undefined && globalConfig.requestTimeout !== undefined) {
+    merged.requestTimeout = globalConfig.requestTimeout;
+  }
+  if (merged.inheritParentEnv === undefined && globalConfig.inheritParentEnv !== undefined) {
+    merged.inheritParentEnv = globalConfig.inheritParentEnv;
+  }
+
+  // Replace semantics
+  if (merged.oauth === undefined && globalConfig.oauth !== undefined) {
+    merged.oauth = globalConfig.oauth;
+  }
+  if (merged.headers === undefined && globalConfig.headers !== undefined) {
+    merged.headers = globalConfig.headers;
+  }
+
+  // env uses merge semantics when both sides are object form
+  if (merged.env === undefined && globalConfig.env !== undefined) {
+    merged.env = globalConfig.env;
+  } else if (isStringRecord(globalConfig.env) && isStringRecord(merged.env)) {
+    merged.env = { ...globalConfig.env, ...merged.env };
+  }
+
+  // Global headers should only apply to HTTP/SSE transports.
+  if (merged.type === 'stdio' && globalConfig.headers !== undefined && serverConfig.headers === undefined) {
+    delete merged.headers;
+  }
+
+  // Global inheritParentEnv should only apply to stdio transports.
+  if (
+    (merged.type === 'http' || merged.type === 'sse' || merged.type === 'streamableHttp') &&
+    globalConfig.inheritParentEnv !== undefined &&
+    serverConfig.inheritParentEnv === undefined
+  ) {
+    delete merged.inheritParentEnv;
+  }
+
+  return merged;
+}
+
+/**
+ * Merge global shareable settings with all servers.
+ */
+export function mergeGlobalWithServers(
+  globalConfig: GlobalTransportConfig | undefined,
+  servers: Record<string, MCPServerParams>,
+): Record<string, MCPServerParams> {
+  const mergedServers: Record<string, MCPServerParams> = {};
+
+  for (const [serverName, serverConfig] of Object.entries(servers)) {
+    mergedServers[serverName] = mergeGlobalAndServerConfig(globalConfig, serverConfig);
+  }
+
+  return mergedServers;
+}

--- a/src/config/mcpConfigMerge.ts
+++ b/src/config/mcpConfigMerge.ts
@@ -52,6 +52,9 @@ export function mergeGlobalAndServerConfig(
   if (merged.inheritParentEnv === undefined && globalConfig.inheritParentEnv !== undefined) {
     merged.inheritParentEnv = globalConfig.inheritParentEnv;
   }
+  if (merged.envFilter === undefined && globalConfig.envFilter !== undefined) {
+    merged.envFilter = globalConfig.envFilter;
+  }
 
   // Replace semantics
   if (merged.oauth === undefined && globalConfig.oauth !== undefined) {
@@ -80,6 +83,13 @@ export function mergeGlobalAndServerConfig(
     serverConfig.inheritParentEnv === undefined
   ) {
     delete merged.inheritParentEnv;
+  }
+  if (
+    (merged.type === 'http' || merged.type === 'sse' || merged.type === 'streamableHttp') &&
+    globalConfig.envFilter !== undefined &&
+    serverConfig.envFilter === undefined
+  ) {
+    delete merged.envFilter;
   }
 
   return merged;

--- a/src/constants/mcp.ts
+++ b/src/constants/mcp.ts
@@ -5,6 +5,7 @@ import { ClientCapabilities, ServerCapabilities } from '@modelcontextprotocol/sd
 
 // MCP constants
 export const MCP_CONFIG_FILE = 'mcp.json';
+export const APP_CONFIG_FILE = 'config.toml';
 export const MCP_INSTRUCTIONS_TEMPLATE_FILE = 'instructions-template.md';
 export const MCP_SERVER_NAME = '1mcp';
 export const MCP_SERVER_VERSION = '0.31.0-beta1';

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -3,7 +3,7 @@
  */
 import os from 'os';
 
-import { MCP_CONFIG_FILE, MCP_INSTRUCTIONS_TEMPLATE_FILE } from './mcp.js';
+import { APP_CONFIG_FILE, MCP_CONFIG_FILE, MCP_INSTRUCTIONS_TEMPLATE_FILE } from './mcp.js';
 import { DEFAULT_MCP_SERVERS, MCP_CONFIG_SCHEMA_URL, PROJECT_CONFIG_SCHEMA_URL } from './schema.js';
 
 // Global config paths
@@ -11,6 +11,7 @@ export const CONFIG_DIR_NAME = '1mcp';
 export const BACKUP_DIR_NAME = 'backups';
 export const DEFAULT_CONFIG = {
   $schema: MCP_CONFIG_SCHEMA_URL,
+  serverDefaults: {},
   mcpServers: DEFAULT_MCP_SERVERS,
 };
 
@@ -60,6 +61,14 @@ export function getConfigPath(configDir?: string): string {
     return `${configDir}/${MCP_CONFIG_FILE}`;
   }
   return getGlobalConfigPath();
+}
+
+/**
+ * Get the app config file path (config.toml)
+ */
+export function getAppConfigPath(configDir?: string): string {
+  const dir = configDir ? configDir : getGlobalConfigDir();
+  return `${dir}/${APP_CONFIG_FILE}`;
 }
 
 /**

--- a/src/core/types/transport.ts
+++ b/src/core/types/transport.ts
@@ -80,6 +80,7 @@ export interface GlobalTransportConfig {
   readonly oauth?: OAuthConfig;
   readonly headers?: Record<string, string>;
   readonly inheritParentEnv?: boolean;
+  readonly envFilter?: string[];
 }
 
 /**
@@ -288,6 +289,7 @@ export const GLOBAL_TRANSPORT_CONFIG_KEYS = [
   'oauth',
   'headers',
   'inheritParentEnv',
+  'envFilter',
 ] as const;
 
 /**
@@ -302,6 +304,7 @@ export const globalTransportConfigSchema = transportConfigSchema.pick({
   oauth: true,
   headers: true,
   inheritParentEnv: true,
+  envFilter: true,
 });
 
 /**

--- a/src/core/types/transport.ts
+++ b/src/core/types/transport.ts
@@ -69,6 +69,58 @@ export interface BaseTransportConfig {
 }
 
 /**
+ * Shareable transport settings that can be defined globally and inherited by servers
+ */
+export interface GlobalTransportConfig {
+  readonly env?: Record<string, string> | string[];
+  /** @deprecated Use connectionTimeout and requestTimeout instead */
+  readonly timeout?: number;
+  readonly connectionTimeout?: number;
+  readonly requestTimeout?: number;
+  readonly oauth?: OAuthConfig;
+  readonly headers?: Record<string, string>;
+  readonly inheritParentEnv?: boolean;
+}
+
+/**
+ * Application-level configuration that can be set in mcp.json under the "app" key.
+ * CLI args and ONE_MCP_* env vars always take precedence over these values.
+ */
+export interface ApplicationConfig {
+  readonly transport?: 'http' | 'sse' | 'stdio';
+  readonly port?: number;
+  readonly host?: string;
+  readonly logLevel?: 'debug' | 'info' | 'warn' | 'error';
+  readonly logFile?: string;
+  readonly auth?: {
+    readonly enabled?: boolean;
+    readonly sessionTtl?: number;
+    readonly rateLimitWindow?: number;
+    readonly rateLimitMax?: number;
+    readonly trustProxy?: string;
+    readonly enableScopeValidation?: boolean;
+    readonly enableEnhancedSecurity?: boolean;
+  };
+  readonly asyncLoading?: {
+    readonly enabled?: boolean;
+    readonly minServers?: number;
+    readonly timeout?: number;
+    readonly batchNotifications?: boolean;
+    readonly batchDelay?: number;
+  };
+  readonly lazyLoading?: {
+    readonly enabled?: boolean;
+    readonly mode?: 'full' | 'metatool' | 'hybrid';
+    readonly cacheMaxEntries?: number;
+    readonly inlineCatalog?: boolean;
+  };
+  readonly configReload?: {
+    readonly enabled?: boolean;
+    readonly debounce?: number;
+  };
+}
+
+/**
  * Common configuration for HTTP-based transports (HTTP and SSE)
  */
 export interface HTTPBasedTransportConfig extends BaseTransportConfig {
@@ -180,6 +232,78 @@ export const transportConfigSchema = z.object({
 });
 
 /**
+ * Zod schema for application-level configuration
+ */
+export const applicationConfigSchema = z.object({
+  transport: z.enum(['http', 'sse', 'stdio']).optional().describe('Transport type for the 1MCP server'),
+  port: z.number().int().min(1).max(65535).optional().describe('HTTP port to listen on'),
+  host: z.string().optional().describe('HTTP host to listen on'),
+  logLevel: z.enum(['debug', 'info', 'warn', 'error']).optional().describe('Log level'),
+  logFile: z.string().optional().describe('Path to log file'),
+  auth: z
+    .object({
+      enabled: z.boolean().optional().describe('Enable OAuth 2.1 authentication'),
+      sessionTtl: z.number().int().min(1).optional().describe('Session TTL in minutes'),
+      rateLimitWindow: z.number().int().min(1).optional().describe('Rate limit window in minutes'),
+      rateLimitMax: z.number().int().min(1).optional().describe('Maximum requests per rate limit window'),
+      trustProxy: z.string().optional().describe('Trust proxy configuration for Express.js'),
+      enableScopeValidation: z.boolean().optional().describe('Enable tag-based scope validation'),
+      enableEnhancedSecurity: z.boolean().optional().describe('Enable enhanced security middleware'),
+    })
+    .optional(),
+  asyncLoading: z
+    .object({
+      enabled: z.boolean().optional().describe('Enable asynchronous MCP server loading'),
+      minServers: z.number().int().min(0).optional().describe('Minimum servers to wait for before accepting requests'),
+      timeout: z.number().int().min(0).optional().describe('Initial load timeout in milliseconds'),
+      batchNotifications: z.boolean().optional().describe('Batch capability change notifications'),
+      batchDelay: z.number().int().min(0).optional().describe('Batch delay in milliseconds'),
+    })
+    .optional(),
+  lazyLoading: z
+    .object({
+      enabled: z.boolean().optional().describe('Enable lazy loading for tools'),
+      mode: z.enum(['full', 'metatool', 'hybrid']).optional().describe('Lazy loading mode'),
+      cacheMaxEntries: z.number().int().min(0).optional().describe('Maximum tool schemas to cache'),
+      inlineCatalog: z.boolean().optional().describe('Include full tool catalog in initialize template'),
+    })
+    .optional(),
+  configReload: z
+    .object({
+      enabled: z.boolean().optional().describe('Enable automatic configuration hot-reload'),
+      debounce: z.number().int().min(0).optional().describe('Debounce delay in milliseconds'),
+    })
+    .optional(),
+});
+
+/**
+ * Keys allowed in the global MCP configuration section
+ */
+export const GLOBAL_TRANSPORT_CONFIG_KEYS = [
+  'env',
+  'timeout',
+  'connectionTimeout',
+  'requestTimeout',
+  'oauth',
+  'headers',
+  'inheritParentEnv',
+] as const;
+
+/**
+ * Zod schema for global MCP configuration
+ * Only includes shareable settings that can be inherited by servers.
+ */
+export const globalTransportConfigSchema = transportConfigSchema.pick({
+  env: true,
+  timeout: true,
+  connectionTimeout: true,
+  requestTimeout: true,
+  oauth: true,
+  headers: true,
+  inheritParentEnv: true,
+});
+
+/**
  * Union type for all transport configurations
  */
 export type TransportConfig = HTTPBasedTransportConfig | StdioTransportConfig;
@@ -228,6 +352,8 @@ export interface TemplateServerConfig {
 export interface MCPServerConfiguration {
   /** Version of the configuration format for migration purposes */
   version?: string;
+  /** Shareable defaults inherited by all MCP servers (transport settings only) */
+  serverDefaults?: GlobalTransportConfig;
   /** Static server configurations (no template processing) */
   mcpServers: Record<string, MCPServerParams>;
   /** Template-based server configurations (processed with context) */
@@ -253,6 +379,9 @@ export const templateSettingsSchema = z.object({
  */
 export const mcpServerConfigSchema = z.object({
   version: z.string().optional().describe('Version of the configuration format for migration purposes'),
+  serverDefaults: globalTransportConfigSchema
+    .optional()
+    .describe('Shareable defaults inherited by all MCP servers (transport settings only)'),
   mcpServers: z
     .record(z.string(), transportConfigSchema)
     .describe('Static server configurations (no template processing)'),

--- a/src/core/types/transport.ts
+++ b/src/core/types/transport.ts
@@ -154,6 +154,7 @@ export const oAuthConfigSchema = z.object({
   clientSecret: z.string().optional().describe('OAuth client secret for authentication'),
   scopes: z.array(z.string()).optional().describe('OAuth scopes to request'),
   autoRegister: z.boolean().optional().describe('Automatically register OAuth client if not already registered'),
+  redirectUrl: z.string().optional().describe('OAuth redirect URL used after auth'),
 });
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -99,6 +99,17 @@ describe('Index Module', () => {
       expect(serverOptions['enable-scope-validation'].default).toBe(true);
       expect(serverOptions['enable-enhanced-security'].default).toBe(false);
     });
+
+    it('should normalize argv forwarded through a script runner', async () => {
+      const { normalizeCliArgv } = await import('./index.js');
+
+      expect(normalizeCliArgv(['--', '--config', '.tmp/mcp.json', '--port', '3052'])).toEqual([
+        '--config',
+        '.tmp/mcp.json',
+        '--port',
+        '3052',
+      ]);
+    });
   });
 
   describe('Environment Variables', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -94,10 +94,15 @@ describe('Index Module', () => {
       expect('default' in serverOptions.transport).toBe(false);
 
       expect(serverOptions.pagination.default).toBe(false);
-      expect(serverOptions.auth.default).toBe(false);
-      expect(serverOptions['enable-auth'].default).toBe(false);
-      expect(serverOptions['enable-scope-validation'].default).toBe(true);
-      expect(serverOptions['enable-enhanced-security'].default).toBe(false);
+      expect('default' in serverOptions.auth).toBe(false);
+      expect('default' in serverOptions['enable-auth']).toBe(false);
+      expect('default' in serverOptions['enable-scope-validation']).toBe(false);
+      expect('default' in serverOptions['enable-enhanced-security']).toBe(false);
+      expect('default' in serverOptions['session-ttl']).toBe(false);
+      expect('default' in serverOptions['rate-limit-window']).toBe(false);
+      expect('default' in serverOptions['enable-async-loading']).toBe(false);
+      expect('default' in serverOptions['enable-lazy-loading']).toBe(false);
+      expect('default' in serverOptions['enable-config-reload']).toBe(false);
     });
 
     it('should normalize argv forwarded through a script runner', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -92,7 +92,6 @@ describe('Index Module', () => {
           describe: 'Transport type to use (stdio or http, sse is deprecated)',
           type: 'string',
           choices: ['stdio', 'http', 'sse'],
-          default: 'http',
         },
         port: {
           alias: 'P',
@@ -146,7 +145,7 @@ describe('Index Module', () => {
       expect(expectedOptions.transport.choices).toContain('stdio');
       expect(expectedOptions.transport.choices).toContain('http');
       expect(expectedOptions.transport.choices).toContain('sse');
-      expect(expectedOptions.transport.default).toBe('http');
+      expect('default' in expectedOptions.transport).toBe(false);
 
       expect(expectedOptions.pagination.default).toBe(false);
       expect(expectedOptions.auth.default).toBe(false);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -84,74 +84,20 @@ describe('Index Module', () => {
   });
 
   describe('CLI Argument Structure', () => {
-    it('should define expected CLI options structure', () => {
-      // Test the structure of CLI options that would be used by yargs
-      const expectedOptions = {
-        transport: {
-          alias: 't',
-          describe: 'Transport type to use (stdio or http, sse is deprecated)',
-          type: 'string',
-          choices: ['stdio', 'http', 'sse'],
-        },
-        port: {
-          alias: 'P',
-          describe: 'HTTP port to listen on, applicable when transport is http',
-          type: 'number',
-        },
-        host: {
-          alias: 'H',
-          describe: 'HTTP host to listen on, applicable when transport is http',
-          type: 'string',
-        },
-        config: {
-          alias: 'c',
-          describe: 'Path to the config file',
-          type: 'string',
-        },
-        tags: {
-          alias: 'g',
-          describe: 'Tags to filter clients (comma-separated)',
-          type: 'string',
-        },
-        pagination: {
-          alias: 'p',
-          describe: 'Enable pagination',
-          type: 'boolean',
-          default: false,
-        },
-        auth: {
-          describe: 'Enable authentication (OAuth 2.1) - deprecated, use --enable-auth',
-          type: 'boolean',
-          default: false,
-        },
-        'enable-auth': {
-          describe: 'Enable authentication (OAuth 2.1)',
-          type: 'boolean',
-          default: false,
-        },
-        'enable-scope-validation': {
-          describe: 'Enable tag-based scope validation',
-          type: 'boolean',
-          default: true,
-        },
-        'enable-enhanced-security': {
-          describe: 'Enable enhanced security middleware',
-          type: 'boolean',
-          default: false,
-        },
-      };
+    it('should define expected CLI options structure', async () => {
+      const { serverOptions } = await import('./commands/serve/index.js');
 
       // Verify the option structure is well-formed
-      expect(expectedOptions.transport.choices).toContain('stdio');
-      expect(expectedOptions.transport.choices).toContain('http');
-      expect(expectedOptions.transport.choices).toContain('sse');
-      expect('default' in expectedOptions.transport).toBe(false);
+      expect(serverOptions.transport.choices).toContain('stdio');
+      expect(serverOptions.transport.choices).toContain('http');
+      expect(serverOptions.transport.choices).toContain('sse');
+      expect('default' in serverOptions.transport).toBe(false);
 
-      expect(expectedOptions.pagination.default).toBe(false);
-      expect(expectedOptions.auth.default).toBe(false);
-      expect(expectedOptions['enable-auth'].default).toBe(false);
-      expect(expectedOptions['enable-scope-validation'].default).toBe(true);
-      expect(expectedOptions['enable-enhanced-security'].default).toBe(false);
+      expect(serverOptions.pagination.default).toBe(false);
+      expect(serverOptions.auth.default).toBe(false);
+      expect(serverOptions['enable-auth'].default).toBe(false);
+      expect(serverOptions['enable-scope-validation'].default).toBe(true);
+      expect(serverOptions['enable-enhanced-security'].default).toBe(false);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,16 @@ import { setupRunCommand } from './commands/run/index.js';
 import { serverOptions, setupServeCommand } from './commands/serve/index.js';
 import { configureGlobalLogger } from './logger/configureGlobalLogger.js';
 
+export function normalizeCliArgv(argv: string[]): string[] {
+  if (argv[0] === '--') {
+    return argv.slice(1);
+  }
+
+  return argv;
+}
+
 // Parse command line arguments and set up commands
-let yargsInstance = yargs(hideBin(process.argv));
+let yargsInstance = yargs(normalizeCliArgv(hideBin(process.argv)));
 
 // Set up base yargs with global options
 yargsInstance = yargsInstance
@@ -134,7 +142,7 @@ function checkGlobalOptionConflicts(argv: string[]): void {
  */
 async function main() {
   // Check for global option conflicts before parsing
-  checkGlobalOptionConflicts(process.argv);
+  checkGlobalOptionConflicts(['node', 'cli', ...normalizeCliArgv(hideBin(process.argv))]);
 
   // Let yargs handle all command processing
   await yargsInstance.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@
 import { MCP_SERVER_VERSION } from '@src/constants.js';
 import { GlobalOptions, globalOptions } from '@src/globalOptions.js';
 import logger from '@src/logger/logger.js';
+import { normalizeCliArgv, normalizedArgv } from '@src/utils/cli/normalizedArgv.js';
 
 import 'source-map-support/register.js';
 import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
 
 import { setupAppCommands } from './commands/app/index.js';
 import { setupAuthCommands } from './commands/auth/index.js';
@@ -20,16 +20,10 @@ import { setupRunCommand } from './commands/run/index.js';
 import { serverOptions, setupServeCommand } from './commands/serve/index.js';
 import { configureGlobalLogger } from './logger/configureGlobalLogger.js';
 
-export function normalizeCliArgv(argv: string[]): string[] {
-  if (argv[0] === '--') {
-    return argv.slice(1);
-  }
-
-  return argv;
-}
+export { normalizeCliArgv, normalizedArgv };
 
 // Parse command line arguments and set up commands
-let yargsInstance = yargs(normalizeCliArgv(hideBin(process.argv)));
+let yargsInstance = yargs(normalizedArgv);
 
 // Set up base yargs with global options
 yargsInstance = yargsInstance
@@ -142,7 +136,7 @@ function checkGlobalOptionConflicts(argv: string[]): void {
  */
 async function main() {
   // Check for global option conflicts before parsing
-  checkGlobalOptionConflicts(['node', 'cli', ...normalizeCliArgv(hideBin(process.argv))]);
+  checkGlobalOptionConflicts(['node', 'cli', ...normalizedArgv]);
 
   // Let yargs handle all command processing
   await yargsInstance.parse();

--- a/src/utils/cli/normalizedArgv.ts
+++ b/src/utils/cli/normalizedArgv.ts
@@ -1,0 +1,11 @@
+import { hideBin } from 'yargs/helpers';
+
+export function normalizeCliArgv(argv: string[]): string[] {
+  if (argv[0] === '--') {
+    return argv.slice(1);
+  }
+
+  return argv;
+}
+
+export const normalizedArgv = normalizeCliArgv(hideBin(process.argv));

--- a/src/utils/validation/urlDetection.ts
+++ b/src/utils/validation/urlDetection.ts
@@ -1,6 +1,7 @@
 import { getConfigDir } from '@src/constants.js';
 import { cleanupPidFile, readPidFile } from '@src/core/server/pidFileManager.js';
 import { createSafeErrorMessage } from '@src/logger/secureLogger.js';
+import { normalizedArgv } from '@src/utils/cli/normalizedArgv.js';
 
 /**
  * Multi-method URL detection system for app commands.
@@ -14,7 +15,7 @@ import { createSafeErrorMessage } from '@src/logger/secureLogger.js';
  * Method 1: Detect URL from CLI arguments (highest priority)
  */
 export function detectUrlFromCliArgs(): string {
-  const args = process.argv;
+  const args = normalizedArgv;
 
   // Parse external-url flag
   const externalUrlIndex = args.findIndex((arg) => arg === '--external-url' || arg === '-u');

--- a/test/e2e/commands/error-scenarios.test.ts
+++ b/test/e2e/commands/error-scenarios.test.ts
@@ -37,11 +37,13 @@ describe('Error Scenarios E2E', () => {
       const malformedConfig = '{ "servers": [ { "name": "test", "command": incomplete json';
       await writeFile(environment.getConfigPath(), malformedConfig);
 
-      const result = await runner.runMcpCommand('list');
+      const result = await runner.runMcpCommand('list', {
+        expectError: true,
+      });
 
-      // CLI gracefully handles malformed config by showing "No MCP servers are configured"
-      runner.assertSuccess(result);
-      runner.assertOutputContains(result, 'No MCP servers are configured');
+      runner.assertFailure(result, 1);
+      runner.assertOutputContains(result, 'Failed to list servers', true);
+      runner.assertOutputContains(result, 'Invalid JSON in configuration file', true);
     });
 
     it('should handle config file with invalid structure', async () => {
@@ -83,11 +85,13 @@ describe('Error Scenarios E2E', () => {
     it('should handle empty config file', async () => {
       await writeFile(environment.getConfigPath(), '');
 
-      const result = await runner.runMcpCommand('list');
+      const result = await runner.runMcpCommand('list', {
+        expectError: true,
+      });
 
-      // CLI gracefully handles empty config by showing "No MCP servers are configured"
-      runner.assertSuccess(result);
-      runner.assertOutputContains(result, 'No MCP servers are configured');
+      runner.assertFailure(result, 1);
+      runner.assertOutputContains(result, 'Failed to list servers', true);
+      runner.assertOutputContains(result, 'Invalid JSON in configuration file', true);
     });
 
     it('should handle config file with circular references', async () => {

--- a/test/e2e/commands/mcp/mcp-list.test.ts
+++ b/test/e2e/commands/mcp/mcp-list.test.ts
@@ -202,11 +202,13 @@ describe('MCP List Command E2E', () => {
       const malformedConfigPath = environment.getConfigPath();
       await fs.writeFile(malformedConfigPath, '{ invalid json');
 
-      const result = await runner.runMcpCommand('list');
+      const result = await runner.runMcpCommand('list', {
+        expectError: true,
+      });
 
-      // CLI handles malformed config gracefully, showing empty list
-      runner.assertSuccess(result);
-      runner.assertOutputContains(result, 'No MCP servers are configured');
+      runner.assertFailure(result, 1);
+      runner.assertOutputContains(result, 'Failed to list servers', true);
+      runner.assertOutputContains(result, 'Invalid JSON in configuration file', true);
     });
 
     it('should show help when --help is used', async () => {


### PR DESCRIPTION
## Summary
- add shared serverDefaults support for MCP config loading, merging, listing, status output, examples, and schema/docs
- preserve CLI-over-config precedence while letting 1mcp serve honor config.toml transport, host, and port when flags are omitted
- add regression coverage for config merging and real CLI parsing behavior

## Testing
- rtk pnpm vitest run src/config/mcpConfigManager.test.ts src/config/mcpConfigMerge.test.ts src/commands/serve/index.test.ts src/commands/serve/serve.test.ts src/index.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global server defaults (shared timeouts, env, headers, OAuth) with per-server inheritance; CLI now shows a “Global Defaults” section and per-server “Inherited” keys. Added app-level TOML config support, an example TOML, and a new streamableHttp transport; improved effective-config behavior for list/status commands.
* **Documentation**
  * Migration guide, examples, and schema/docs updated for serverDefaults and merge semantics.
* **Tests**
  * Expanded coverage for merging, app-config loading, CLI precedence, error scenarios, and command output.
* **Chores**
  * Added TOML parsing dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->