### PR TITLE
fix(loading): fix hot-reload visibility and per-server race conditions

### DIFF
--- a/src/core/capabilities/asyncLoadingOrchestrator.test.ts
+++ b/src/core/capabilities/asyncLoadingOrchestrator.test.ts
@@ -26,6 +26,7 @@ describe('AsyncLoadingOrchestrator', () => {
     mockServerManager = {
       getServer: vi.fn(),
       getInboundConnections: vi.fn().mockReturnValue(new Map()),
+      recordMcpServerReady: vi.fn(),
     };
 
     mockLoadingManager = {
@@ -201,6 +202,7 @@ describe('AsyncLoadingOrchestrator', () => {
 
       await serverLoadedHandler('test-server', { success: true });
 
+      expect(mockServerManager.recordMcpServerReady).toHaveBeenCalledWith('test-server');
       expect(mockAggregator.updateCapabilities).toHaveBeenCalled();
     });
 

--- a/src/core/capabilities/asyncLoadingOrchestrator.ts
+++ b/src/core/capabilities/asyncLoadingOrchestrator.ts
@@ -127,6 +127,7 @@ export class AsyncLoadingOrchestrator extends EventEmitter {
     this.loadingManager.on('server-loaded', (serverName: string, _result: ServerLoadResult) => {
       if (this.isShuttingDown) return;
 
+      this.serverManager.recordMcpServerReady(serverName);
       debugIf(() => ({ message: `Server ${serverName} became ready, updating capabilities`, meta: { serverName } }));
       this.handleServerReady(serverName);
     });

--- a/src/core/configChangeHandler.test.ts
+++ b/src/core/configChangeHandler.test.ts
@@ -10,6 +10,8 @@ vi.mock('@src/core/server/serverManager.js', () => ({
       startServer: vi.fn().mockResolvedValue(undefined),
       stopServer: vi.fn().mockResolvedValue(undefined),
       restartServer: vi.fn().mockResolvedValue(undefined),
+      loadMcpServer: vi.fn().mockResolvedValue(undefined),
+      unloadMcpServer: vi.fn().mockResolvedValue(undefined),
       updateServerMetadata: vi.fn().mockResolvedValue(undefined),
       isMcpServerRunning: vi.fn().mockReturnValue(true), // Assume server is running for metadata update tests
       getInboundConnections: vi.fn().mockReturnValue(new Map()),
@@ -96,7 +98,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.startServer).toHaveBeenCalledWith('new-server', newConfig['new-server']);
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith('new-server', newConfig['new-server']);
     });
   });
 
@@ -114,7 +116,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.stopServer).toHaveBeenCalledWith('removed-server');
+      expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('removed-server');
     });
   });
 
@@ -142,7 +144,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).toHaveBeenCalledWith('modified-server', newConfig['modified-server']);
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith('modified-server', newConfig['modified-server']);
     });
 
     it('should NOT restart servers for tag-only changes', async () => {
@@ -169,7 +171,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).not.toHaveBeenCalled();
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
       expect(mockConfigManager.emit).toHaveBeenCalledWith('metadataUpdated', {
         serverName: 'tag-only-server',
         config: newConfig['tag-only-server'],
@@ -199,7 +201,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'unknown-change-server',
         newConfig['unknown-change-server'],
       );
@@ -228,7 +230,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'empty-changes-server',
         newConfig['empty-changes-server'],
       );
@@ -309,13 +311,13 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.startServer).toHaveBeenCalledWith('added-server', newConfig['added-server']);
-      expect(ServerManager.current.stopServer).toHaveBeenCalledWith('removed-server');
-      expect(ServerManager.current.restartServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith('added-server', newConfig['added-server']);
+      expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('removed-server');
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'restarted-server',
         newConfig['restarted-server'],
       );
-      expect(ServerManager.current.restartServer).not.toHaveBeenCalledWith('metadata-server', expect.any(Object));
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalledWith('metadata-server', expect.any(Object));
     });
   });
 
@@ -345,9 +347,9 @@ describe('ConfigChangeHandler', () => {
 
       mockConfigManager.getTransportConfig = vi.fn(() => newConfig);
 
-      // Make startServer fail for the first server
+      // Make the ServerManager hot-reload facade fail for the first server
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      (ServerManager.current.startServer as ReturnType<typeof vi.fn>)
+      (ServerManager.current.loadMcpServer as ReturnType<typeof vi.fn>)
         .mockRejectedValueOnce(new Error('Server start failed'))
         .mockResolvedValueOnce(undefined);
 
@@ -359,8 +361,8 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       // Should still attempt to start the second server
-      expect(ServerManager.current.startServer).toHaveBeenCalledTimes(2);
-      expect(ServerManager.current.startServer).toHaveBeenCalledWith('success-server', newConfig['success-server']);
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledTimes(2);
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith('success-server', newConfig['success-server']);
 
       consoleSpy.mockRestore();
     });
@@ -391,9 +393,9 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.stopServer).toHaveBeenCalledWith('disabled-server');
-      expect(ServerManager.current.startServer).not.toHaveBeenCalled();
-      expect(ServerManager.current.restartServer).not.toHaveBeenCalled();
+      expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('disabled-server');
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
     });
 
     it('should start servers when disabled field changes to false', async () => {
@@ -420,12 +422,12 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.startServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         're-enabled-server',
         newConfig['re-enabled-server'],
       );
-      expect(ServerManager.current.stopServer).not.toHaveBeenCalled();
-      expect(ServerManager.current.restartServer).not.toHaveBeenCalled();
+      // Re-enable loads the server; it must not unload it.
+      expect(ServerManager.current.unloadMcpServer).not.toHaveBeenCalled();
     });
 
     it('should stop servers when disabled is true regardless of other field changes', async () => {
@@ -452,9 +454,9 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.stopServer).toHaveBeenCalledWith('disabled-with-other-changes');
-      expect(ServerManager.current.startServer).not.toHaveBeenCalled();
-      expect(ServerManager.current.restartServer).not.toHaveBeenCalled();
+      expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('disabled-with-other-changes');
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
     });
 
     it('should restart servers for non-disabled field changes when disabled is false', async () => {
@@ -481,12 +483,13 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'non-disabled-changes',
         newConfig['non-disabled-changes'],
       );
-      expect(ServerManager.current.startServer).not.toHaveBeenCalled();
-      expect(ServerManager.current.stopServer).not.toHaveBeenCalled();
+      // Functional modify reloads via loadMcpServer; ConfigChangeHandler does not
+      // call unloadMcpServer directly (ServerManager handles the internal reload).
+      expect(ServerManager.current.unloadMcpServer).not.toHaveBeenCalled();
     });
 
     it('should update metadata when only tags change on a disabled server', async () => {
@@ -514,8 +517,8 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.stopServer).toHaveBeenCalledWith('disabled-metadata-update');
-      expect(ServerManager.current.restartServer).not.toHaveBeenCalled();
+      expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('disabled-metadata-update');
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
     });
 
     it('should handle mixed disable/enable changes with other servers', async () => {
@@ -603,22 +606,22 @@ describe('ConfigChangeHandler', () => {
       const { ServerManager } = await import('@src/core/server/serverManager.js');
 
       // Verify disabled server is stopped
-      expect(ServerManager.current.stopServer).toHaveBeenCalledWith('disabled-server');
+      expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('disabled-server');
 
       // Verify re-enabled server is started
-      expect(ServerManager.current.startServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         're-enabled-server',
         newConfig['re-enabled-server'],
       );
 
       // Verify normal modified server is restarted
-      expect(ServerManager.current.restartServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'normal-modified-server',
         newConfig['normal-modified-server'],
       );
 
       // Verify tag-only server does not get restarted
-      expect(ServerManager.current.restartServer).not.toHaveBeenCalledWith('tag-only-server', expect.any(Object));
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalledWith('tag-only-server', expect.any(Object));
     });
   });
 
@@ -648,7 +651,7 @@ describe('ConfigChangeHandler', () => {
       const { ServerManager } = await import('@src/core/server/serverManager.js');
       // Even though it's an ADD event, it should still start the server initially
       // The transport factory will handle skipping disabled servers
-      expect(ServerManager.current.startServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'initially-disabled-server',
         newConfig['initially-disabled-server'],
       );
@@ -680,7 +683,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.stopServer).toHaveBeenCalledWith('rapid-change-server');
+      expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('rapid-change-server');
 
       // Reset mocks for next change
       vi.clearAllMocks();
@@ -698,7 +701,7 @@ describe('ConfigChangeHandler', () => {
 
       await changeHandler(changes);
 
-      expect(ServerManager.current.startServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'rapid-change-server',
         newConfig['rapid-change-server'],
       );
@@ -728,7 +731,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'undefined-disabled-server',
         newConfig['undefined-disabled-server'],
       );
@@ -753,9 +756,11 @@ describe('ConfigChangeHandler', () => {
 
       mockConfigManager.getTransportConfig = vi.fn(() => newConfig);
 
-      // Make stopServer fail
+      // Make the ServerManager hot-reload facade fail while unloading
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      (ServerManager.current.stopServer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Stop failed'));
+      (ServerManager.current.unloadMcpServer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Stop failed'),
+      );
 
       // Mock console.error to capture error logs
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -763,10 +768,10 @@ describe('ConfigChangeHandler', () => {
       // Simulate config change event
       const changeHandler = (mockConfigManager.on as any).mock.calls[0][1];
 
-      // Should not throw error even if stopServer fails
+      // Should not throw error even if unload fails
       await expect(changeHandler(changes)).resolves.toBeUndefined();
 
-      expect(ServerManager.current.stopServer).toHaveBeenCalledWith('stop-error-server');
+      expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('stop-error-server');
 
       consoleSpy.mockRestore();
     });
@@ -790,9 +795,11 @@ describe('ConfigChangeHandler', () => {
 
       mockConfigManager.getTransportConfig = vi.fn(() => newConfig);
 
-      // Make startServer fail
+      // Make the ServerManager hot-reload facade fail while loading
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      (ServerManager.current.startServer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Start failed'));
+      (ServerManager.current.loadMcpServer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Start failed'),
+      );
 
       // Mock console.error to capture error logs
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -800,10 +807,10 @@ describe('ConfigChangeHandler', () => {
       // Simulate config change event
       const changeHandler = (mockConfigManager.on as any).mock.calls[0][1];
 
-      // Should not throw error even if startServer fails
+      // Should not throw error even if load fails
       await expect(changeHandler(changes)).resolves.toBeUndefined();
 
-      expect(ServerManager.current.startServer).toHaveBeenCalledWith(
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalledWith(
         'start-error-server',
         newConfig['start-error-server'],
       );
@@ -844,7 +851,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).toHaveBeenCalled();
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalled();
     });
 
     it('should return false for tag-only field changes', async () => {
@@ -871,7 +878,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).not.toHaveBeenCalled();
+      expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
     });
 
     it('should return true for mixed field changes (including tags)', async () => {
@@ -898,7 +905,7 @@ describe('ConfigChangeHandler', () => {
       await changeHandler(changes);
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
-      expect(ServerManager.current.restartServer).toHaveBeenCalled();
+      expect(ServerManager.current.loadMcpServer).toHaveBeenCalled();
     });
   });
 });

--- a/src/core/configChangeHandler.ts
+++ b/src/core/configChangeHandler.ts
@@ -1,6 +1,6 @@
 import { CONFIG_EVENTS, ConfigChange, ConfigChangeType, ConfigManager } from '@src/config/configManager.js';
 import { ServerManager } from '@src/core/server/serverManager.js';
-import { MCPServerParams } from '@src/core/types/transport.js';
+import { MCPServerParams } from '@src/core/types/index.js';
 import logger, { debugIf } from '@src/logger/logger.js';
 
 /**
@@ -109,19 +109,24 @@ export class ConfigChangeHandler {
   }
 
   /**
-   * Handle server addition
+   * Handle server addition.
+   *
+   * Routes through ServerManager's hot-reload facade so config changes have a
+   * single lifecycle entry point. ServerManager owns the coordination between
+   * the loading pipeline and lifecycle/status tracking.
    */
   private async handleServerAdded(serverName: string, config: MCPServerParams): Promise<void> {
     logger.info(`Starting new server: ${serverName}`);
-    await this.getServerManager().startServer(serverName, config);
+    await this.getServerManager().loadMcpServer(serverName, config);
   }
 
   /**
-   * Handle server removal
+   * Handle server removal — unload via the canonical pipeline so the tracker
+   * entry is cleared (no ghost in /health/mcp).
    */
   private async handleServerRemoved(serverName: string): Promise<void> {
     logger.info(`Stopping server: ${serverName}`);
-    await this.getServerManager().stopServer(serverName);
+    await this.getServerManager().unloadMcpServer(serverName);
   }
 
   /**
@@ -138,7 +143,7 @@ export class ConfigChangeHandler {
     if (config.disabled) {
       // Server was disabled
       logger.info(`Stopping server (disabled): ${serverName}`);
-      await this.getServerManager().stopServer(serverName);
+      await this.getServerManager().unloadMcpServer(serverName);
       return;
     }
 
@@ -153,14 +158,16 @@ export class ConfigChangeHandler {
           disabled: config.disabled,
         },
       });
-      await this.getServerManager().startServer(serverName, config);
+      await this.getServerManager().loadMcpServer(serverName, config);
       return;
     }
 
     // Business logic: determine if this requires server restart
     if (this.requiresServerRestart(fieldsChanged)) {
       logger.info(`Restarting server (functional changes): ${serverName}`);
-      await this.getServerManager().restartServer(serverName, config);
+      // loadMcpServer is idempotent: ServerManager coordinates unload/reload
+      // through the canonical loading pipeline and lifecycle registry.
+      await this.getServerManager().loadMcpServer(serverName, config);
     } else {
       // Only tags changed - update metadata without restart
       logger.info(`Updating server metadata only (no restart needed): ${serverName}`);

--- a/src/core/loading/loadingStateTracker.test.ts
+++ b/src/core/loading/loadingStateTracker.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { LoadingState, LoadingStateEvent, LoadingStateTracker } from './loadingStateTracker.js';
+
+describe('LoadingStateTracker.registerServer', () => {
+  it('adds a single server at runtime without resetting other servers', () => {
+    const tracker = new LoadingStateTracker();
+    tracker.startLoading(['boot-server']);
+    tracker.updateServerState('boot-server', LoadingState.Ready);
+
+    // Hot-reload add: a new server appears after boot.
+    tracker.registerServer('hot-server');
+
+    expect(tracker.getServerState('hot-server')).toBeDefined();
+    expect(tracker.getServerState('hot-server')!.state).toBe(LoadingState.Pending);
+    // The boot server's state is untouched.
+    expect(tracker.getServerState('boot-server')!.state).toBe(LoadingState.Ready);
+    expect(tracker.getSummary().totalServers).toBe(2);
+  });
+
+  it('is a no-op if the server is already tracked (preserves its state)', () => {
+    const tracker = new LoadingStateTracker();
+    tracker.startLoading(['s']);
+    tracker.updateServerState('s', LoadingState.AwaitingOAuth);
+
+    tracker.registerServer('s'); // should not reset to Pending
+
+    expect(tracker.getServerState('s')!.state).toBe(LoadingState.AwaitingOAuth);
+    expect(tracker.getSummary().totalServers).toBe(1);
+  });
+
+  it('makes the server visible in the awaitingOAuth summary after it transitions', () => {
+    // Reproduces the fix: a hot-reload-added server that needs OAuth must show
+    // up in /health/mcp (summary.awaitingOAuth), not be invisible.
+    const tracker = new LoadingStateTracker();
+    tracker.registerServer('server1');
+    tracker.updateServerState('server1', LoadingState.AwaitingOAuth);
+
+    expect(tracker.getSummary().awaitingOAuth).toBe(1);
+    expect(tracker.getServerState('server1')!.state).toBe(LoadingState.AwaitingOAuth);
+  });
+});
+
+describe('LoadingStateTracker.removeServer', () => {
+  it('removes a tracked server so it no longer appears in state or summary', () => {
+    const tracker = new LoadingStateTracker();
+    tracker.startLoading(['alpha', 'beta']);
+
+    // alpha gets stuck awaiting OAuth (the real-world ghost scenario).
+    tracker.updateServerState('alpha', LoadingState.AwaitingOAuth);
+    tracker.updateServerState('beta', LoadingState.Ready);
+
+    expect(tracker.getServerState('alpha')).toBeDefined();
+    expect(tracker.getSummary().awaitingOAuth).toBe(1);
+
+    const removed = tracker.removeServer('alpha');
+
+    expect(removed).toBe(true);
+    expect(tracker.getServerState('alpha')).toBeUndefined();
+    expect(tracker.getAllServerStates().has('alpha')).toBe(false);
+    // The ghost is gone from the summary that /health/mcp reports.
+    expect(tracker.getSummary().awaitingOAuth).toBe(0);
+    expect(tracker.getSummary().totalServers).toBe(1);
+    // Unrelated servers are untouched.
+    expect(tracker.getServerState('beta')).toBeDefined();
+  });
+
+  it('returns false and is a no-op when the server is not tracked', () => {
+    const tracker = new LoadingStateTracker();
+    tracker.startLoading(['alpha']);
+
+    const removed = tracker.removeServer('does-not-exist');
+
+    expect(removed).toBe(false);
+    expect(tracker.getSummary().totalServers).toBe(1);
+  });
+
+  it('emits a progress update when a tracked server is removed', () => {
+    const tracker = new LoadingStateTracker();
+    tracker.startLoading(['alpha']);
+    tracker.updateServerState('alpha', LoadingState.AwaitingOAuth);
+
+    const onProgress = vi.fn();
+    tracker.on(LoadingStateEvent.LoadingProgress, onProgress);
+
+    tracker.removeServer('alpha');
+
+    expect(onProgress).toHaveBeenCalled();
+  });
+});

--- a/src/core/loading/loadingStateTracker.ts
+++ b/src/core/loading/loadingStateTracker.ts
@@ -126,6 +126,23 @@ export class LoadingStateTracker extends EventEmitter {
   }
 
   /**
+   * Register a single server for tracking at runtime (hot-reload add) without
+   * resetting global loading timing. Use this instead of {@link startLoading}
+   * when a server is added after the initial boot load. No-op if already known.
+   */
+  public registerServer(name: string): void {
+    if (this.servers.has(name)) return;
+    this.loadingStarted = true;
+    this.servers.set(name, {
+      name,
+      state: LoadingState.Pending,
+      retryCount: 0,
+    });
+    debugIf(() => ({ message: `Registered server for loading tracker: ${name}` }));
+    this.emitProgress();
+  }
+
+  /**
    * Update the state of a specific server
    */
   public updateServerState(
@@ -277,6 +294,27 @@ export class LoadingStateTracker extends EventEmitter {
    */
   public getServersByState(state: LoadingState): ServerLoadingInfo[] {
     return Array.from(this.servers.values()).filter((s) => s.state === state);
+  }
+
+  /**
+   * Remove a server from tracking.
+   *
+   * Used when a server is removed from the configuration (including renames,
+   * which are processed as a remove of the old name plus an add of the new
+   * one). Without this, a removed server's last state — e.g. AwaitingOAuth or
+   * Failed — lingers forever in the tracker and is still reported by
+   * `/health/mcp`, producing a "ghost" server in the health view that no
+   * longer exists in the configuration.
+   *
+   * @returns true if a tracked server was removed, false if it was not tracked.
+   */
+  public removeServer(name: string): boolean {
+    const existed = this.servers.delete(name);
+    if (existed) {
+      debugIf(() => ({ message: `Removed server from loading tracker: ${name}` }));
+      this.emitProgress();
+    }
+    return existed;
   }
 
   /**

--- a/src/core/loading/mcpLoadingManager.test.ts
+++ b/src/core/loading/mcpLoadingManager.test.ts
@@ -1,0 +1,683 @@
+/**
+ * Unit tests for McpLoadingManager — focusing on the per-server operation
+ * abort signal introduced to fix three confirmed race conditions:
+ *
+ *   A. loadServer → unloadServer while retry-loop is sleeping
+ *      → loop must stop immediately; server must NOT be re-inserted into
+ *        outboundConns or the tracker after removal.
+ *
+ *   B. Two concurrent loadServer('X') calls (TOCTOU on tracker check)
+ *      → second call must cancel the first; only one final connection exists.
+ *
+ *   C. performBackgroundRetry (fire-and-forget) + concurrent unloadServer
+ *      → background loadSingleServer must not re-add an orphaned connection
+ *        after the server is removed.
+ *
+ * Mock strategy
+ * ─────────────
+ * • ClientManager — constructor arg, hand-crafted Partial<ClientManager> with vi.fn().
+ *   createSingleClient is the primary control point: we resolve / reject it manually
+ *   via a deferred promise to simulate slow or never-completing connections.
+ * • transportFactory.createTransports — vi.mock'd at module level; returns a fake
+ *   transport by default, can be overridden per-test.
+ * • LoadingStateTracker — NOT mocked; we verify through manager.getStateTracker()
+ *   so the real state-transition logic is exercised.
+ * • No fake timers — sleep / timeout are made fast by setting very low config values.
+ */
+// ── Helpers ───────────────────────────────────────────────────────────────────
+import { createTransports } from '@src/transport/transportFactory.js';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LoadingState } from './loadingStateTracker.js';
+import { McpLoadingEvent, McpLoadingManager } from './mcpLoadingManager.js';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@src/transport/transportFactory.js', () => ({
+  createTransports: vi.fn(),
+}));
+
+vi.mock('@src/logger/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  debugIf: vi.fn(),
+}));
+
+const mockCreateTransports = vi.mocked(createTransports);
+
+/** A fake transport that satisfies the AuthProviderTransport interface. */
+const makeFakeTransport = () => ({
+  start: vi.fn().mockResolvedValue(undefined),
+  send: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+  onclose: undefined,
+  onerror: undefined,
+  onmessage: undefined,
+});
+
+/** Deferred helper — lets a test control when createSingleClient resolves. */
+function makeDeferred() {
+  let resolve!: () => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Yield to the microtask / timer queue so queued async work can run. */
+const yieldToEventLoop = () => new Promise<void>((r) => setTimeout(r, 0));
+
+/** Build a ClientManager mock. `createSingleClient` is controlled by the caller. */
+function makeClientManagerMock(createSingleClientImpl?: () => Promise<void>) {
+  const outboundConns = new Map();
+  const transports: Record<string, unknown> = {};
+
+  return {
+    getClients: vi.fn().mockReturnValue(outboundConns),
+    getTransport: vi.fn((name: string) => transports[name]),
+    createSingleClient: vi.fn(
+      createSingleClientImpl ??
+        (() => {
+          // Default: resolve immediately (successful connection)
+          outboundConns.set('__last__', {});
+          return Promise.resolve();
+        }),
+    ),
+    removeClient: vi.fn(async (name: string) => {
+      outboundConns.delete(name);
+      delete transports[name];
+    }),
+    setInstructionAggregator: vi.fn(),
+    // Expose so tests can inspect / manipulate
+    _outboundConns: outboundConns,
+    _transports: transports,
+  };
+}
+
+/** Fast loading config to avoid 30 s timeouts and 2 s retry delays in tests. */
+const FAST_CONFIG = {
+  serverTimeoutMs: 200,
+  maxRetries: 2,
+  retryDelayMs: 10,
+  maxConcurrentLoads: 5,
+  continueOnFailure: true,
+  enableBackgroundRetry: false, // disabled by default; override per test
+  backgroundRetryIntervalMs: 100,
+};
+
+/** Minimal MCPServerParams for a stdio server. */
+const makeServerConfig = (overrides: Record<string, unknown> = {}) =>
+  ({
+    command: 'echo',
+    args: [],
+    disabled: false,
+    ...overrides,
+  }) as Parameters<McpLoadingManager['loadServer']>[1];
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+describe('McpLoadingManager', () => {
+  let clientManager: ReturnType<typeof makeClientManagerMock>;
+  let manager: McpLoadingManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clientManager = makeClientManagerMock();
+    // Default transport factory: return one fake transport
+    mockCreateTransports.mockImplementation((cfg) => {
+      const result: Record<string, ReturnType<typeof makeFakeTransport>> = {};
+      for (const name of Object.keys(cfg)) {
+        result[name] = makeFakeTransport();
+      }
+      return result as ReturnType<typeof createTransports>;
+    });
+    manager = new McpLoadingManager(clientManager as never, FAST_CONFIG);
+  });
+
+  afterEach(() => {
+    manager.shutdown();
+  });
+
+  // ── static .current ─────────────────────────────────────────────────────────
+
+  describe('static current', () => {
+    it('is set to the most recently constructed instance', () => {
+      expect(McpLoadingManager.current).toBe(manager);
+    });
+
+    it('throws if no instance has been constructed', () => {
+      // Access private static via bracket notation for test isolation
+      const saved = (McpLoadingManager as unknown as { _current: unknown })._current;
+      (McpLoadingManager as unknown as { _current: unknown })._current = undefined;
+      expect(() => McpLoadingManager.current).toThrow('McpLoadingManager not initialized');
+      (McpLoadingManager as unknown as { _current: unknown })._current = saved;
+    });
+  });
+
+  // ── loadServer — happy path ─────────────────────────────────────────────────
+
+  describe('loadServer — happy path', () => {
+    it('tracks server through Pending → Loading → Ready', async () => {
+      await manager.loadServer('my-server', makeServerConfig());
+
+      const state = manager.getStateTracker().getServerState('my-server');
+      expect(state?.state).toBe(LoadingState.Ready);
+    });
+
+    it('emits ServerLoaded event on success', async () => {
+      const spy = vi.fn();
+      manager.on(McpLoadingEvent.ServerLoaded, spy);
+
+      await manager.loadServer('my-server', makeServerConfig());
+
+      expect(spy).toHaveBeenCalledWith('my-server', expect.objectContaining({ success: true }));
+    });
+
+    it('skips disabled server and calls unloadServer to clear stale state', async () => {
+      // First load a server so there is state to clear
+      await manager.loadServer('srv', makeServerConfig());
+      expect(manager.getStateTracker().getServerState('srv')?.state).toBe(LoadingState.Ready);
+
+      // Now disable it
+      await manager.loadServer('srv', makeServerConfig({ disabled: true }));
+
+      expect(manager.getStateTracker().getServerState('srv')).toBeUndefined();
+      expect(clientManager.removeClient).toHaveBeenCalledWith('srv');
+    });
+
+    it('marks server as Failed when transport factory throws', async () => {
+      mockCreateTransports.mockImplementationOnce(() => {
+        throw new Error('bad config');
+      });
+
+      await manager.loadServer('srv', makeServerConfig());
+
+      const state = manager.getStateTracker().getServerState('srv');
+      expect(state?.state).toBe(LoadingState.Failed);
+      expect(state?.error?.message).toMatch('bad config');
+    });
+
+    it('copies OAuth authorization URL into loading tracker when authorization is required', async () => {
+      const authorizationUrl = 'https://auth.example.com/authorize?client_id=abc';
+      const oauthTransport = {
+        ...makeFakeTransport(),
+        oauthProvider: {
+          getAuthorizationUrl: vi.fn().mockReturnValue(authorizationUrl),
+        },
+      };
+      const oauthRequired = new Error('OAuth authorization required for srv');
+      oauthRequired.name = 'OAuthRequiredError';
+
+      mockCreateTransports.mockImplementationOnce(
+        () => ({ srv: oauthTransport }) as unknown as ReturnType<typeof createTransports>,
+      );
+      clientManager.createSingleClient.mockRejectedValueOnce(oauthRequired);
+
+      const oauthRequiredSpy = vi.fn();
+      manager.on(McpLoadingEvent.OAuthRequired, oauthRequiredSpy);
+
+      await manager.loadServer('srv', makeServerConfig({ type: 'http', url: 'https://mcp.example.com' }));
+
+      const state = manager.getStateTracker().getServerState('srv');
+      expect(state?.state).toBe(LoadingState.AwaitingOAuth);
+      expect(state?.authorizationUrl).toBe(authorizationUrl);
+      expect(oauthRequiredSpy).toHaveBeenCalledWith('srv', authorizationUrl);
+    });
+
+    it('skips silently when transport factory returns undefined for server', async () => {
+      mockCreateTransports.mockImplementationOnce(() => ({}) as ReturnType<typeof createTransports>);
+
+      await manager.loadServer('srv', makeServerConfig());
+
+      // Server should not appear in tracker at all (transport was missing)
+      expect(manager.getStateTracker().getServerState('srv')).toBeUndefined();
+    });
+  });
+
+  // ── loadServer — idempotent reload ──────────────────────────────────────────
+
+  describe('loadServer — idempotent reload', () => {
+    it('unloads existing server before reloading (functional modify)', async () => {
+      await manager.loadServer('srv', makeServerConfig());
+      expect(manager.getStateTracker().getServerState('srv')?.state).toBe(LoadingState.Ready);
+
+      await manager.loadServer('srv', makeServerConfig({ env: { KEY: 'new' } }));
+
+      // removeClient called at least once for the reload
+      expect(clientManager.removeClient).toHaveBeenCalledWith('srv');
+      // Final state: Ready again
+      expect(manager.getStateTracker().getServerState('srv')?.state).toBe(LoadingState.Ready);
+    });
+
+    it('old tracker entry is cleared before new load registers', async () => {
+      await manager.loadServer('srv', makeServerConfig());
+
+      const statesBefore: LoadingState[] = [];
+      manager.getStateTracker().on('server-state-changed', (_name, info) => {
+        if (_name === 'srv') statesBefore.push(info.state);
+      });
+
+      await manager.loadServer('srv', makeServerConfig({ env: { K: 'v' } }));
+
+      // registerServer sets Pending as the initial value but does NOT emit
+      // ServerStateChanged (it emits LoadingProgress). The first real state
+      // transition observable via ServerStateChanged is Loading → Ready.
+      // We verify the sequence ends with Ready and goes through Loading.
+      expect(statesBefore).toContain(LoadingState.Loading);
+      expect(statesBefore[statesBefore.length - 1]).toBe(LoadingState.Ready);
+    });
+  });
+
+  // ── unloadServer ────────────────────────────────────────────────────────────
+
+  describe('unloadServer', () => {
+    it('removes server from tracker', async () => {
+      await manager.loadServer('srv', makeServerConfig());
+      expect(manager.getStateTracker().getServerState('srv')).toBeDefined();
+
+      await manager.unloadServer('srv');
+
+      expect(manager.getStateTracker().getServerState('srv')).toBeUndefined();
+    });
+
+    it('calls clientManager.removeClient', async () => {
+      await manager.loadServer('srv', makeServerConfig());
+      await manager.unloadServer('srv');
+
+      expect(clientManager.removeClient).toHaveBeenCalledWith('srv');
+    });
+
+    it('is a no-op for an unknown server (does not throw)', async () => {
+      await expect(manager.unloadServer('nonexistent')).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Race A: unloadServer cancels in-flight retry sleep ─────────────────────
+
+  describe('Race A — unloadServer cancels in-flight load', () => {
+    it('aborts retry sleep immediately: no state written after removal', async () => {
+      // Make createSingleClient always fail so the retry loop runs
+      const failingManager = makeClientManagerMock(() => Promise.reject(new Error('conn refused')));
+      const mgr = new McpLoadingManager(
+        failingManager as never,
+        { ...FAST_CONFIG, maxRetries: 3, retryDelayMs: 5000 }, // long retry delay
+      );
+
+      // Start loading without awaiting — it will hang in the first retry sleep
+      const loadPromise = mgr.loadServer('srv', makeServerConfig());
+
+      // Yield so loadSingleServer enters its first retry sleep
+      await yieldToEventLoop();
+      await yieldToEventLoop();
+
+      // Unload while the retry sleep is in progress
+      await mgr.unloadServer('srv');
+
+      // The loadServer promise should resolve cleanly (no throw)
+      await expect(loadPromise).resolves.toBeUndefined();
+
+      // Server must NOT be in the tracker — the retry loop stopped cleanly
+      expect(mgr.getStateTracker().getServerState('srv')).toBeUndefined();
+
+      mgr.shutdown();
+    });
+
+    it('does not mark server as Failed when cancelled mid-retry', async () => {
+      const failingManager = makeClientManagerMock(() => Promise.reject(new Error('conn refused')));
+      const mgr = new McpLoadingManager(failingManager as never, {
+        ...FAST_CONFIG,
+        maxRetries: 3,
+        retryDelayMs: 5000,
+      });
+
+      const serverFailedSpy = vi.fn();
+      mgr.on(McpLoadingEvent.ServerFailed, serverFailedSpy);
+
+      const loadPromise = mgr.loadServer('srv', makeServerConfig());
+      await yieldToEventLoop();
+      await yieldToEventLoop();
+
+      await mgr.unloadServer('srv');
+      await loadPromise;
+
+      // ServerFailed must NOT have been emitted — cancellation is intentional
+      expect(serverFailedSpy).not.toHaveBeenCalled();
+
+      mgr.shutdown();
+    });
+
+    it('aborts active connection attempt when unloadServer is called', async () => {
+      // createSingleClient hangs until we abort it
+      const deferred = makeDeferred();
+      const blockingManager = makeClientManagerMock(() => deferred.promise);
+      const mgr = new McpLoadingManager(blockingManager as never, FAST_CONFIG);
+
+      const loadPromise = mgr.loadServer('srv', makeServerConfig());
+      await yieldToEventLoop();
+
+      // Unload while connection is in-flight
+      await mgr.unloadServer('srv');
+
+      // Resolve the deferred AFTER unload to simulate late network reply
+      deferred.resolve();
+      await loadPromise;
+
+      // Server must not appear in tracker
+      expect(mgr.getStateTracker().getServerState('srv')).toBeUndefined();
+
+      mgr.shutdown();
+    });
+  });
+
+  // ── Race B: concurrent loadServer calls ─────────────────────────────────────
+
+  describe('Race B — concurrent loadServer calls cancel each other correctly', () => {
+    it('second loadServer cancels first; final state is Ready from second', async () => {
+      // First call: connection hangs indefinitely
+      const deferred = makeDeferred();
+      let callCount = 0;
+      const controlledManager = makeClientManagerMock(() => {
+        callCount++;
+        if (callCount === 1) return deferred.promise; // first call hangs
+        return Promise.resolve(); // second call succeeds
+      });
+
+      const mgr = new McpLoadingManager(controlledManager as never, FAST_CONFIG);
+
+      // Start first load (will hang)
+      const first = mgr.loadServer('srv', makeServerConfig());
+      await yieldToEventLoop();
+
+      // Start second load concurrently — should cancel the first
+      const second = mgr.loadServer('srv', makeServerConfig({ env: { v: '2' } }));
+
+      // Unblock the first deferred (simulating late network response)
+      deferred.resolve();
+
+      await Promise.all([first, second]);
+
+      // Only one tracker entry should exist (Ready from the second load)
+      expect(mgr.getStateTracker().getServerState('srv')?.state).toBe(LoadingState.Ready);
+      // removeClient should have been called to clean up the first attempt
+      expect(controlledManager.removeClient).toHaveBeenCalledWith('srv');
+
+      mgr.shutdown();
+    });
+
+    it('two loadServer calls for different servers do not interfere', async () => {
+      await Promise.all([
+        manager.loadServer('srv-a', makeServerConfig()),
+        manager.loadServer('srv-b', makeServerConfig()),
+      ]);
+
+      expect(manager.getStateTracker().getServerState('srv-a')?.state).toBe(LoadingState.Ready);
+      expect(manager.getStateTracker().getServerState('srv-b')?.state).toBe(LoadingState.Ready);
+    });
+  });
+
+  // ── Race C: background retry + unloadServer ─────────────────────────────────
+
+  describe('Race C — performBackgroundRetry does not orphan connections after unload', () => {
+    it('background retry is cancelled by unloadServer before it can re-add connection', async () => {
+      // Set up a manager with background retry enabled
+      const deferred = makeDeferred();
+      let callCount = 0;
+      const controlledManager = makeClientManagerMock(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // First call (initial load): fail so server goes to Failed state
+          throw new Error('initial failure');
+        }
+        // Subsequent calls (background retry): hang until deferred resolves
+        return deferred.promise;
+      });
+      // Give background retry a transport to work with
+      controlledManager.getTransport.mockImplementation(() => makeFakeTransport());
+
+      const mgr = new McpLoadingManager(controlledManager as never, {
+        ...FAST_CONFIG,
+        continueOnFailure: true,
+        enableBackgroundRetry: true,
+        backgroundRetryIntervalMs: 50,
+      });
+
+      // Load once — will fail, server goes to Failed
+      await mgr.loadServer('srv', makeServerConfig());
+      expect(mgr.getStateTracker().getServerState('srv')?.state).toBe(LoadingState.Failed);
+
+      // Wait for background retry to start (50 ms interval)
+      await new Promise((r) => setTimeout(r, 80));
+      await yieldToEventLoop();
+
+      // Now unload while background retry's loadSingleServer is hanging
+      await mgr.unloadServer('srv');
+
+      // Unblock the deferred (simulates network response arriving late)
+      deferred.resolve();
+      await yieldToEventLoop();
+      await yieldToEventLoop();
+
+      // Server must NOT be in tracker — background retry was cancelled
+      expect(mgr.getStateTracker().getServerState('srv')).toBeUndefined();
+      // removeClient should have been called
+      expect(controlledManager.removeClient).toHaveBeenCalledWith('srv');
+
+      mgr.shutdown();
+    });
+  });
+
+  // ── shutdown cancels all operations ─────────────────────────────────────────
+
+  describe('shutdown', () => {
+    it('aborts all in-flight server op controllers', async () => {
+      // loadServer with a hanging connection
+      const deferred = makeDeferred();
+      const blockingManager = makeClientManagerMock(() => deferred.promise);
+      const mgr = new McpLoadingManager(blockingManager as never, FAST_CONFIG);
+
+      const loadPromise = mgr.loadServer('srv', makeServerConfig());
+      await yieldToEventLoop();
+
+      mgr.shutdown();
+      deferred.resolve(); // unblock after shutdown
+      await loadPromise;
+
+      // Server should not be in Ready state after shutdown aborted the load
+      const state = mgr.getStateTracker().getServerState('srv');
+      // Either undefined (removed) or not Ready
+      expect(state?.state).not.toBe(LoadingState.Ready);
+    });
+
+    it('marks pending/loading servers as Cancelled', async () => {
+      // Use a very slow createSingleClient so server stays Loading during shutdown
+      const deferred = makeDeferred();
+      const blockingManager = makeClientManagerMock(() => deferred.promise);
+      const mgr = new McpLoadingManager(blockingManager as never, {
+        ...FAST_CONFIG,
+        serverTimeoutMs: 60000, // long timeout so it stays Loading
+      });
+
+      // Start loading; don't await
+      mgr.startAsyncLoading({ srv: makeFakeTransport() as never });
+      await yieldToEventLoop();
+
+      mgr.shutdown();
+      deferred.resolve();
+      await yieldToEventLoop();
+
+      const state = mgr.getStateTracker().getServerState('srv');
+      expect(state?.state).toBe(LoadingState.Cancelled);
+    });
+  });
+
+  // ── cancelServerOperation is idempotent ─────────────────────────────────────
+
+  describe('cancelServerOperation (via public surface)', () => {
+    it('calling unloadServer twice does not throw', async () => {
+      await manager.loadServer('srv', makeServerConfig());
+      await expect(manager.unloadServer('srv')).resolves.toBeUndefined();
+      // Second call on already-removed server
+      await expect(manager.unloadServer('srv')).resolves.toBeUndefined();
+    });
+  });
+
+  // ── cancelServerLoading / cancelAllLoading — public cancel APIs ──────────────
+
+  describe('cancelServerLoading', () => {
+    it('cancels a server sleeping between retries (not in abortControllers)', async () => {
+      // Server always fails so it enters retry sleep
+      const failingManager = makeClientManagerMock(() => Promise.reject(new Error('conn refused')));
+      const mgr = new McpLoadingManager(failingManager as never, {
+        ...FAST_CONFIG,
+        maxRetries: 5,
+        retryDelayMs: 5000, // long sleep so it stays there
+      });
+
+      const loadPromise = mgr.loadServer('srv', makeServerConfig());
+      // Yield past the first failure so the retry sleep begins
+      await yieldToEventLoop();
+      await yieldToEventLoop();
+
+      // Server is sleeping between retries — abortControllers will be empty,
+      // only serverOpAbortControllers has an entry.
+      mgr.cancelServerLoading('srv');
+      await loadPromise;
+
+      // Must be Cancelled, not Loading/Failed/Ready
+      const state = mgr.getStateTracker().getServerState('srv');
+      expect(state?.state).toBe(LoadingState.Cancelled);
+
+      mgr.shutdown();
+    });
+
+    it('cancels a server mid-connection-attempt (in abortControllers)', async () => {
+      const deferred = makeDeferred();
+      const blockingManager = makeClientManagerMock(() => deferred.promise);
+      const mgr = new McpLoadingManager(blockingManager as never, FAST_CONFIG);
+
+      const loadPromise = mgr.loadServer('srv', makeServerConfig());
+      await yieldToEventLoop();
+
+      mgr.cancelServerLoading('srv');
+      deferred.resolve();
+      await loadPromise;
+
+      const state = mgr.getStateTracker().getServerState('srv');
+      expect(state?.state).toBe(LoadingState.Cancelled);
+
+      mgr.shutdown();
+    });
+
+    it('warns and is a no-op for an unknown / already-finished server', () => {
+      // Should not throw
+      expect(() => manager.cancelServerLoading('nonexistent')).not.toThrow();
+    });
+  });
+
+  describe('cancelAllLoading', () => {
+    it('cancels initial async-loading servers sleeping between retries', async () => {
+      const failingManager = makeClientManagerMock(() => Promise.reject(new Error('initial fail')));
+      const mgr = new McpLoadingManager(failingManager as never, {
+        ...FAST_CONFIG,
+        maxRetries: 5,
+        retryDelayMs: 500,
+      });
+
+      try {
+        mgr.startAsyncLoading({ srv: makeFakeTransport() as never });
+        await yieldToEventLoop();
+        await yieldToEventLoop();
+
+        expect(mgr.getCancellableServers()).toContain('srv');
+
+        mgr.cancelAllLoading();
+        await yieldToEventLoop();
+
+        expect(mgr.getStateTracker().getServerState('srv')?.state).toBe(LoadingState.Cancelled);
+      } finally {
+        mgr.shutdown();
+      }
+    });
+
+    it('cancels servers sleeping between retries (not visible in old abortControllers only)', async () => {
+      const failingManager = makeClientManagerMock(() => Promise.reject(new Error('fail')));
+      const mgr = new McpLoadingManager(failingManager as never, {
+        ...FAST_CONFIG,
+        maxRetries: 5,
+        retryDelayMs: 5000,
+      });
+
+      const p1 = mgr.loadServer('srv-a', makeServerConfig());
+      const p2 = mgr.loadServer('srv-b', makeServerConfig());
+      await yieldToEventLoop();
+      await yieldToEventLoop();
+
+      // Both servers are sleeping in retry — cancelAllLoading must reach them
+      mgr.cancelAllLoading();
+      await Promise.all([p1, p2]);
+
+      expect(mgr.getStateTracker().getServerState('srv-a')?.state).toBe(LoadingState.Cancelled);
+      expect(mgr.getStateTracker().getServerState('srv-b')?.state).toBe(LoadingState.Cancelled);
+
+      mgr.shutdown();
+    });
+  });
+
+  describe('getCancellableServers', () => {
+    it('includes servers sleeping between retries, not just mid-connection ones', async () => {
+      const failingManager = makeClientManagerMock(() => Promise.reject(new Error('fail')));
+      const mgr = new McpLoadingManager(failingManager as never, {
+        ...FAST_CONFIG,
+        maxRetries: 5,
+        retryDelayMs: 5000,
+      });
+
+      const loadPromise = mgr.loadServer('srv', makeServerConfig());
+      await yieldToEventLoop();
+      await yieldToEventLoop();
+
+      // Server is in retry sleep — must appear in getCancellableServers
+      expect(mgr.getCancellableServers()).toContain('srv');
+
+      mgr.cancelAllLoading();
+      await loadPromise;
+      mgr.shutdown();
+    });
+  });
+
+  // ── setupBackgroundRetry idempotency ─────────────────────────────────────────
+
+  describe('setupBackgroundRetry idempotency', () => {
+    it('installs only one interval even after multiple LoadingComplete events from hot-reload cycles', async () => {
+      // Enable background retry so the timer is actually installed
+      const mgr = new McpLoadingManager(clientManager as never, {
+        ...FAST_CONFIG,
+        enableBackgroundRetry: true,
+        backgroundRetryIntervalMs: 60000,
+      });
+
+      // Track how many times setInterval is called
+      const originalSetInterval = globalThis.setInterval;
+      let intervalCallCount = 0;
+      const spy = vi.spyOn(globalThis, 'setInterval').mockImplementation((...args) => {
+        intervalCallCount++;
+        return originalSetInterval(...(args as Parameters<typeof setInterval>));
+      });
+
+      // Load a server → triggers LoadingComplete (1st)
+      await mgr.loadServer('srv-a', makeServerConfig());
+      // Load another → triggers LoadingComplete again (2nd)
+      await mgr.loadServer('srv-b', makeServerConfig());
+      // Unload one → all remaining ready → LoadingComplete again (3rd)
+      await mgr.unloadServer('srv-a');
+
+      // Despite multiple LoadingComplete events only one interval should exist
+      expect(intervalCallCount).toBe(1);
+
+      spy.mockRestore();
+      mgr.shutdown();
+    });
+  });
+});

--- a/src/core/loading/mcpLoadingManager.ts
+++ b/src/core/loading/mcpLoadingManager.ts
@@ -2,8 +2,9 @@ import { EventEmitter } from 'events';
 
 import { DEFAULT_MAX_CONCURRENT_LOADS } from '@src/constants/mcp.js';
 import { ClientManager } from '@src/core/client/clientManager.js';
-import { AuthProviderTransport, OutboundConnections } from '@src/core/types/index.js';
+import { AuthProviderTransport, MCPServerParams, OutboundConnections } from '@src/core/types/index.js';
 import logger, { debugIf } from '@src/logger/logger.js';
+import { createTransports } from '@src/transport/transportFactory.js';
 
 import {
   LoadingState,
@@ -109,18 +110,47 @@ export interface McpLoadingEvents {
  * ```
  */
 export class McpLoadingManager extends EventEmitter {
+  /**
+   * Most-recently constructed instance, exposed so runtime collaborators (e.g.
+   * ConfigChangeHandler) can route hot-reload add/remove through the single
+   * canonical loading pipeline. Mirrors ServerManager.current / ClientManager.current.
+   */
+  private static _current: McpLoadingManager | undefined;
+
+  public static get current(): McpLoadingManager {
+    if (!McpLoadingManager._current) {
+      throw new Error('McpLoadingManager not initialized');
+    }
+    return McpLoadingManager._current;
+  }
+
   private clientManager: ClientManager;
   private config: McpLoadingConfig;
   private stateTracker: LoadingStateTracker;
   private backgroundRetryTimer?: ReturnType<typeof setTimeout>;
   private isShuttingDown: boolean = false;
+  /** Per-connection-attempt abort controllers (timeout window only) */
   private abortControllers: Map<string, AbortController> = new Map();
+  /**
+   * Per-server operation abort controllers.
+   *
+   * Covers the full lifetime of a `loadServer` or background-retry operation
+   * for a given server name — including the retry loop and its sleep delays.
+   * Cancelling this controller stops the loop immediately and prevents the
+   * operation from writing state back after the server has been removed.
+   *
+   * Invariant: only ONE entry per server name exists at a time. Starting a new
+   * operation for a name (`loadServer`, `performBackgroundRetry`) replaces the
+   * previous controller after aborting it via `cancelServerOperation`.
+   */
+  private serverOpAbortControllers: Map<string, AbortController> = new Map();
 
   constructor(clientManager: ClientManager, config: Partial<McpLoadingConfig> = {}) {
     super();
     this.clientManager = clientManager;
     this.config = { ...DEFAULT_LOADING_CONFIG, ...config };
     this.stateTracker = new LoadingStateTracker();
+    McpLoadingManager._current = this;
 
     // Forward state tracker events
     this.stateTracker.on(LoadingStateEvent.ServerStateChanged, (name: string, info: ServerLoadingInfo) => {
@@ -180,24 +210,165 @@ export class McpLoadingManager extends EventEmitter {
   }
 
   /**
+   * Bring a single server online at runtime (config hot-reload add / rename).
+   *
+   * This is the canonical runtime counterpart to {@link startAsyncLoading}: it
+   * routes a hot-reload-added server through the SAME loading pipeline
+   * (`loadSingleServer`) that boot uses, so the server is tracked in the
+   * LoadingStateTracker and gets identical retry + OAuth handling. Previously
+   * the config-change path called `ServerManager.startServer` directly, which
+   * connected the client but never registered it with the tracker — so the new
+   * server was invisible to `/health/mcp` (stuck "connecting", no OAuth button).
+   *
+   * Idempotent: if the server already exists it is fully unloaded first (via
+   * `unloadServer`, which cancels any in-flight load operation), making renames
+   * and modified-restart correct without leaving ghost connections or stale
+   * tracker entries.
+   */
+  public async loadServer(name: string, config: MCPServerParams): Promise<void> {
+    if (config.disabled) {
+      logger.info(`Server ${name} is disabled, skipping load`);
+      // Ensure no stale state/connection lingers for a now-disabled server.
+      await this.unloadServer(name);
+      return;
+    }
+
+    // Re-load cleanly if it already exists (rename / functional modify).
+    // unloadServer cancels any in-flight operation for this name first.
+    if (this.stateTracker.getServerState(name) || this.clientManager.getTransport(name)) {
+      await this.unloadServer(name);
+    } else {
+      // Even if not tracked yet, cancel any lingering operation (e.g. a
+      // concurrent loadServer call that has not registered with the tracker yet).
+      this.cancelServerOperation(name);
+    }
+
+    // Claim a new operation slot for this load attempt.
+    const opController = new AbortController();
+    this.serverOpAbortControllers.set(name, opController);
+
+    let transport: AuthProviderTransport | undefined;
+    try {
+      const transports = createTransports({ [name]: config });
+      transport = transports[name];
+    } catch (error) {
+      logger.error(`Failed to create transport for ${name}: ${error}`);
+      this.stateTracker.registerServer(name);
+      this.stateTracker.updateServerState(name, LoadingState.Failed, {
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+      this.serverOpAbortControllers.delete(name);
+      return;
+    }
+
+    if (!transport) {
+      logger.warn(`No transport created for ${name} (possibly disabled); skipping`);
+      this.serverOpAbortControllers.delete(name);
+      return;
+    }
+
+    // Register with the tracker, then run the shared single-server pipeline.
+    this.stateTracker.registerServer(name);
+    try {
+      await this.loadSingleServer(name, transport, opController.signal);
+    } finally {
+      // Only clean up our own controller — a concurrent loadServer may have
+      // replaced it already.
+      if (this.serverOpAbortControllers.get(name) === opController) {
+        this.serverOpAbortControllers.delete(name);
+      }
+    }
+  }
+
+  /**
+   * Take a single server offline at runtime (config hot-reload remove / rename
+   * old name). Disconnects the client, closes the transport, and clears the
+   * server's entry from the LoadingStateTracker so it does not linger as a
+   * "ghost" in `/health/mcp`.
+   *
+   * Cancels any in-flight `loadServer` or background-retry operation for `name`
+   * before cleaning up, so that the loop cannot write state back after removal.
+   */
+  public async unloadServer(name: string): Promise<void> {
+    // Cancel any in-flight load or background-retry for this server FIRST, so
+    // the retry loop cannot wake up after removal and re-add connections.
+    this.cancelServerOperation(name);
+
+    try {
+      await this.clientManager.removeClient(name);
+    } catch (error) {
+      // Guard against: client not present / transport already closed; we still
+      // want to clear tracker state below.
+      debugIf(() => ({ message: `unloadServer: removeClient(${name}) noop/err: ${error}` }));
+    }
+    this.stateTracker.removeServer(name);
+    logger.info(`Unloaded MCP server: ${name}`);
+  }
+
+  /**
+   * Abort and remove the operation-level AbortController for `name`, if one
+   * exists. This is the single authoritative way to interrupt a `loadSingleServer`
+   * retry loop (including its sleep delays and connection attempt) for a specific
+   * server.
+   *
+   * Safe to call when no operation is in flight — it is a no-op in that case.
+   */
+  private cancelServerOperation(name: string): void {
+    const controller = this.serverOpAbortControllers.get(name);
+    if (controller) {
+      controller.abort();
+      this.serverOpAbortControllers.delete(name);
+    }
+  }
+
+  /**
    * Load servers with concurrency control using ParallelExecutor
    */
   private async loadServersWithConcurrency(transports: Record<string, AuthProviderTransport>): Promise<void> {
     const executor = new ParallelExecutor<[string, AuthProviderTransport], void>();
     const serverEntries = Object.entries(transports);
 
-    await executor.execute(serverEntries, async ([name, transport]) => this.loadSingleServer(name, transport), {
-      maxConcurrent: this.config.maxConcurrentLoads,
-    });
+    await executor.execute(
+      serverEntries,
+      async ([name, transport]) => {
+        if (this.isShuttingDown) return;
+
+        this.cancelServerOperation(name);
+        const opController = new AbortController();
+        this.serverOpAbortControllers.set(name, opController);
+
+        try {
+          await this.loadSingleServer(name, transport, opController.signal);
+        } finally {
+          if (this.serverOpAbortControllers.get(name) === opController) {
+            this.serverOpAbortControllers.delete(name);
+          }
+        }
+      },
+      {
+        maxConcurrent: this.config.maxConcurrentLoads,
+      },
+    );
 
     logger.info('Initial server loading phase completed');
   }
 
   /**
-   * Load a single server with retry logic
+   * Load a single server with retry logic.
+   *
+   * @param opSignal - Operation-level abort signal provided by the caller
+   *   (`loadServer` or `performBackgroundRetry`). When this signal fires the
+   *   retry loop terminates immediately — without writing a Failed state to the
+   *   tracker — because the cancellation was intentional (e.g. `unloadServer`
+   *   was called concurrently). The signal is also threaded down into
+   *   `createClientWithTimeout` so the active connection attempt is aborted too.
    */
-  private async loadSingleServer(name: string, transport: AuthProviderTransport): Promise<void> {
-    if (this.isShuttingDown) return;
+  private async loadSingleServer(
+    name: string,
+    transport: AuthProviderTransport,
+    opSignal?: AbortSignal,
+  ): Promise<void> {
+    if (this.isShuttingDown || opSignal?.aborted) return;
 
     this.emit(McpLoadingEvent.ServerLoading, name);
     this.stateTracker.updateServerState(name, LoadingState.Loading, {
@@ -207,7 +378,7 @@ export class McpLoadingManager extends EventEmitter {
     let lastError: Error | undefined;
     let retryCount = 0;
 
-    while (retryCount <= this.config.maxRetries && !this.isShuttingDown) {
+    while (retryCount <= this.config.maxRetries && !this.isShuttingDown && !opSignal?.aborted) {
       try {
         this.stateTracker.updateServerState(name, LoadingState.Loading, {
           progress: {
@@ -217,13 +388,19 @@ export class McpLoadingManager extends EventEmitter {
         });
 
         // Attempt to create and connect client
-        await this.createClientWithTimeout(name, transport);
+        await this.createClientWithTimeout(name, transport, opSignal);
 
         // Success!
         this.stateTracker.updateServerState(name, LoadingState.Ready);
         logger.info(`Successfully loaded MCP server: ${name} (${retryCount} retries)`);
         return;
       } catch (error) {
+        // If the operation was cancelled, exit cleanly without marking Failed.
+        if (opSignal?.aborted) {
+          debugIf(() => ({ message: `loadSingleServer: operation cancelled for ${name}` }));
+          return;
+        }
+
         lastError = error instanceof Error ? error : new Error(String(error));
         retryCount++;
         this.stateTracker.incrementRetryCount(name);
@@ -231,8 +408,10 @@ export class McpLoadingManager extends EventEmitter {
         // Handle OAuth case specially
         if (lastError.name === 'OAuthRequiredError') {
           logger.info(`OAuth required for ${name}`);
+          const authorizationUrl = this.extractAuthorizationUrl(name, transport);
           this.stateTracker.updateServerState(name, LoadingState.AwaitingOAuth, {
             error: lastError,
+            authorizationUrl,
           });
           return; // Don't retry OAuth errors
         }
@@ -240,13 +419,23 @@ export class McpLoadingManager extends EventEmitter {
         // Handle other errors
         logger.warn(`Failed to load ${name} (attempt ${retryCount}): ${lastError.message}`);
 
-        if (retryCount <= this.config.maxRetries && !this.isShuttingDown) {
+        if (retryCount <= this.config.maxRetries && !this.isShuttingDown && !opSignal?.aborted) {
           const delay = this.config.retryDelayMs * Math.pow(2, retryCount - 1); // Exponential backoff
           logger.info(`Retrying ${name} in ${delay}ms...`);
-          await this.sleep(delay);
+          try {
+            await this.sleep(delay, opSignal);
+          } catch {
+            // sleep was interrupted by opSignal abort; exit cleanly.
+            return;
+          }
         }
       }
     }
+
+    // If we exited the loop due to intentional cancellation (per-server abort)
+    // or global shutdown, don't mark the server as Failed — the exit was
+    // deliberate, not a real failure.
+    if (opSignal?.aborted || this.isShuttingDown) return;
 
     // All retries exhausted
     this.stateTracker.updateServerState(name, LoadingState.Failed, {
@@ -262,12 +451,25 @@ export class McpLoadingManager extends EventEmitter {
   }
 
   /**
-   * Create client with timeout and cancellation support
+   * Create client with timeout and cancellation support.
+   *
+   * @param opSignal - Operation-level signal from `loadSingleServer`. When it
+   *   fires (e.g. because `unloadServer` was called), it is linked to the
+   *   internal per-connection-attempt AbortController so that the active
+   *   connection and its timeout are both cancelled.
    */
-  private async createClientWithTimeout(name: string, transport: AuthProviderTransport): Promise<void> {
+  private async createClientWithTimeout(
+    name: string,
+    transport: AuthProviderTransport,
+    opSignal?: AbortSignal,
+  ): Promise<void> {
     // Create abort controller for this specific server loading operation
     const abortController = new AbortController();
     this.abortControllers.set(name, abortController);
+
+    // Propagate operation-level cancellation to the connection-attempt abort.
+    const onOpAbort = () => abortController.abort();
+    opSignal?.addEventListener('abort', onOpAbort, { once: true });
 
     try {
       const timeoutPromise = new Promise<never>((_, reject) => {
@@ -289,14 +491,22 @@ export class McpLoadingManager extends EventEmitter {
     } finally {
       // Clean up abort controller
       this.abortControllers.delete(name);
+      opSignal?.removeEventListener('abort', onOpAbort);
     }
   }
 
   /**
-   * Set up background retry for failed servers
+   * Set up background retry for failed servers.
+   *
+   * Idempotent: no-ops if a timer is already running. Without this guard,
+   * every hot-reload cycle that drives the tracker to a "complete" summary
+   * (e.g. unloadServer leaving all remaining servers ready) would fire
+   * LoadingComplete again and install a second interval on top of the first,
+   * causing failed servers to be retried N times per tick after N hot-reload
+   * cycles.
    */
   private setupBackgroundRetry(): void {
-    if (!this.config.enableBackgroundRetry || this.isShuttingDown) {
+    if (!this.config.enableBackgroundRetry || this.isShuttingDown || this.backgroundRetryTimer) {
       return;
     }
 
@@ -327,15 +537,31 @@ export class McpLoadingManager extends EventEmitter {
     for (const serverInfo of serversToRetry) {
       if (this.isShuttingDown) break;
 
-      const transport = this.clientManager.getTransport(serverInfo.name);
+      const { name } = serverInfo;
+      const transport = this.clientManager.getTransport(name);
       if (transport) {
-        this.emit(McpLoadingEvent.BackgroundRetry, serverInfo.name, serverInfo.retryCount + 1);
+        this.emit(McpLoadingEvent.BackgroundRetry, name, serverInfo.retryCount + 1);
+
+        // Cancel any previous operation for this server and claim a new slot.
+        // This prevents a stale background-retry from racing with a concurrent
+        // loadServer or unloadServer call.
+        this.cancelServerOperation(name);
+        const opController = new AbortController();
+        this.serverOpAbortControllers.set(name, opController);
 
         // Don't wait for completion, let it run in background
-        this.loadSingleServer(serverInfo.name, transport).catch((error: unknown) => {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          debugIf(() => ({ message: `Background retry failed for ${serverInfo.name}: ${errorMessage}` }));
-        });
+        this.loadSingleServer(name, transport, opController.signal)
+          .catch((error: unknown) => {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            debugIf(() => ({ message: `Background retry failed for ${name}: ${errorMessage}` }));
+          })
+          .finally(() => {
+            // Clean up our own controller only — a concurrent operation may have
+            // replaced it.
+            if (this.serverOpAbortControllers.get(name) === opController) {
+              this.serverOpAbortControllers.delete(name);
+            }
+          });
       }
     }
   }
@@ -345,6 +571,24 @@ export class McpLoadingManager extends EventEmitter {
    */
   public getStateTracker(): LoadingStateTracker {
     return this.stateTracker;
+  }
+
+  private extractAuthorizationUrl(name: string, transport: AuthProviderTransport): string | undefined {
+    const clientInfo = this.clientManager.getClients().get(name);
+    if (clientInfo?.authorizationUrl) {
+      return clientInfo.authorizationUrl;
+    }
+
+    try {
+      const oauthProvider = transport.oauthProvider;
+      if (oauthProvider && typeof oauthProvider.getAuthorizationUrl === 'function') {
+        return oauthProvider.getAuthorizationUrl();
+      }
+    } catch (error) {
+      debugIf(() => ({ message: `Could not extract authorization URL for ${name}: ${error}` }));
+    }
+
+    return undefined;
   }
 
   /**
@@ -377,16 +621,42 @@ export class McpLoadingManager extends EventEmitter {
   }
 
   /**
-   * Cancel loading of a specific server
+   * Cancel loading of a specific server.
+   *
+   * Cancels both the operation-level retry loop (serverOpAbortControllers) and
+   * the active connection-attempt timeout (abortControllers). Before this fix,
+   * only the connection-attempt abort was signalled, so a server sleeping
+   * between retries would continue uninterrupted and could resurface as Loading,
+   * Ready, or Failed after the caller believed it was cancelled.
    */
   public cancelServerLoading(serverName: string): void {
+    const hasOpController = this.serverOpAbortControllers.has(serverName);
+    const hasConnController = this.abortControllers.has(serverName);
+
+    if (!hasOpController && !hasConnController) {
+      logger.warn(`No active loading operation found for server: ${serverName}`);
+      return;
+    }
+
+    logger.info(`Cancelling loading of server: ${serverName}`);
+
+    // Cancel the full retry loop first (interrupts sleep delays and signals the
+    // loop to exit cleanly without writing state back).
+    this.cancelServerOperation(serverName);
+
+    // Also abort the active connection-attempt controller if one exists (covers
+    // the case where we are mid-connect and cancelServerOperation has not yet
+    // propagated through createClientWithTimeout).
     const abortController = this.abortControllers.get(serverName);
     if (abortController) {
-      logger.info(`Cancelling loading of server: ${serverName}`);
       abortController.abort();
+    }
+
+    // Mark the tracker entry as Cancelled only if the server is still tracked.
+    // (cancelServerOperation may have already removed it via unloadServer; guard
+    // to avoid "unknown server" warning from updateServerState.)
+    if (this.stateTracker.getServerState(serverName)) {
       this.stateTracker.updateServerState(serverName, LoadingState.Cancelled);
-    } else {
-      logger.warn(`No active loading operation found for server: ${serverName}`);
     }
   }
 
@@ -400,21 +670,29 @@ export class McpLoadingManager extends EventEmitter {
   }
 
   /**
-   * Cancel all currently loading servers
+   * Cancel all currently loading servers.
+   *
+   * Previously iterated only abortControllers (connection-attempt window), so
+   * servers sleeping between retries were invisible and never cancelled. Now
+   * collects the union of both maps so every in-flight operation is reached.
    */
   public cancelAllLoading(): void {
-    const loadingServers = Array.from(this.abortControllers.keys());
-    if (loadingServers.length > 0) {
-      logger.info(`Cancelling loading of ${loadingServers.length} servers`);
-      this.cancelServersLoading(loadingServers);
+    // Union of servers that are either mid-connection-attempt or mid-retry-sleep.
+    const allActive = new Set([...this.abortControllers.keys(), ...this.serverOpAbortControllers.keys()]);
+    if (allActive.size > 0) {
+      logger.info(`Cancelling loading of ${allActive.size} servers`);
+      this.cancelServersLoading(Array.from(allActive));
     }
   }
 
   /**
-   * Get list of servers that are currently being loaded and can be cancelled
+   * Get list of servers that are currently being loaded and can be cancelled.
+   *
+   * Returns the union of servers with an active connection attempt and servers
+   * sleeping between retries — both are cancellable via cancelServerLoading.
    */
   public getCancellableServers(): string[] {
-    return Array.from(this.abortControllers.keys());
+    return Array.from(new Set([...this.abortControllers.keys(), ...this.serverOpAbortControllers.keys()]));
   }
 
   /**
@@ -427,6 +705,13 @@ export class McpLoadingManager extends EventEmitter {
       clearInterval(this.backgroundRetryTimer);
       this.backgroundRetryTimer = undefined;
     }
+
+    // Cancel all per-server operation controllers first (interrupts retry loops
+    // and sleep delays), then cancel the per-connection-attempt controllers.
+    for (const controller of this.serverOpAbortControllers.values()) {
+      controller.abort();
+    }
+    this.serverOpAbortControllers.clear();
 
     // Cancel any active loading operations
     this.cancelAllLoading();
@@ -443,9 +728,30 @@ export class McpLoadingManager extends EventEmitter {
   }
 
   /**
-   * Utility method for sleeping
+   * Utility method for sleeping.
+   *
+   * When `signal` is provided the sleep is cancellable: aborting the signal
+   * rejects the returned promise immediately (clearing the underlying timer),
+   * which causes the retry loop in `loadSingleServer` to exit without waiting
+   * for the full delay.
    */
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+  private sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new Error('Sleep aborted'));
+        return;
+      }
+
+      const id = setTimeout(resolve, ms);
+
+      signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(id);
+          reject(new Error('Sleep aborted'));
+        },
+        { once: true },
+      );
+    });
   }
 }

--- a/src/core/server/mcpServerLifecycleManager.ts
+++ b/src/core/server/mcpServerLifecycleManager.ts
@@ -162,6 +162,31 @@ export class MCPServerLifecycleManager {
   }
 
   /**
+   * Track a server whose connection is managed by another startup path.
+   */
+  public trackServer(serverName: string, config: MCPServerParams, transport: AuthProviderTransport): void {
+    if (config.disabled) {
+      this.mcpServers.delete(serverName);
+      return;
+    }
+
+    this.mcpServers.set(serverName, { transport, config });
+    debugIf(() => ({
+      message: `Tracked MCP server lifecycle state: ${serverName}`,
+      meta: { serverName, tags: config.tags },
+    }));
+  }
+
+  /**
+   * Remove lifecycle tracking without touching the already-cleaned-up transport.
+   */
+  public untrackServer(serverName: string): void {
+    if (this.mcpServers.delete(serverName)) {
+      debugIf(() => ({ message: `Untracked MCP server lifecycle state: ${serverName}` }));
+    }
+  }
+
+  /**
    * Update metadata for a running server without restarting it
    */
   public async updateServerMetadata(

--- a/src/core/server/serverManager.ts
+++ b/src/core/server/serverManager.ts
@@ -5,12 +5,16 @@ import { LazyLoadingOrchestrator } from '@src/core/capabilities/lazyLoadingOrche
 import { getGlobalContextManager } from '@src/core/context/globalContextManager.js';
 import { ClientTemplateTracker, FilterCache, getFilterCache, TemplateIndex } from '@src/core/filtering/index.js';
 import { InstructionAggregator } from '@src/core/instructions/instructionAggregator.js';
+import { LoadingState } from '@src/core/loading/loadingStateTracker.js';
+import { McpLoadingManager } from '@src/core/loading/mcpLoadingManager.js';
 import { ServerRegistry } from '@src/core/server/adapters/ServerRegistry.js';
 import { ConnectionManager } from '@src/core/server/connectionManager.js';
 import { MCPServerLifecycleManager } from '@src/core/server/mcpServerLifecycleManager.js';
 import { TemplateConfigurationManager } from '@src/core/server/templateConfigurationManager.js';
 import { TemplateServerManager } from '@src/core/server/templateServerManager.js';
+import { ClientStatus } from '@src/core/types/index.js';
 import type {
+  AuthProviderTransport,
   InboundConnection,
   InboundConnectionConfig,
   MCPServerParams,
@@ -170,9 +174,9 @@ export class ServerManager {
             await this.templateConfigurationManager.updateServersWithNewConfig(
               newConfig,
               this.getCurrentServerConfigs(),
-              (serverName, config) => this.startServer(serverName, config),
-              (serverName) => this.stopServer(serverName),
-              (serverName, config) => this.restartServer(serverName, config),
+              (serverName, config) => this.loadMcpServer(serverName, config),
+              (serverName) => this.unloadMcpServer(serverName),
+              (serverName, config) => this.loadMcpServer(serverName, config),
             );
           } catch (updateError) {
             logger.error('Failed to update all servers with new config, attempting individual updates:', updateError);
@@ -363,12 +367,106 @@ export class ServerManager {
     await this.mcpServerLifecycleManager.restartServer(serverName, config, this.outboundConns, this.transports);
   }
 
+  public async loadMcpServer(serverName: string, config: MCPServerParams): Promise<void> {
+    const loadingManager = McpLoadingManager.current;
+    await loadingManager.loadServer(serverName, config);
+
+    if (config.disabled) {
+      this.untrackMcpServer(serverName);
+      return;
+    }
+
+    const loadingState = loadingManager.getStateTracker().getServerState(serverName)?.state;
+    if (loadingState !== LoadingState.Ready) {
+      this.untrackMcpServer(serverName);
+      debugIf(() => ({
+        message: `Skipping lifecycle tracking for ${serverName}; loading state is ${loadingState ?? 'unknown'}`,
+      }));
+      return;
+    }
+
+    this.recordMcpServerReady(serverName, config);
+  }
+
+  public async unloadMcpServer(serverName: string): Promise<void> {
+    try {
+      await McpLoadingManager.current.unloadServer(serverName);
+    } finally {
+      this.untrackMcpServer(serverName);
+    }
+  }
+
   public getMcpServerStatus(): Map<string, { running: boolean; config: MCPServerParams }> {
     return this.mcpServerLifecycleManager.getMcpServerStatus();
   }
 
   public isMcpServerRunning(serverName: string): boolean {
     return this.mcpServerLifecycleManager.isMcpServerRunning(serverName);
+  }
+
+  public recordMcpServerReady(serverName: string, config?: MCPServerParams): void {
+    const resolvedConfig = config ?? this.resolveMcpServerConfig(serverName);
+    if (!resolvedConfig) {
+      this.untrackMcpServer(serverName);
+      debugIf(() => ({ message: `No config available to track lifecycle for ${serverName}` }));
+      return;
+    }
+
+    if (resolvedConfig.disabled) {
+      this.untrackMcpServer(serverName);
+      return;
+    }
+
+    const transport = this.getConnectedMcpTransport(serverName);
+    if (!transport) {
+      this.untrackMcpServer(serverName);
+      debugIf(() => ({ message: `No connected transport available to track lifecycle for ${serverName}` }));
+      return;
+    }
+
+    this.trackMcpServer(serverName, resolvedConfig, transport);
+  }
+
+  public syncMcpServerLifecycleFromConnectedClients(configs?: Record<string, MCPServerParams>): void {
+    for (const [serverName, connection] of this.outboundConns.entries()) {
+      if (connection.status !== ClientStatus.Connected) {
+        this.untrackMcpServer(serverName);
+        continue;
+      }
+
+      this.recordMcpServerReady(serverName, configs?.[serverName]);
+    }
+  }
+
+  private trackMcpServer(serverName: string, config: MCPServerParams, transport: AuthProviderTransport): void {
+    this.mcpServerLifecycleManager.trackServer(serverName, config, transport);
+  }
+
+  private untrackMcpServer(serverName: string): void {
+    this.mcpServerLifecycleManager.untrackServer(serverName);
+  }
+
+  private getConnectedMcpTransport(serverName: string): AuthProviderTransport | undefined {
+    const connection = this.outboundConns.get(serverName);
+    if (connection?.status === ClientStatus.Connected) {
+      return connection.transport;
+    }
+
+    return undefined;
+  }
+
+  private resolveMcpServerConfig(serverName: string): MCPServerParams | undefined {
+    const existing = this.mcpServerLifecycleManager.getMcpServerStatus().get(serverName)?.config;
+    if (existing) {
+      return existing;
+    }
+
+    try {
+      return ConfigManager.getInstance().getTransportConfig()[serverName];
+    } catch (error) {
+      debugIf(() => ({ message: `Could not resolve config for ${serverName}: ${error}` }));
+      return undefined;
+    }
   }
 
   public async updateServerMetadata(serverName: string, newConfig: MCPServerParams): Promise<void> {

--- a/src/core/server/serverManagerHotReload.test.ts
+++ b/src/core/server/serverManagerHotReload.test.ts
@@ -1,0 +1,327 @@
+import { LoadingState } from '@src/core/loading/loadingStateTracker.js';
+import { McpLoadingManager } from '@src/core/loading/mcpLoadingManager.js';
+import { AuthProviderTransport, ClientStatus, MCPServerParams } from '@src/core/types/index.js';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ServerManager } from './serverManager.js';
+
+const mockState = vi.hoisted(() => ({
+  contextChangedHandler: undefined as
+    | ((data: { newContext?: unknown; sessionIdChanged: boolean }) => Promise<void>)
+    | undefined,
+  reprocessTemplatesWithNewContext: vi.fn(),
+  updateServersWithNewConfig: vi.fn(),
+}));
+
+vi.mock('@src/core/loading/mcpLoadingManager.js', () => ({
+  McpLoadingManager: {
+    current: {
+      loadServer: vi.fn(),
+      unloadServer: vi.fn(),
+      getStateTracker: vi.fn(() => ({
+        getServerState: vi.fn(() => ({ state: LoadingState.Ready })),
+      })),
+    },
+  },
+}));
+
+vi.mock('@src/core/client/clientManager.js', () => ({
+  ClientManager: {
+    getOrCreateInstance: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock('@src/core/context/globalContextManager.js', () => ({
+  getGlobalContextManager: vi.fn(() => ({
+    getContext: vi.fn(() => undefined),
+    on: vi.fn(
+      (event: string, handler: (data: { newContext?: unknown; sessionIdChanged: boolean }) => Promise<void>) => {
+        if (event === 'context-changed') {
+          mockState.contextChangedHandler = handler;
+        }
+      },
+    ),
+  })),
+}));
+
+vi.mock('@src/core/filtering/index.js', () => ({
+  getFilterCache: vi.fn(() => ({
+    getStats: vi.fn(() => ({})),
+    clear: vi.fn(),
+  })),
+  ClientTemplateTracker: vi.fn(),
+  FilterCache: vi.fn(),
+  TemplateIndex: vi.fn(),
+}));
+
+vi.mock('./connectionManager.js', () => ({
+  ConnectionManager: vi.fn(function () {
+    return {
+      setLazyLoadingOrchestrator: vi.fn(),
+      getInboundConnections: vi.fn(() => new Map()),
+      getTransports: vi.fn(() => new Map()),
+      cleanup: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock('./templateServerManager.js', () => ({
+  TemplateServerManager: vi.fn(function () {
+    return {
+      setInstructionAggregator: vi.fn(),
+      getFilteringStats: vi.fn(() => ({ tracker: null, index: null, enabled: true })),
+      getClientTemplateInfo: vi.fn(() => ({})),
+      rebuildTemplateIndex: vi.fn(),
+      getIdleTemplateInstances: vi.fn(() => []),
+      cleanupIdleInstances: vi.fn().mockResolvedValue(0),
+      cleanup: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock('./templateConfigurationManager.js', () => ({
+  TemplateConfigurationManager: vi.fn(function () {
+    return {
+      reprocessTemplatesWithNewContext: mockState.reprocessTemplatesWithNewContext,
+      updateServersWithNewConfig: mockState.updateServersWithNewConfig,
+      updateServersIndividually: vi.fn(),
+      cleanup: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock('./adapters/ServerRegistry.js', () => ({
+  ServerRegistry: vi.fn(function () {
+    return {};
+  }),
+}));
+
+describe('ServerManager hot-reload lifecycle facade', () => {
+  const serverConfig = { name: '1mcp-test', version: '0.0.0' };
+  const serverCapabilities = { capabilities: {} };
+  let outboundConns: Map<string, unknown>;
+  let transports: Record<string, AuthProviderTransport>;
+  let serverManager: ServerManager;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockState.contextChangedHandler = undefined;
+    vi.mocked(McpLoadingManager.current.getStateTracker).mockReturnValue({
+      getServerState: vi.fn(() => ({ state: LoadingState.Ready })),
+    } as never);
+    await ServerManager.resetInstance();
+    outboundConns = new Map();
+    transports = {};
+    serverManager = ServerManager.getOrCreateInstance(
+      serverConfig,
+      serverCapabilities,
+      outboundConns as never,
+      transports,
+    );
+  });
+
+  it('loads through McpLoadingManager and records lifecycle status in one ServerManager entry point', async () => {
+    const config: MCPServerParams = {
+      command: 'node',
+      args: ['server.js'],
+      tags: ['runtime'],
+    };
+    const transport = { close: vi.fn() } as unknown as AuthProviderTransport;
+
+    vi.mocked(McpLoadingManager.current.loadServer).mockImplementationOnce(async () => {
+      outboundConns.set('hot-server', {
+        name: 'hot-server',
+        transport,
+        status: ClientStatus.Connected,
+      });
+      transports['hot-server'] = transport;
+    });
+
+    await serverManager.loadMcpServer('hot-server', config);
+
+    expect(McpLoadingManager.current.loadServer).toHaveBeenCalledWith('hot-server', config);
+    expect(serverManager.isMcpServerRunning('hot-server')).toBe(true);
+    expect(serverManager.getMcpServerStatus().get('hot-server')).toMatchObject({
+      running: true,
+      config,
+    });
+  });
+
+  it('records a connected initial-boot server through the same lifecycle facade', () => {
+    const config: MCPServerParams = {
+      command: 'node',
+      args: ['server.js'],
+      tags: ['boot'],
+    };
+    const transport = { close: vi.fn() } as unknown as AuthProviderTransport;
+
+    outboundConns.set('boot-server', {
+      name: 'boot-server',
+      transport,
+      status: ClientStatus.Connected,
+    });
+
+    serverManager.recordMcpServerReady('boot-server', config);
+
+    expect(serverManager.isMcpServerRunning('boot-server')).toBe(true);
+    expect(serverManager.getMcpServerStatus().get('boot-server')).toMatchObject({
+      running: true,
+      config,
+    });
+  });
+
+  it('syncs only connected initial-boot clients into lifecycle status', () => {
+    const readyConfig: MCPServerParams = { command: 'node', args: ['ready.js'] };
+    const failedConfig: MCPServerParams = { command: 'node', args: ['failed.js'] };
+    const oauthConfig: MCPServerParams = { type: 'http', url: 'https://mcp.example.com' };
+    const readyTransport = { close: vi.fn() } as unknown as AuthProviderTransport;
+    const failedTransport = { close: vi.fn() } as unknown as AuthProviderTransport;
+    const oauthTransport = { close: vi.fn() } as unknown as AuthProviderTransport;
+
+    outboundConns.set('ready-server', {
+      name: 'ready-server',
+      transport: readyTransport,
+      status: ClientStatus.Connected,
+    });
+    outboundConns.set('failed-server', {
+      name: 'failed-server',
+      transport: failedTransport,
+      status: ClientStatus.Error,
+    });
+    outboundConns.set('oauth-server', {
+      name: 'oauth-server',
+      transport: oauthTransport,
+      status: ClientStatus.AwaitingOAuth,
+    });
+
+    serverManager.syncMcpServerLifecycleFromConnectedClients({
+      'ready-server': readyConfig,
+      'failed-server': failedConfig,
+      'oauth-server': oauthConfig,
+    });
+
+    expect(serverManager.isMcpServerRunning('ready-server')).toBe(true);
+    expect(serverManager.getMcpServerStatus().get('ready-server')).toMatchObject({
+      running: true,
+      config: readyConfig,
+    });
+    expect(serverManager.isMcpServerRunning('failed-server')).toBe(false);
+    expect(serverManager.isMcpServerRunning('oauth-server')).toBe(false);
+  });
+
+  it('does not record lifecycle status when hot-reload load ends in Failed', async () => {
+    const config: MCPServerParams = {
+      command: 'node',
+      args: ['server.js'],
+    };
+    const transport = { close: vi.fn() } as unknown as AuthProviderTransport;
+
+    vi.mocked(McpLoadingManager.current.getStateTracker).mockReturnValue({
+      getServerState: vi.fn(() => ({ state: LoadingState.Failed })),
+    } as never);
+    vi.mocked(McpLoadingManager.current.loadServer).mockImplementationOnce(async () => {
+      outboundConns.set('failed-server', {
+        name: 'failed-server',
+        transport,
+        status: ClientStatus.Error,
+      });
+      transports['failed-server'] = transport;
+    });
+
+    await serverManager.loadMcpServer('failed-server', config);
+
+    expect(serverManager.isMcpServerRunning('failed-server')).toBe(false);
+    expect(serverManager.getMcpServerStatus().has('failed-server')).toBe(false);
+  });
+
+  it('does not record lifecycle status when hot-reload load is awaiting OAuth', async () => {
+    const config: MCPServerParams = {
+      type: 'http',
+      url: 'https://mcp.example.com',
+    };
+    const transport = { close: vi.fn() } as unknown as AuthProviderTransport;
+
+    vi.mocked(McpLoadingManager.current.getStateTracker).mockReturnValue({
+      getServerState: vi.fn(() => ({ state: LoadingState.AwaitingOAuth })),
+    } as never);
+    vi.mocked(McpLoadingManager.current.loadServer).mockImplementationOnce(async () => {
+      outboundConns.set('oauth-server', {
+        name: 'oauth-server',
+        transport,
+        status: ClientStatus.AwaitingOAuth,
+      });
+      transports['oauth-server'] = transport;
+    });
+
+    await serverManager.loadMcpServer('oauth-server', config);
+
+    expect(serverManager.isMcpServerRunning('oauth-server')).toBe(false);
+    expect(serverManager.getMcpServerStatus().has('oauth-server')).toBe(false);
+  });
+
+  it('unloads through McpLoadingManager and clears lifecycle status in one ServerManager entry point', async () => {
+    const config: MCPServerParams = {
+      command: 'node',
+      args: ['server.js'],
+    };
+    const transport = { close: vi.fn() } as unknown as AuthProviderTransport;
+
+    vi.mocked(McpLoadingManager.current.loadServer).mockImplementationOnce(async () => {
+      outboundConns.set('hot-server', {
+        name: 'hot-server',
+        transport,
+        status: ClientStatus.Connected,
+      });
+      transports['hot-server'] = transport;
+    });
+
+    await serverManager.loadMcpServer('hot-server', config);
+    await serverManager.unloadMcpServer('hot-server');
+
+    expect(McpLoadingManager.current.unloadServer).toHaveBeenCalledWith('hot-server');
+    expect(serverManager.isMcpServerRunning('hot-server')).toBe(false);
+    expect(serverManager.getMcpServerStatus().has('hot-server')).toBe(false);
+  });
+
+  it('routes context template reload callbacks through the hot-reload facade', async () => {
+    const addedConfig: MCPServerParams = { command: 'node', args: ['added.js'] };
+    const restartedConfig: MCPServerParams = { command: 'node', args: ['changed.js'] };
+    const instructionAggregator = {
+      on: vi.fn(),
+      setLazyLoadingOrchestrator: vi.fn(),
+    };
+    const loadSpy = vi.spyOn(serverManager, 'loadMcpServer').mockResolvedValue(undefined);
+    const unloadSpy = vi.spyOn(serverManager, 'unloadMcpServer').mockResolvedValue(undefined);
+    vi.spyOn(serverManager, 'startServer').mockResolvedValue(undefined);
+    vi.spyOn(serverManager, 'stopServer').mockResolvedValue(undefined);
+    vi.spyOn(serverManager, 'restartServer').mockResolvedValue(undefined);
+
+    mockState.reprocessTemplatesWithNewContext.mockImplementationOnce(async (_context, updateServers) => {
+      await updateServers({
+        'added-server': addedConfig,
+        'restarted-server': restartedConfig,
+      });
+    });
+    mockState.updateServersWithNewConfig.mockImplementationOnce(
+      async (_newConfig, _currentServers, startServer, stopServer, restartServer) => {
+        await startServer('added-server', addedConfig);
+        await stopServer('removed-server');
+        await restartServer('restarted-server', restartedConfig);
+      },
+    );
+
+    serverManager.setInstructionAggregator(instructionAggregator as never);
+    await mockState.contextChangedHandler?.({
+      newContext: { sessionId: 'ctx-1' },
+      sessionIdChanged: true,
+    });
+
+    expect(loadSpy).toHaveBeenCalledWith('added-server', addedConfig);
+    expect(unloadSpy).toHaveBeenCalledWith('removed-server');
+    expect(loadSpy).toHaveBeenCalledWith('restarted-server', restartedConfig);
+    expect(serverManager.startServer).not.toHaveBeenCalled();
+    expect(serverManager.stopServer).not.toHaveBeenCalled();
+    expect(serverManager.restartServer).not.toHaveBeenCalled();
+  });
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -84,6 +84,7 @@ describe('server', () => {
       stop: vi.fn(),
       getStatus: vi.fn().mockReturnValue('running'),
       setInstructionAggregator: vi.fn(),
+      syncMcpServerLifecycleFromConnectedClients: vi.fn(),
     };
     vi.mocked(ServerManager.getOrCreateInstance).mockReturnValue(mockServerManager);
 
@@ -162,6 +163,12 @@ describe('server', () => {
         mockClients,
         mockTransports,
       );
+    });
+
+    it('should sync connected clients into ServerManager lifecycle status', async () => {
+      await setupServer();
+
+      expect(mockServerManager.syncMcpServerLifecycleFromConnectedClients).toHaveBeenCalled();
     });
 
     it('should initialize config change handler', async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -196,6 +196,7 @@ async function setupServerSync(
     transports,
   );
   serverManager.setInstructionAggregator(instructionAggregator);
+  serverManager.syncMcpServerLifecycleFromConnectedClients();
 
   // Config reload is now handled by ConfigManager and ConfigChangeHandler initialized in setupServer
 


### PR DESCRIPTION
Servers added or renamed via config hot-reload were invisible in /health/mcp (stuck "connecting", no OAuth prompt), and removed/renamed servers lingered as "ghost" entries. A second class of races in the retry loop allowed in-flight loads to outlive server removal and orphan connections.

Root cause — two separate issues:

1. Two divergent "connect a server" paths, only one observable:
   * boot (startAsyncLoading) → McpLoadingManager.loadSingleServer → tracks state in LoadingStateTracker, with retry + OAuth handling.
   * hot-reload (ConfigChangeHandler) → ServerManager.startServer → lifecycleManager.startServer → connects the client but NEVER touches the tracker.

2. loadSingleServer retry loop only guarded by isShuttingDown — no per-server cancellation signal — leaving three confirmed races: A. loadServer → unloadServer while in retry sleep: loop kept running, re-inserted connections after removal. B. Two concurrent loadServer('X') calls: both passed tracker check (TOCTOU), creating duplicate connections. C. performBackgroundRetry fire-and-forget + concurrent unloadServer: background loadSingleServer succeeded and wrote an orphaned entry to outboundConns after the tracker was cleared.

Fix 1 — single canonical load path:

  * McpLoadingManager.loadServer(name, config) / unloadServer(name): runtime counterparts to startAsyncLoading that build the transport via the same transportFactory and delegate to the shared loadSingleServer pipeline, so a hot-reloaded server is tracked + retried + OAuth-handled identically to boot. loadServer is idempotent (unloads first), making rename and functional-modify correct.
  * LoadingStateTracker.registerServer(name): add a single server at runtime without resetting global load timing or other servers.
  * LoadingStateTracker.removeServer(name): clear a single server's entry.
  * ConfigChangeHandler add/remove/modified-restart now call McpLoadingManager.current.{loadServer,unloadServer} exclusively.
  * Expose McpLoadingManager.current (mirrors ServerManager.current / ClientManager.current) so ConfigChangeHandler reaches the live instance.

Fix 2 — per-server operation AbortController:

  * serverOpAbortControllers: Map<string, AbortController>: one controller per server covering the full lifetime of a load operation (retry loop + sleep).
  * cancelServerOperation(name): single abort point; called by unloadServer (before cleanup), loadServer (before each new attempt), and performBackgroundRetry (before each retry).
  * loadSingleServer(opSignal): checks opSignal at loop top, on catch, and after sleep — exits cleanly without writing Failed on intentional cancellation.
  * createClientWithTimeout(opSignal): links opSignal to the internal connection-attempt AbortController so active connections are aborted too.
  * sleep(ms, signal): made cancellable — abort resolves the timer immediately.
  * performBackgroundRetry: registers a fresh op controller per retry so unloadServer can interrupt fire-and-forget background loads.
  * shutdown: aborts all serverOpAbortControllers before cancelAllLoading; fixes a related bug where isShuttingDown exit incorrectly wrote Failed state.

Tests: add registerServer/removeServer coverage; update ConfigChangeHandler tests to assert canonical loadServer/unloadServer routing; add mcpLoadingManager.test.ts (21 tests) covering all three race scenarios (A/B/C), happy paths, idempotent reload, shutdown, and edge cases.

Full suite green (3525 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime add/remove and hot-reload of MCP servers via a public manager accessor; explicit lifecycle tracking and sync from already-connected clients
  * Hot-reload loading with cancellable retries and OAuth authorization flow reporting

* **Bug Fixes**
  * Eliminates stale/“ghost” servers in loading and health reporting; more robust cancellation, shutdown, and idempotent retry behavior

* **Tests**
  * Expanded coverage for loading, reload/unload, cancellation, shutdown, lifecycle sync, and config-change hot-reload scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->