### PR TITLE
fix: allow esbuild builds in pnpm workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,10 +163,5 @@
     "vitepress": "^1.6.3",
     "vitepress-plugin-mermaid": "^2.0.17",
     "vitest": "^1.4.0"
-  },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - '.'
+
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary
- Replace the package.json pnpm ignoredBuiltDependencies entry with pnpm-workspace.yaml allowBuilds.
- Declare the root package in pnpm-workspace.yaml so workspace-level pnpm config is applied.

## Verification
- Not run; PR metadata update only.