### PR TITLE
fix: HTTP transport host header validation

### DIFF
--- a/src/transport/http/server.test.ts
+++ b/src/transport/http/server.test.ts
@@ -113,6 +113,37 @@ describe('ExpressServer', () => {
   let mockConfigManager: any;
   let expressServer: ExpressServer;
 
+  const runRegisteredMiddleware = (headers: Record<string, string>) =>
+    mockApp.use.mock.calls
+      .map(([middleware]: any[]) => middleware)
+      .filter((middleware: unknown) => typeof middleware === 'function')
+      .map((middleware: any) => {
+        const res = {
+          status: vi.fn().mockReturnThis(),
+          json: vi.fn().mockReturnThis(),
+        };
+        const next = vi.fn();
+
+        middleware({ headers }, res, next);
+
+        return { middleware, res, next };
+      });
+
+  const getBlockingMiddleware = (headers: Record<string, string>) => {
+    const blockedResult = runRegisteredMiddleware(headers).find(
+      ({ res }: any) => vi.mocked(res.status).mock.calls[0]?.[0] === 403,
+    );
+
+    expect(blockedResult).toBeDefined();
+    return blockedResult;
+  };
+
+  const expectNoBlockingMiddleware = (headers: Record<string, string>) => {
+    expect(
+      runRegisteredMiddleware(headers).some(({ res }: any) => vi.mocked(res.status).mock.calls[0]?.[0] === 403),
+    ).toBe(false);
+  };
+
   beforeEach(async () => {
     vi.clearAllMocks();
 
@@ -460,6 +491,143 @@ describe('ExpressServer', () => {
       expect(resolveOrigin('http://127.0.0.1:3050')).toBe('http://127.0.0.1:3050');
       expect(resolveOrigin('http://[::1]:3050')).toBe('http://[::1]:3050');
       expect(resolveOrigin('http://127.0.1.1:3050')).toBe('http://127.0.1.1:3050');
+    });
+
+    it('should reject spoofed host headers for loopback external URLs', async () => {
+      mockConfigManager.get.mockImplementation((key: string) => {
+        if (key === 'trustProxy') return 'loopback';
+        if (key === 'auth') return { sessionStoragePath: '/tmp/sessions' };
+        if (key === 'features') return { enhancedSecurity: false, auth: false };
+        if (key === 'externalUrl') return 'http://127.0.0.1:3050';
+        if (key === 'host') return '0.0.0.0';
+        if (key === 'port') return 3050;
+        if (key === 'rateLimit') return { windowMs: 900000, max: 100 };
+        if (key === 'sessionPersistence') return { backgroundFlushSeconds: 30 };
+        return undefined;
+      });
+      mockConfigManager.getUrl.mockReturnValue('http://127.0.0.1:3050');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      const blockedResult = getBlockingMiddleware({
+        host: 'attacker.example:3050',
+      });
+
+      expect(blockedResult.res.status).toHaveBeenCalledWith(403);
+      expect(blockedResult.res.json).toHaveBeenCalledWith({ error: 'Forbidden host header' });
+      expect(blockedResult.next).not.toHaveBeenCalled();
+    });
+
+    it('should reject spoofed host headers for wildcard binds without external URLs', async () => {
+      mockConfigManager.get.mockImplementation((key: string) => {
+        if (key === 'trustProxy') return 'loopback';
+        if (key === 'auth') return { sessionStoragePath: '/tmp/sessions' };
+        if (key === 'features') return { enhancedSecurity: false, auth: false };
+        if (key === 'externalUrl') return undefined;
+        if (key === 'host') return '0.0.0.0';
+        if (key === 'port') return 3050;
+        if (key === 'rateLimit') return { windowMs: 900000, max: 100 };
+        if (key === 'sessionPersistence') return { backgroundFlushSeconds: 30 };
+        return undefined;
+      });
+      mockConfigManager.getUrl.mockReturnValue('http://0.0.0.0:3050');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      const blockedResult = getBlockingMiddleware({
+        host: 'attacker.example:3050',
+      });
+
+      expect(blockedResult.res.status).toHaveBeenCalledWith(403);
+      expect(blockedResult.res.json).toHaveBeenCalledWith({ error: 'Forbidden host header' });
+      expect(blockedResult.next).not.toHaveBeenCalled();
+    });
+
+    it('should allow loopback host headers for loopback external URLs', async () => {
+      mockConfigManager.get.mockImplementation((key: string) => {
+        if (key === 'trustProxy') return 'loopback';
+        if (key === 'auth') return { sessionStoragePath: '/tmp/sessions' };
+        if (key === 'features') return { enhancedSecurity: false, auth: false };
+        if (key === 'externalUrl') return 'http://127.0.0.1:3050';
+        if (key === 'host') return '0.0.0.0';
+        if (key === 'port') return 3050;
+        if (key === 'rateLimit') return { windowMs: 900000, max: 100 };
+        if (key === 'sessionPersistence') return { backgroundFlushSeconds: 30 };
+        return undefined;
+      });
+      mockConfigManager.getUrl.mockReturnValue('http://127.0.0.1:3050');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      expectNoBlockingMiddleware({ host: '127.0.0.1:3050' });
+    });
+
+    it('should reject non-loopback origins before CORS for loopback external URLs', async () => {
+      mockConfigManager.get.mockImplementation((key: string) => {
+        if (key === 'trustProxy') return 'loopback';
+        if (key === 'auth') return { sessionStoragePath: '/tmp/sessions' };
+        if (key === 'features') return { enhancedSecurity: false, auth: false };
+        if (key === 'externalUrl') return 'http://127.0.0.1:3050';
+        if (key === 'host') return '0.0.0.0';
+        if (key === 'port') return 3050;
+        if (key === 'rateLimit') return { windowMs: 900000, max: 100 };
+        if (key === 'sessionPersistence') return { backgroundFlushSeconds: 30 };
+        return undefined;
+      });
+      mockConfigManager.getUrl.mockReturnValue('http://127.0.0.1:3050');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      const blockedResult = getBlockingMiddleware({
+        host: '127.0.0.1:3050',
+        origin: 'http://attacker.example:3050',
+      });
+
+      expect(blockedResult.res.status).toHaveBeenCalledWith(403);
+      expect(blockedResult.res.json).toHaveBeenCalledWith({ error: 'Forbidden origin header' });
+      expect(blockedResult.next).not.toHaveBeenCalled();
+    });
+
+    it('should allow public host headers for public external URLs', async () => {
+      mockConfigManager.get.mockImplementation((key: string) => {
+        if (key === 'trustProxy') return 'loopback';
+        if (key === 'auth') return { sessionStoragePath: '/tmp/sessions' };
+        if (key === 'features') return { enhancedSecurity: false, auth: false };
+        if (key === 'externalUrl') return 'https://mcp.example.com';
+        if (key === 'host') return '127.0.0.1';
+        if (key === 'port') return 3050;
+        if (key === 'rateLimit') return { windowMs: 900000, max: 100 };
+        if (key === 'sessionPersistence') return { backgroundFlushSeconds: 30 };
+        return undefined;
+      });
+      mockConfigManager.getUrl.mockReturnValue('https://mcp.example.com');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      expectNoBlockingMiddleware({ host: 'mcp.example.com' });
+    });
+
+    it('should reject spoofed host headers for public external URLs', async () => {
+      mockConfigManager.get.mockImplementation((key: string) => {
+        if (key === 'trustProxy') return 'loopback';
+        if (key === 'auth') return { sessionStoragePath: '/tmp/sessions' };
+        if (key === 'features') return { enhancedSecurity: false, auth: false };
+        if (key === 'externalUrl') return 'https://mcp.example.com';
+        if (key === 'host') return '127.0.0.1';
+        if (key === 'port') return 3050;
+        if (key === 'rateLimit') return { windowMs: 900000, max: 100 };
+        if (key === 'sessionPersistence') return { backgroundFlushSeconds: 30 };
+        return undefined;
+      });
+      mockConfigManager.getUrl.mockReturnValue('https://mcp.example.com');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      const blockedResult = getBlockingMiddleware({ host: 'attacker.example:3050' });
+
+      expect(blockedResult.res.status).toHaveBeenCalledWith(403);
+      expect(blockedResult.res.json).toHaveBeenCalledWith({ error: 'Forbidden host header' });
+      expect(blockedResult.next).not.toHaveBeenCalled();
     });
 
     it('should handle security middleware conditionally', async () => {

--- a/src/transport/http/server.test.ts
+++ b/src/transport/http/server.test.ts
@@ -69,7 +69,7 @@ vi.mock('./middlewares/scopeAuthMiddleware.js', () => ({
 }));
 
 vi.mock('./middlewares/httpRequestLogger.js', () => ({
-  httpRequestLogger: vi.fn(),
+  httpRequestLogger: vi.fn((_req, _res, next) => next()),
 }));
 
 vi.mock('./routes/streamableHttpRoutes.js', () => ({
@@ -113,32 +113,53 @@ describe('ExpressServer', () => {
   let mockConfigManager: any;
   let expressServer: ExpressServer;
 
-  const runRegisteredMiddleware = (headers: Record<string, string>) =>
-    mockApp.use.mock.calls
+  type TestHeaders = Record<string, string | string[] | undefined>;
+  type MiddlewareResult = {
+    middleware: any;
+    res: {
+      status: ReturnType<typeof vi.fn>;
+      json: ReturnType<typeof vi.fn>;
+    };
+    next: ReturnType<typeof vi.fn>;
+  };
+
+  const runRegisteredMiddleware = (headers: TestHeaders) => {
+    const results: MiddlewareResult[] = [];
+    const middlewares = mockApp.use.mock.calls
       .map(([middleware]: any[]) => middleware)
-      .filter((middleware: unknown) => typeof middleware === 'function')
-      .map((middleware: any) => {
-        const res = {
-          status: vi.fn().mockReturnThis(),
-          json: vi.fn().mockReturnThis(),
-        };
-        const next = vi.fn();
+      .filter((middleware: unknown) => typeof middleware === 'function');
 
-        middleware({ headers }, res, next);
+    for (const middleware of middlewares) {
+      const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+      };
+      const next = vi.fn();
 
-        return { middleware, res, next };
-      });
+      middleware({ headers }, res, next);
+      results.push({ middleware, res, next });
 
-  const getBlockingMiddleware = (headers: Record<string, string>) => {
+      if (next.mock.calls.length === 0) {
+        break;
+      }
+    }
+
+    return results;
+  };
+
+  const getBlockingMiddleware = (headers: TestHeaders): MiddlewareResult => {
     const blockedResult = runRegisteredMiddleware(headers).find(
       ({ res }: any) => vi.mocked(res.status).mock.calls[0]?.[0] === 403,
     );
 
-    expect(blockedResult).toBeDefined();
+    if (!blockedResult) {
+      throw new Error('Expected a middleware to block the request');
+    }
+
     return blockedResult;
   };
 
-  const expectNoBlockingMiddleware = (headers: Record<string, string>) => {
+  const expectNoBlockingMiddleware = (headers: TestHeaders) => {
     expect(
       runRegisteredMiddleware(headers).some(({ res }: any) => vi.mocked(res.status).mock.calls[0]?.[0] === 403),
     ).toBe(false);
@@ -560,6 +581,57 @@ describe('ExpressServer', () => {
       expressServer = new ExpressServer(mockServerManager);
 
       expectNoBlockingMiddleware({ host: '127.0.0.1:3050' });
+    });
+
+    it('should reject malformed bracketed loopback host headers', async () => {
+      mockConfigManager.get.mockImplementation((key: string) => {
+        if (key === 'trustProxy') return 'loopback';
+        if (key === 'auth') return { sessionStoragePath: '/tmp/sessions' };
+        if (key === 'features') return { enhancedSecurity: false, auth: false };
+        if (key === 'externalUrl') return 'http://127.0.0.1:3050';
+        if (key === 'host') return '0.0.0.0';
+        if (key === 'port') return 3050;
+        if (key === 'rateLimit') return { windowMs: 900000, max: 100 };
+        if (key === 'sessionPersistence') return { backgroundFlushSeconds: 30 };
+        return undefined;
+      });
+      mockConfigManager.getUrl.mockReturnValue('http://127.0.0.1:3050');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      const blockedResult = getBlockingMiddleware({
+        host: '[::1]attacker.example',
+      });
+
+      expect(blockedResult.res.status).toHaveBeenCalledWith(403);
+      expect(blockedResult.res.json).toHaveBeenCalledWith({ error: 'Forbidden host header' });
+      expect(blockedResult.next).not.toHaveBeenCalled();
+    });
+
+    it('should reject duplicate origin headers on loopback requests', async () => {
+      mockConfigManager.get.mockImplementation((key: string) => {
+        if (key === 'trustProxy') return 'loopback';
+        if (key === 'auth') return { sessionStoragePath: '/tmp/sessions' };
+        if (key === 'features') return { enhancedSecurity: false, auth: false };
+        if (key === 'externalUrl') return 'http://127.0.0.1:3050';
+        if (key === 'host') return '0.0.0.0';
+        if (key === 'port') return 3050;
+        if (key === 'rateLimit') return { windowMs: 900000, max: 100 };
+        if (key === 'sessionPersistence') return { backgroundFlushSeconds: 30 };
+        return undefined;
+      });
+      mockConfigManager.getUrl.mockReturnValue('http://127.0.0.1:3050');
+
+      expressServer = new ExpressServer(mockServerManager);
+
+      const blockedResult = getBlockingMiddleware({
+        host: '127.0.0.1:3050',
+        origin: ['http://127.0.0.1:3050', 'http://attacker.example:3050'],
+      });
+
+      expect(blockedResult.res.status).toHaveBeenCalledWith(403);
+      expect(blockedResult.res.json).toHaveBeenCalledWith({ error: 'Forbidden origin header' });
+      expect(blockedResult.next).not.toHaveBeenCalled();
     });
 
     it('should reject non-loopback origins before CORS for loopback external URLs', async () => {

--- a/src/transport/http/server.ts
+++ b/src/transport/http/server.ts
@@ -13,6 +13,7 @@ import logger from '@src/logger/logger.js';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import express from 'express';
+import { z } from 'zod';
 
 import errorHandler from './middlewares/errorHandler.js';
 import { httpRequestLogger } from './middlewares/httpRequestLogger.js';
@@ -35,6 +36,13 @@ interface CompatibleRateLimitOptions {
   legacyHeaders?: boolean;
   handler?: (req: express.Request, res: express.Response) => void;
 }
+
+const RequestHeaderSchema = z
+  .object({
+    host: z.union([z.string(), z.array(z.string())]).optional(),
+    origin: z.union([z.string(), z.array(z.string())]).optional(),
+  })
+  .passthrough();
 
 function isLoopbackOrigin(origin: string | undefined): boolean {
   if (!origin) {
@@ -72,7 +80,16 @@ function normalizeHostHeader(host: string | string[] | undefined): string | unde
 
   if (normalizedHost.startsWith('[')) {
     const end = normalizedHost.indexOf(']');
-    return end > 0 ? host.slice(1, end).toLowerCase() : undefined;
+    if (end <= 0) {
+      return undefined;
+    }
+
+    const remainder = normalizedHost.slice(end + 1);
+    if (remainder && !/^:\d+$/.test(remainder)) {
+      return undefined;
+    }
+
+    return normalizedHost.slice(1, end);
   }
 
   const colonCount = (normalizedHost.match(/:/g) || []).length;
@@ -138,17 +155,23 @@ function isHostAllowed(
 
 function createLoopbackRequestGuard(configManager: AgentConfigManager): express.RequestHandler {
   return (req, res, next) => {
+    const headers = RequestHeaderSchema.safeParse(req.headers);
+    if (!headers.success) {
+      res.status(403).json({ error: 'Forbidden host header' });
+      return;
+    }
+
     const externalHostname = getUrlHostname(configManager.get('externalUrl'));
     const boundHostname = normalizeHostHeader(configManager.get('host'));
-    const requestHost = normalizeHostHeader(req.headers.host);
+    const requestHost = normalizeHostHeader(headers.data.host);
 
     if (!isHostAllowed(requestHost, externalHostname, boundHostname)) {
       res.status(403).json({ error: 'Forbidden host header' });
       return;
     }
 
-    const origin = Array.isArray(req.headers.origin) ? undefined : req.headers.origin;
-    if (isLoopbackHostname(requestHost) && req.headers.origin && (!origin || !isLoopbackOrigin(origin))) {
+    const origin = headers.data.origin;
+    if (isLoopbackHostname(requestHost) && origin && (Array.isArray(origin) || !isLoopbackOrigin(origin))) {
       res.status(403).json({ error: 'Forbidden origin header' });
       return;
     }

--- a/src/transport/http/server.ts
+++ b/src/transport/http/server.ts
@@ -59,6 +59,104 @@ function isLoopbackOrigin(origin: string | undefined): boolean {
   }
 }
 
+function normalizeHostHeader(host: string | string[] | undefined): string | undefined {
+  if (!host) {
+    return undefined;
+  }
+
+  if (Array.isArray(host)) {
+    return undefined;
+  }
+
+  const normalizedHost = host.toLowerCase();
+
+  if (normalizedHost.startsWith('[')) {
+    const end = normalizedHost.indexOf(']');
+    return end > 0 ? host.slice(1, end).toLowerCase() : undefined;
+  }
+
+  const colonCount = (normalizedHost.match(/:/g) || []).length;
+  if (colonCount === 0) {
+    return normalizedHost;
+  }
+  if (colonCount === 1) {
+    return normalizedHost.split(':')[0];
+  }
+
+  return normalizedHost;
+}
+
+function isLoopbackHostname(hostname: string | undefined): boolean {
+  if (!hostname) {
+    return false;
+  }
+
+  const normalizedHost = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  const hostParts = normalizedHost.split('.');
+  const isIPv4Loopback =
+    hostParts.length === 4 &&
+    hostParts[0] === '127' &&
+    hostParts.every((part) => /^\d+$/.test(part) && Number(part) <= 255);
+
+  return normalizedHost === 'localhost' || normalizedHost === '::1' || isIPv4Loopback;
+}
+
+function isWildcardHostname(hostname: string | undefined): boolean {
+  return hostname === '0.0.0.0' || hostname === '::';
+}
+
+function getUrlHostname(url: string | undefined): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    return normalizeHostHeader(new URL(url).hostname);
+  } catch {
+    return undefined;
+  }
+}
+
+function isHostAllowed(
+  requestHost: string | undefined,
+  externalHostname: string | undefined,
+  boundHostname: string | undefined,
+): boolean {
+  if (externalHostname && requestHost === externalHostname) {
+    return true;
+  }
+
+  if (
+    isLoopbackHostname(requestHost) &&
+    (isLoopbackHostname(externalHostname) || isLoopbackHostname(boundHostname) || isWildcardHostname(boundHostname))
+  ) {
+    return true;
+  }
+
+  return !externalHostname && Boolean(boundHostname) && requestHost === boundHostname;
+}
+
+function createLoopbackRequestGuard(configManager: AgentConfigManager): express.RequestHandler {
+  return (req, res, next) => {
+    const externalHostname = getUrlHostname(configManager.get('externalUrl'));
+    const boundHostname = normalizeHostHeader(configManager.get('host'));
+    const requestHost = normalizeHostHeader(req.headers.host);
+
+    if (!isHostAllowed(requestHost, externalHostname, boundHostname)) {
+      res.status(403).json({ error: 'Forbidden host header' });
+      return;
+    }
+
+    const origin = Array.isArray(req.headers.origin) ? undefined : req.headers.origin;
+    if (isLoopbackHostname(requestHost) && req.headers.origin && (!origin || !isLoopbackOrigin(origin))) {
+      res.status(403).json({ error: 'Forbidden origin header' });
+      return;
+    }
+
+    next();
+  };
+}
+
 /**
  * ExpressServer orchestrates the HTTP/SSE transport layer for the MCP server.
  *
@@ -141,6 +239,7 @@ export class ExpressServer {
 
     // Add HTTP request logging middleware (early in the stack for complete coverage)
     this.app.use(httpRequestLogger);
+    this.app.use(createLoopbackRequestGuard(this.configManager));
 
     this.app.use(
       cors({


### PR DESCRIPTION
## Summary
- add request Host validation before CORS and route handling
- allow configured public external URLs and valid loopback access
- reject spoofed Host and non-loopback Origin combinations for local HTTP transport paths

## Verification
- pnpm vitest run src/transport/http/server.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added a loopback/bound-host request guard that validates incoming `Host` and `Origin` headers and blocks spoofed or malformed values.  
- Unauthorized requests now receive a **403 (Forbidden)** response with a clear error message (e.g., forbidden host/origin).  
- Local requests remain functional when they match the configured loopback/bound host rules, including IPv6/bracketed `Host` handling and duplicate origin scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->