### PR TITLE
fix: harden browser-origin security boundaries

### DIFF
--- a/src/auth/sdkOAuthServerProvider.test.ts
+++ b/src/auth/sdkOAuthServerProvider.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 
+import type { AuthorizationParams } from '@modelcontextprotocol/sdk/server/auth/provider.js';
 import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -114,6 +115,62 @@ describe('SDKOAuthProvider', () => {
         // Restore original method
         configManager.get('features').auth = originalIsAuthEnabled;
       }
+    });
+
+    it('should escape client_name in consent page HTML', () => {
+      const maliciousClient: OAuthClientInformationFull = {
+        client_id: 'malicious-client',
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        redirect_uris: ['http://localhost:3000/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+        client_name: '<img src=x onerror=alert(1)>',
+      };
+
+      const html = provider['generateConsentPageHtml'](
+        maliciousClient,
+        'auth-request-123',
+        ['context7'],
+        ['context7', 'playwright'],
+      );
+
+      expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+      expect(html).not.toContain('<title>Authorize <img src=x onerror=alert(1)></title>');
+      expect(html).not.toContain('<strong><img src=x onerror=alert(1)></strong>');
+    });
+
+    it('should set restrictive CSP headers when rendering the consent page', async () => {
+      const client: OAuthClientInformationFull = {
+        client_id: 'test-client',
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        redirect_uris: ['http://localhost:3000/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+        client_name: 'Test Client',
+      };
+      const params: AuthorizationParams = {
+        redirectUri: 'http://localhost:3000/callback',
+        codeChallenge: 'challenge-123',
+        state: 'state-123',
+        scopes: ['tag:context7'],
+      };
+      const response = {
+        set: vi.fn(),
+        send: vi.fn(),
+        removeHeader: vi.fn(),
+      } as any;
+
+      await provider['renderConsentPage'](client, params, ['tag:context7'], ['context7'], response);
+
+      expect(response.set).toHaveBeenCalledWith(
+        'Content-Security-Policy',
+        "default-src 'none'; form-action 'self'; style-src 'unsafe-inline'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none';",
+      );
+      expect(response.set).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(response.send).toHaveBeenCalledTimes(1);
+      expect(response.removeHeader).not.toHaveBeenCalledWith('Content-Security-Policy');
     });
   });
 });

--- a/src/auth/sdkOAuthServerProvider.test.ts
+++ b/src/auth/sdkOAuthServerProvider.test.ts
@@ -140,6 +140,29 @@ describe('SDKOAuthProvider', () => {
       expect(html).not.toContain('<strong><img src=x onerror=alert(1)></strong>');
     });
 
+    it('should escape auth request id and tag values in consent page HTML', () => {
+      const client: OAuthClientInformationFull = {
+        client_id: 'test-client',
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        redirect_uris: ['http://localhost:3000/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+        client_name: 'Test Client',
+      };
+      const maliciousAuthRequestId = 'auth-request-123" autofocus onfocus="alert(1)';
+      const maliciousTag = 'context7"><script>alert(1)</script>';
+
+      const html = provider['generateConsentPageHtml'](client, maliciousAuthRequestId, [maliciousTag], [maliciousTag]);
+
+      expect(html).toContain('auth-request-123&quot; autofocus onfocus=&quot;alert(1)');
+      expect(html).toContain('context7&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+      expect(html).not.toContain(`value="${maliciousAuthRequestId}"`);
+      expect(html).not.toContain(`id="scope_${maliciousTag}"`);
+      expect(html).not.toContain(`value="tag:${maliciousTag}"`);
+      expect(html).not.toContain(`<strong>${maliciousTag}</strong>`);
+    });
+
     it('should set restrictive CSP headers when rendering the consent page', async () => {
       const client: OAuthClientInformationFull = {
         client_id: 'test-client',

--- a/src/auth/sdkOAuthServerProvider.ts
+++ b/src/auth/sdkOAuthServerProvider.ts
@@ -13,6 +13,7 @@ import { McpConfigManager } from '@src/config/mcpConfigManager.js';
 import { AUTH_CONFIG } from '@src/constants.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
 import logger from '@src/logger/logger.js';
+import { escapeHtml } from '@src/utils/validation/sanitization.js';
 import {
   auditScopeOperation,
   scopesToTags,
@@ -23,6 +24,9 @@ import {
 import type { Response } from 'express';
 
 import { OAuthStorageService } from './storage/oauthStorageService.js';
+
+const OAUTH_CONSENT_PAGE_CSP =
+  "default-src 'none'; form-action 'self'; style-src 'unsafe-inline'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none';";
 
 /**
  * File-based OAuth clients store implementation using the new repository architecture
@@ -172,8 +176,7 @@ export class SDKOAuthServerProvider implements OAuthServerProvider {
     const scopeTags = scopesToTags(requestedScopes);
     const consentPageHtml = this.generateConsentPageHtml(client, authRequestId, scopeTags, availableTags);
 
-    // Remove any CSP that might interfere with form submission
-    res.removeHeader('Content-Security-Policy');
+    res.set('Content-Security-Policy', OAUTH_CONSENT_PAGE_CSP);
     res.set('Content-Type', 'text/html');
     res.send(consentPageHtml);
   }
@@ -231,7 +234,7 @@ export class SDKOAuthServerProvider implements OAuthServerProvider {
     requestedTags: string[],
     availableTags: string[],
   ): string {
-    const clientName = client.client_name || client.client_id;
+    const clientName = escapeHtml(client.client_name || client.client_id);
 
     return `
 <!DOCTYPE html>

--- a/src/auth/sdkOAuthServerProvider.ts
+++ b/src/auth/sdkOAuthServerProvider.ts
@@ -235,6 +235,7 @@ export class SDKOAuthServerProvider implements OAuthServerProvider {
     availableTags: string[],
   ): string {
     const clientName = escapeHtml(client.client_name || client.client_id);
+    const escapedAuthRequestId = escapeHtml(authRequestId);
 
     return `
 <!DOCTYPE html>
@@ -274,30 +275,32 @@ export class SDKOAuthServerProvider implements OAuthServerProvider {
         </div>
 
         <form method="POST" action="/oauth/consent">
-            <input type="hidden" name="auth_request_id" value="${authRequestId}">
+            <input type="hidden" name="auth_request_id" value="${escapedAuthRequestId}">
 
             <div class="scopes-section">
                 <h3>Server Access Permissions</h3>
                 <p>Select which server groups this application can access:</p>
 
                 ${availableTags
-                  .map(
-                    (tag) => `
+                  .map((tag) => {
+                    const escapedTag = escapeHtml(tag);
+
+                    return `
                     <div class="scope-item">
                         <input type="checkbox"
-                               id="scope_${tag}"
+                               id="scope_${escapedTag}"
                                name="scopes"
-                               value="tag:${tag}"
+                               value="tag:${escapedTag}"
                                ${requestedTags.includes(tag) ? 'checked' : ''}>
-                        <label for="scope_${tag}">
-                            <strong>${tag}</strong> servers
+                        <label for="scope_${escapedTag}">
+                            <strong>${escapedTag}</strong> servers
                         </label>
                     </div>
                     <div class="tag-description">
-                        Access servers tagged with "${tag}"
+                        Access servers tagged with "${escapedTag}"
                     </div>
-                `,
-                  )
+                `;
+                  })
                   .join('')}
             </div>
 

--- a/src/transport/http/routes/apiRoutes.test.ts
+++ b/src/transport/http/routes/apiRoutes.test.ts
@@ -1,10 +1,13 @@
 import { type ServerAdapter, ServerStatus, ServerType } from '@src/core/server/adapters/types.js';
 import { ClientStatus, type OutboundConnections } from '@src/core/types/index.js';
 
+import express from 'express';
 import type { Request, RequestHandler, Response } from 'express';
+import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  createApiRoutes,
   createInspectHandler,
   createServersHandler,
   createToolInvocationsHandler,
@@ -1001,6 +1004,27 @@ describe('apiRoutes /api/tool-invocations', () => {
     res.locals.tagFilterMode = 'none';
     next();
   };
+
+  it('rejects browser-origin POST requests before reaching the tool invocation handler', async () => {
+    const serverManager = {
+      getLazyLoadingOrchestrator: vi.fn(() => undefined),
+      getClient: vi.fn(() => undefined),
+      getClients: vi.fn(() => new Map()),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1', createApiRoutes(serverManager as never, scopeAuthMiddleware));
+
+    const response = await request(app)
+      .post('/api/v1/tool-invocations')
+      .set('Origin', 'http://evil.example.com')
+      .send({ tool: 'server/tool' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: 'Cross-origin requests are not allowed for this endpoint' });
+    expect(serverManager.getLazyLoadingOrchestrator).not.toHaveBeenCalled();
+    expect(serverManager.getClient).not.toHaveBeenCalled();
+  });
 
   it('returns 400 when tool field is missing', async () => {
     const serverManager = { getLazyLoadingOrchestrator: vi.fn(() => undefined) };

--- a/src/transport/http/routes/apiRoutes.test.ts
+++ b/src/transport/http/routes/apiRoutes.test.ts
@@ -1,10 +1,13 @@
 import { type ServerAdapter, ServerStatus, ServerType } from '@src/core/server/adapters/types.js';
 import { ClientStatus, type OutboundConnections } from '@src/core/types/index.js';
 
+import express from 'express';
 import type { Request, RequestHandler, Response } from 'express';
+import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  createApiRoutes,
   createInspectHandler,
   createServersHandler,
   createToolInvocationsHandler,
@@ -1110,6 +1113,27 @@ describe('apiRoutes /api/tool-invocations', () => {
 
   beforeEach(() => {
     mockedGetTransportConfig.mockReturnValue({});
+  });
+
+  it('rejects browser-origin POST requests before reaching the tool invocation handler', async () => {
+    const serverManager = {
+      getLazyLoadingOrchestrator: vi.fn(() => undefined),
+      getClient: vi.fn(() => undefined),
+      getClients: vi.fn(() => new Map()),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1', createApiRoutes(serverManager as never, scopeAuthMiddleware));
+
+    const response = await request(app)
+      .post('/api/v1/tool-invocations')
+      .set('Origin', 'http://evil.example.com')
+      .send({ tool: 'server/tool' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: 'Cross-origin requests are not allowed for this endpoint' });
+    expect(serverManager.getLazyLoadingOrchestrator).not.toHaveBeenCalled();
+    expect(serverManager.getClient).not.toHaveBeenCalled();
   });
 
   it('returns 400 when tool field is missing', async () => {

--- a/src/transport/http/routes/apiRoutes.ts
+++ b/src/transport/http/routes/apiRoutes.ts
@@ -1,7 +1,7 @@
 import { ServerManager } from '@src/core/server/serverManager.js';
 import tagsExtractor from '@src/transport/http/middlewares/tagsExtractor.js';
 
-import { RequestHandler, Router } from 'express';
+import { NextFunction, Request, RequestHandler, Response, Router } from 'express';
 
 import { createInspectHandler, createServersHandler } from './inspectRoutes.js';
 import { createToolInvocationsHandler, createToolsHandler } from './toolRoutes.js';
@@ -27,13 +27,28 @@ export type { SDKOAuthServerProvider } from '@src/auth/sdkOAuthServerProvider.js
 
 // ---- Route factory ----
 
+export function rejectBrowserOriginRequests(req: Request, res: Response, next: NextFunction): void {
+  if (req.headers.origin) {
+    res.status(403).json({ error: 'Cross-origin requests are not allowed for this endpoint' });
+    return;
+  }
+
+  next();
+}
+
 export function createApiRoutes(serverManager: ServerManager, scopeAuthMiddleware: RequestHandler): Router {
   const router = Router();
 
   router.get('/inspect', tagsExtractor, scopeAuthMiddleware, createInspectHandler(serverManager));
   router.get('/servers', tagsExtractor, scopeAuthMiddleware, createServersHandler(serverManager));
   router.get('/tools', tagsExtractor, scopeAuthMiddleware, createToolsHandler(serverManager));
-  router.post('/tool-invocations', tagsExtractor, scopeAuthMiddleware, createToolInvocationsHandler(serverManager));
+  router.post(
+    '/tool-invocations',
+    rejectBrowserOriginRequests,
+    tagsExtractor,
+    scopeAuthMiddleware,
+    createToolInvocationsHandler(serverManager),
+  );
 
   return router;
 }

--- a/src/transport/http/server.test.ts
+++ b/src/transport/http/server.test.ts
@@ -433,6 +433,32 @@ describe('ExpressServer', () => {
       expect(mockApp.use.mock.calls.length).toBeGreaterThanOrEqual(4);
     });
 
+    it('should configure CORS with explicit origin validation', async () => {
+      const cors = await import('cors');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      const corsOptions = vi.mocked(cors.default).mock.calls[0][0] as {
+        origin: (origin: string | undefined, callback: (err: Error | null, origin?: boolean | string) => void) => void;
+      };
+      const resolveOrigin = (origin: string | undefined): boolean | string | undefined => {
+        let allowedOrigin: boolean | string | undefined;
+        corsOptions.origin(origin, (_err, resolvedOrigin) => {
+          allowedOrigin = resolvedOrigin;
+        });
+        return allowedOrigin;
+      };
+
+      expect(cors.default).toHaveBeenCalledWith(
+        expect.objectContaining({
+          origin: expect.any(Function),
+        }),
+      );
+      expect(resolveOrigin('http://evil.example.com')).toBe(false);
+      expect(resolveOrigin('http://localhost:5173')).toBe('http://localhost:5173');
+      expect(resolveOrigin('http://127.0.0.1:3050')).toBe('http://127.0.0.1:3050');
+    });
+
     it('should handle security middleware conditionally', async () => {
       const { setupSecurityMiddleware } = await import('./middlewares/securityMiddleware.js');
       vi.mocked(setupSecurityMiddleware).mockReturnValue([vi.fn()]);

--- a/src/transport/http/server.test.ts
+++ b/src/transport/http/server.test.ts
@@ -457,6 +457,8 @@ describe('ExpressServer', () => {
       expect(resolveOrigin('http://evil.example.com')).toBe(false);
       expect(resolveOrigin('http://localhost:5173')).toBe('http://localhost:5173');
       expect(resolveOrigin('http://127.0.0.1:3050')).toBe('http://127.0.0.1:3050');
+      expect(resolveOrigin('http://[::1]:3050')).toBe('http://[::1]:3050');
+      expect(resolveOrigin('http://127.0.1.1:3050')).toBe('http://127.0.1.1:3050');
     });
 
     it('should handle security middleware conditionally', async () => {

--- a/src/transport/http/server.ts
+++ b/src/transport/http/server.ts
@@ -19,7 +19,7 @@ import { httpRequestLogger } from './middlewares/httpRequestLogger.js';
 import { createMcpAvailabilityMiddleware } from './middlewares/mcpAvailabilityMiddleware.js';
 import { createScopeAuthMiddleware } from './middlewares/scopeAuthMiddleware.js';
 import { setupSecurityMiddleware } from './middlewares/securityMiddleware.js';
-import { createApiRoutes, createCliTokenRoute } from './routes/apiRoutes.js';
+import { createApiRoutes, createCliTokenRoute, rejectBrowserOriginRequests } from './routes/apiRoutes.js';
 import createHealthRoutes from './routes/healthRoutes.js';
 import createOAuthRoutes from './routes/oauthRoutes.js';
 import { setupSseRoutes } from './routes/sseRoutes.js';
@@ -34,6 +34,22 @@ interface CompatibleRateLimitOptions {
   standardHeaders?: boolean;
   legacyHeaders?: boolean;
   handler?: (req: express.Request, res: express.Response) => void;
+}
+
+function isLoopbackOrigin(origin: string | undefined): boolean {
+  if (!origin) {
+    return false;
+  }
+
+  try {
+    const { hostname, protocol } = new URL(origin);
+    return (
+      (protocol === 'http:' || protocol === 'https:') &&
+      (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1')
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -119,7 +135,13 @@ export class ExpressServer {
     // Add HTTP request logging middleware (early in the stack for complete coverage)
     this.app.use(httpRequestLogger);
 
-    this.app.use(cors()); // Allow all origins for local dev
+    this.app.use(
+      cors({
+        origin: (origin, callback) => {
+          callback(null, isLoopbackOrigin(origin) ? origin : false);
+        },
+      }),
+    );
     this.app.use(bodyParser.json());
     this.app.use(bodyParser.urlencoded({ extended: true }));
 
@@ -184,20 +206,8 @@ export class ExpressServer {
     this.app.use('/health', createHealthRoutes(this.loadingManager));
 
     // CLI token endpoint (localhost-only, no auth middleware).
-    // Reject requests with an Origin header — browsers always send it for cross-origin
-    // requests, so this prevents any web page from silently obtaining a full-scope token
-    // even though the global cors() middleware is permissive.
-    this.app.post(
-      '/api/auth/cli-token',
-      (req, res, next) => {
-        if (req.headers.origin) {
-          res.status(403).json({ error: 'Cross-origin requests are not allowed for this endpoint' });
-          return;
-        }
-        next();
-      },
-      createCliTokenRoute(this.oauthProvider),
-    );
+    // Reject browser-origin requests so a web page cannot silently obtain a full-scope token.
+    this.app.post('/api/auth/cli-token', rejectBrowserOriginRequests, createCliTokenRoute(this.oauthProvider));
 
     // Setup API routes (CLI-oriented fast endpoints, auth via scopeAuthMiddleware)
     const scopeAuthMiddleware = createScopeAuthMiddleware(this.oauthProvider);

--- a/src/transport/http/server.ts
+++ b/src/transport/http/server.ts
@@ -43,9 +43,16 @@ function isLoopbackOrigin(origin: string | undefined): boolean {
 
   try {
     const { hostname, protocol } = new URL(origin);
+    const normalizedHost = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+    const hostParts = normalizedHost.split('.');
+    const isIPv4Loopback =
+      hostParts.length === 4 &&
+      hostParts[0] === '127' &&
+      hostParts.every((part) => /^\d+$/.test(part) && Number(part) <= 255);
+
     return (
       (protocol === 'http:' || protocol === 'https:') &&
-      (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1')
+      (normalizedHost === 'localhost' || normalizedHost === '::1' || isIPv4Loopback)
     );
   } catch {
     return false;


### PR DESCRIPTION
Summary:
- Escape OAuth consent client names and apply a restrictive CSP to the consent page.
- Restrict CORS to loopback origins and reject browser-origin requests for CLI token and tool invocation endpoints.

Validation:
- pnpm test:unit src/auth/sdkOAuthServerProvider.test.ts src/transport/http/routes/apiRoutes.test.ts src/transport/http/server.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced OAuth consent page security with HTML escaping and Content-Security-Policy header enforcement
  * Strengthened cross-origin request handling by restricting tool invocation endpoint to loopback origins only
  * Configured CORS to allow requests only from localhost and loopback addresses

* **Tests**
  * Added validation tests for OAuth consent page security measures
  * Added cross-origin request rejection verification tests
  * Added CORS origin validation tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1mcp-app/agent/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->