### PR TITLE
fix: correct prerelease release notes and branch finalization

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -77,8 +77,15 @@ jobs:
             echo "::error::Invalid npm tag: $NPM_TAG"
             exit 1
           fi
-          if [[ -n "$PRERELEASE_CHANNEL" && "$NPM_TAG" != "$PRERELEASE_CHANNEL" ]]; then
-            echo "::error::Prerelease tags must use npm_tag=$PRERELEASE_CHANNEL"
+          if [[ "$PRERELEASE_CHANNEL" =~ ^(alpha|beta|rc)([0-9-].*)?$ ]]; then
+            EXPECTED_NPM_TAG=next
+          elif [[ -n "$PRERELEASE_CHANNEL" ]]; then
+            EXPECTED_NPM_TAG="$PRERELEASE_CHANNEL"
+          else
+            EXPECTED_NPM_TAG=latest
+          fi
+          if [[ "$NPM_TAG" != "$EXPECTED_NPM_TAG" ]]; then
+            echo "::error::Release tags must use npm_tag=$EXPECTED_NPM_TAG"
             exit 1
           fi
           if [[ -z "$PRERELEASE_CHANNEL" && "$NPM_TAG" != "latest" ]]; then
@@ -110,14 +117,34 @@ jobs:
       - name: Publish to npm
         run: pnpm publish --no-git-checks --access public --provenance --tag ${{ inputs.npm_tag }}
 
+      - name: Resolve release changelog range
+        id: release-notes-range
+        env:
+          VERSION_TAG: ${{ inputs.version_tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: node scripts/resolve-release-notes-range.cjs "$VERSION_TAG" "$RELEASE_SHA"
+
       - name: Generate release changelog
         uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
           config: cliff-release.toml
-          args: --latest --strip header
+          args: --tag ${{ inputs.version_tag }} --strip header ${{ steps.release-notes-range.outputs.range }}
         env:
           GITHUB_REPO: ${{ github.repository }}
+
+      - name: Finalize release changelog
+        id: release-notes
+        env:
+          GIT_CLIFF_OUTPUT: ${{ steps.git-cliff.outputs.changelog }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+          PREVIOUS_TAG: ${{ steps.release-notes-range.outputs.previous_tag }}
+          NPM_TAG: ${{ inputs.npm_tag }}
+        run: |
+          set -euo pipefail
+
+          node scripts/finalize-release-notes.cjs "$GIT_CLIFF_OUTPUT" release-notes.md "$VERSION_TAG" "$PREVIOUS_TAG" "$NPM_TAG"
+          echo "path=release-notes.md" >> "$GITHUB_OUTPUT"
 
       - name: Download all binary artifacts
         uses: actions/download-artifact@v4
@@ -130,7 +157,7 @@ jobs:
           tag_name: ${{ inputs.version_tag }}
           target_commitish: ${{ inputs.release_sha }}
           name: Release ${{ inputs.version_tag }}
-          body: ${{ steps.git-cliff.outputs.content }}
+          body_path: ${{ steps.release-notes.outputs.path }}
           files: binaries/*/*
           draft: false
           prerelease: ${{ inputs.is_prerelease }}

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -109,11 +109,11 @@ jobs:
       id-token: write
 
   # Cuts the release-X.Y maintenance branch only after npm + docker + GitHub
-  # release all succeeded. Skipped for prereleases and for releases that already
-  # ran from a release-X.Y branch.
+  # release all succeeded. Skipped for releases that already ran from a
+  # release-X.Y branch.
   finalize:
     needs: [validate, update-version, release]
-    if: ${{ needs.validate.outputs.release_ref == 'main' && needs.validate.outputs.is_prerelease != 'true' }}
+    if: ${{ needs.validate.outputs.release_ref == 'main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/finalize-release-notes.cjs
+++ b/scripts/finalize-release-notes.cjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const VERSION_TAG_REGEX = /^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+const NPM_TAG_REGEX = /^[A-Za-z][0-9A-Za-z-]*$|^latest$/;
+
+function validateInputs({ versionTag, previousTag, npmTag }) {
+  if (!VERSION_TAG_REGEX.test(versionTag)) {
+    throw new Error('version_tag must be a v-prefixed semver tag.');
+  }
+
+  if (!VERSION_TAG_REGEX.test(previousTag)) {
+    throw new Error('previous_tag must be a v-prefixed semver tag.');
+  }
+
+  if (!NPM_TAG_REGEX.test(npmTag)) {
+    throw new Error('npm_tag must be latest or a valid npm dist-tag.');
+  }
+}
+
+function finalizeReleaseNotes({ content, versionTag, previousTag, npmTag }) {
+  validateInputs({ versionTag, previousTag, npmTag });
+
+  if (!content.includes(`releases/download/${versionTag}`)) {
+    throw new Error(`Release notes do not link to ${versionTag} downloads.`);
+  }
+
+  if (!content.includes(`compare/${previousTag}...${versionTag}`)) {
+    throw new Error(`Release notes do not compare ${previousTag}...${versionTag}.`);
+  }
+
+  return content
+    .replace(/Use `@next` tag for NPM/g, `Use \`@${npmTag}\` tag for NPM`)
+    .replace(/@1mcp\/agent@next/g, `@1mcp/agent@${npmTag}`);
+}
+
+if (require.main === module) {
+  const [inputPath, outputPath, versionTag, previousTag, npmTag] = process.argv.slice(2);
+
+  if (!inputPath || !outputPath || !versionTag || !previousTag || !npmTag) {
+    console.error(
+      'Usage: node scripts/finalize-release-notes.cjs <input_path> <output_path> <version_tag> <previous_tag> <npm_tag>',
+    );
+    process.exit(1);
+  }
+
+  try {
+    const content = fs.readFileSync(inputPath, 'utf8');
+    const finalized = finalizeReleaseNotes({ content, versionTag, previousTag, npmTag });
+    fs.writeFileSync(outputPath, finalized, 'utf8');
+    console.log(`Finalized release notes for ${versionTag}.`);
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { finalizeReleaseNotes };

--- a/scripts/resolve-release-notes-range.cjs
+++ b/scripts/resolve-release-notes-range.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+const VERSION_TAG_REGEX = /^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+const RELEASE_SHA_REGEX = /^[0-9a-f]{40}$/;
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function resolveReleaseNotesRange({ versionTag, releaseSha, cwd = process.cwd() }) {
+  if (!VERSION_TAG_REGEX.test(versionTag)) {
+    throw new Error('version_tag must be a v-prefixed semver tag.');
+  }
+
+  if (!RELEASE_SHA_REGEX.test(releaseSha)) {
+    throw new Error('release_sha must be a 40-character lowercase hexadecimal commit SHA.');
+  }
+
+  let previousTag;
+  try {
+    previousTag = git(cwd, ['describe', '--tags', '--abbrev=0', `${releaseSha}^`]);
+  } catch {
+    throw new Error(`Unable to resolve previous release tag before ${versionTag}.`);
+  }
+
+  return {
+    previousTag,
+    range: `${previousTag}..${releaseSha}`,
+  };
+}
+
+function writeGitHubOutputs(outputs, outputPath) {
+  const lines = Object.entries(outputs).map(([key, value]) => `${key}=${value}`);
+  fs.appendFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+if (require.main === module) {
+  const [versionTag, releaseSha] = process.argv.slice(2);
+
+  if (!versionTag || !releaseSha) {
+    console.error('Usage: node scripts/resolve-release-notes-range.cjs <version_tag> <release_sha>');
+    process.exit(1);
+  }
+
+  try {
+    const outputs = resolveReleaseNotesRange({ versionTag, releaseSha });
+    const githubOutput = process.env.GITHUB_OUTPUT;
+
+    if (githubOutput) {
+      writeGitHubOutputs(
+        {
+          previous_tag: outputs.previousTag,
+          range: outputs.range,
+        },
+        githubOutput,
+      );
+    }
+
+    console.log(`Resolved release notes range ${outputs.range} for ${versionTag}.`);
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { resolveReleaseNotesRange };

--- a/scripts/validate-release-inputs.cjs
+++ b/scripts/validate-release-inputs.cjs
@@ -7,6 +7,7 @@ const VERSION_CORE_PART_REGEX = /^(0|[1-9][0-9]*)$/;
 const PRERELEASE_IDENTIFIER_REGEX = /^[0-9A-Za-z-]+$/;
 const RELEASE_CHANNEL_REGEX = /^[A-Za-z][0-9A-Za-z-]*$/;
 const RELEASE_REF_REGEX = /^release-[0-9]+\.[0-9]+$/;
+const NEXT_NPM_CHANNEL_REGEX = /^(alpha|beta|rc)([0-9-].*)?$/;
 
 function defaultTagExists(tagName) {
   try {
@@ -64,6 +65,14 @@ function parseVersion(version) {
   return { major: coreParts[0], minor: coreParts[1], prerelease };
 }
 
+function resolveNpmTag(releaseChannel) {
+  if (!releaseChannel) {
+    return 'latest';
+  }
+
+  return NEXT_NPM_CHANNEL_REGEX.test(releaseChannel) ? 'next' : releaseChannel;
+}
+
 function validateReleaseInputs({ targetRef, version, tagExists = defaultTagExists }) {
   if (targetRef !== 'main' && !RELEASE_REF_REGEX.test(targetRef)) {
     throw new Error('target_ref must be main or release-<major>.<minor>.');
@@ -99,7 +108,7 @@ function validateReleaseInputs({ targetRef, version, tagExists = defaultTagExist
     targetRef,
     expectedReleaseBranch,
     isPrerelease,
-    npmTag: isPrerelease ? releaseChannel : 'latest',
+    npmTag: resolveNpmTag(releaseChannel),
     dockerRawTag: isPrerelease ? releaseChannel : 'latest',
   };
 }

--- a/src/release/finalize-release-notes.test.ts
+++ b/src/release/finalize-release-notes.test.ts
@@ -1,0 +1,55 @@
+import { createRequire } from 'module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { finalizeReleaseNotes } = require('../../scripts/finalize-release-notes.cjs') as {
+  finalizeReleaseNotes: (args: { content: string; versionTag: string; previousTag: string; npmTag: string }) => string;
+};
+
+describe('finalizeReleaseNotes', () => {
+  it('keeps prerelease npm instructions on the next tag', () => {
+    const content = [
+      '> **Pre-release Version**: This is a pre-release build. Use `@next` tag for NPM.',
+      'https://github.com/1mcp-app/agent/releases/download/v0.33.0-beta1/1mcp-linux-x64.tar.gz',
+      'npm install -g @1mcp/agent@next',
+      '**Full Changelog**: https://github.com/1mcp-app/agent/compare/v0.32.2...v0.33.0-beta1',
+    ].join('\n');
+
+    const finalized = finalizeReleaseNotes({
+      content,
+      versionTag: 'v0.33.0-beta1',
+      previousTag: 'v0.32.2',
+      npmTag: 'next',
+    });
+
+    expect(finalized).toContain('Use `@next` tag for NPM');
+    expect(finalized).toContain('npm install -g @1mcp/agent@next');
+    expect(finalized).not.toContain('@1mcp/agent@beta1');
+  });
+
+  it('rejects release notes that point at the wrong download tag', () => {
+    expect(() =>
+      finalizeReleaseNotes({
+        content:
+          'https://github.com/1mcp-app/agent/releases/download/v0.32.2/1mcp-linux-x64.tar.gz\n' +
+          '**Full Changelog**: https://github.com/1mcp-app/agent/compare/v0.32.2...v0.33.0-beta1',
+        versionTag: 'v0.33.0-beta1',
+        previousTag: 'v0.32.2',
+        npmTag: 'beta1',
+      }),
+    ).toThrow('Release notes do not link to v0.33.0-beta1 downloads.');
+  });
+
+  it('rejects release notes that compare the wrong release range', () => {
+    expect(() =>
+      finalizeReleaseNotes({
+        content:
+          'https://github.com/1mcp-app/agent/releases/download/v0.33.0-beta1/1mcp-linux-x64.tar.gz\n' +
+          '**Full Changelog**: https://github.com/1mcp-app/agent/compare/v0.32.1...v0.32.2',
+        versionTag: 'v0.33.0-beta1',
+        previousTag: 'v0.32.2',
+        npmTag: 'beta1',
+      }),
+    ).toThrow('Release notes do not compare v0.32.2...v0.33.0-beta1.');
+  });
+});

--- a/src/release/release-notes-range.test.ts
+++ b/src/release/release-notes-range.test.ts
@@ -1,0 +1,67 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { createRequire } from 'module';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { resolveReleaseNotesRange } = require('../../scripts/resolve-release-notes-range.cjs') as {
+  resolveReleaseNotesRange: (args: { versionTag: string; releaseSha: string; cwd?: string }) => {
+    previousTag: string;
+    range: string;
+  };
+};
+
+const tempRoots: string[] = [];
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function createFixtureRepository(): { cwd: string; releaseSha: string } {
+  fs.mkdirSync(path.join(process.cwd(), '.tmp'), { recursive: true });
+  const cwd = fs.mkdtempSync(path.join(process.cwd(), '.tmp', 'release-notes-range-'));
+  tempRoots.push(cwd);
+
+  git(cwd, ['init', '--initial-branch', 'main']);
+  git(cwd, ['config', 'user.email', 'test@example.com']);
+  git(cwd, ['config', 'user.name', 'Test User']);
+
+  fs.writeFileSync(path.join(cwd, 'file.txt'), 'previous\n');
+  git(cwd, ['add', 'file.txt']);
+  git(cwd, ['commit', '-m', 'previous release']);
+  git(cwd, ['tag', 'v1.2.3']);
+
+  fs.writeFileSync(path.join(cwd, 'file.txt'), 'current\n');
+  git(cwd, ['add', 'file.txt']);
+  git(cwd, ['commit', '-m', 'current release']);
+  const releaseSha = git(cwd, ['rev-parse', 'HEAD']);
+  git(cwd, ['tag', 'v1.3.0-beta1']);
+
+  return { cwd, releaseSha };
+}
+
+afterEach(() => {
+  for (const tempRoot of tempRoots.splice(0)) {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe('resolveReleaseNotesRange', () => {
+  it('resolves release notes from the previous reachable tag to the release SHA', () => {
+    const { cwd, releaseSha } = createFixtureRepository();
+
+    expect(resolveReleaseNotesRange({ cwd, versionTag: 'v1.3.0-beta1', releaseSha })).toEqual({
+      previousTag: 'v1.2.3',
+      range: `v1.2.3..${releaseSha}`,
+    });
+  });
+
+  it.each([
+    ['1.3.0', '0123456789abcdef0123456789abcdef01234567', 'version_tag must be a v-prefixed semver tag.'],
+    ['v1.3.0', 'not-a-sha', 'release_sha must be a 40-character lowercase hexadecimal commit SHA.'],
+  ])('rejects invalid inputs', (versionTag, releaseSha, expectedError) => {
+    expect(() => resolveReleaseNotesRange({ versionTag, releaseSha })).toThrow(expectedError);
+  });
+});

--- a/src/release/release-pipeline-workflow.test.ts
+++ b/src/release/release-pipeline-workflow.test.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+function readReleasePipelineWorkflow(): string {
+  return fs.readFileSync(path.join(process.cwd(), '.github', 'workflows', 'release-pipeline.yml'), 'utf8');
+}
+
+describe('release-pipeline workflow', () => {
+  it('creates the release branch for prereleases that run from main', () => {
+    const workflow = readReleasePipelineWorkflow();
+    const finalizeJob = workflow.match(/\n\s{2}finalize:\n(?<body>(?:\s{4}.*\n)+)/)?.groups?.body;
+
+    expect(finalizeJob).toBeDefined();
+    expect(finalizeJob).toContain("if: ${{ needs.validate.outputs.release_ref == 'main' }}");
+    expect(finalizeJob).not.toContain('is_prerelease');
+  });
+});

--- a/src/release/validate-release-inputs.test.ts
+++ b/src/release/validate-release-inputs.test.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'module';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const { validateReleaseInputs } = require('../scripts/validate-release-inputs.cjs') as {
+const { validateReleaseInputs } = require('../../scripts/validate-release-inputs.cjs') as {
   validateReleaseInputs: (args: { targetRef: string; version: string; tagExists?: (tagName: string) => boolean }) => {
     version: string;
     versionTag: string;
@@ -16,11 +16,13 @@ const { validateReleaseInputs } = require('../scripts/validate-release-inputs.cj
 
 describe('validateReleaseInputs', () => {
   it.each([
-    ['1.2.3-alpha.1', 'alpha'],
-    ['1.2.3-alpha-build.1', 'alpha-build'],
-    ['1.2.3-beta1', 'beta1'],
-    ['1.2.3-rc1', 'rc1'],
-  ])('accepts semver prerelease version %s', (version, releaseTag) => {
+    ['1.2.3-alpha.1', 'next', 'alpha'],
+    ['1.2.3-alpha-build.1', 'next', 'alpha-build'],
+    ['1.2.3-beta1', 'next', 'beta1'],
+    ['1.2.3-beta.1', 'next', 'beta'],
+    ['1.2.3-rc1', 'next', 'rc1'],
+    ['1.2.3-canary.1', 'canary', 'canary'],
+  ])('maps semver prerelease version %s to npm tag %s', (version, npmTag, dockerRawTag) => {
     const result = validateReleaseInputs({
       targetRef: 'main',
       version,
@@ -32,8 +34,8 @@ describe('validateReleaseInputs', () => {
       versionTag: `v${version}`,
       expectedReleaseBranch: 'release-1.2',
       isPrerelease: true,
-      npmTag: releaseTag,
-      dockerRawTag: releaseTag,
+      npmTag,
+      dockerRawTag,
     });
   });
 


### PR DESCRIPTION
## Summary
This PR fixes the prerelease release flow so GitHub Release notes and npm dist-tags match the actual published version.

- Adds an explicit release-notes range resolver so release changelogs are generated from the previous reachable tag through the exact release SHA instead of relying on `git-cliff --latest`.
- Adds a release-note finalization step that validates the download tag, validates the compare range, and rewrites npm install guidance to the resolved npm dist-tag.
- Maps `alpha*`, `beta*`, and `rc*` prerelease channels to npm `next`, while preserving custom prerelease channels like `canary`.
- Updates the release pipeline finalize job so releases from `main`, including prereleases, create the expected `release-X.Y` branch.
- Adds regression coverage for release-note range resolution, release-note finalization, npm tag policy, and release workflow finalization.

## Test Coverage
All new release-script and workflow policy paths are covered by focused regression tests:

- `src/release/finalize-release-notes.test.ts`
- `src/release/release-notes-range.test.ts`
- `src/release/release-pipeline-workflow.test.ts`
- `src/release/validate-release-inputs.test.ts`

## Pre-Landing Review
Manual scoped review found no blocking issue in the changed release scripts/workflows.

## Design Review
No frontend files changed, design review skipped.

## Eval Results
No prompt-related files changed, evals skipped.

## Plan Completion
No plan file detected for this PR creation pass.

## Verification Results
- [x] `pnpm test:unit -- src/release/finalize-release-notes.test.ts src/release/release-notes-range.test.ts src/release/release-pipeline-workflow.test.ts src/release/validate-release-inputs.test.ts` passed. Vitest ran 247 files and 3,724 tests successfully under the repo config.
- [x] `pnpm exec prettier --check` passed on all touched workflow, script, and release test files.
- [x] `git diff --check origin/main...HEAD` passed.
- [ ] `actionlint` was not run because it is not installed in this checkout (`pnpm exec actionlint` reports command not found).

## Test plan
- [x] Full unit test suite passed through the focused release test command.
- [x] Formatting check passed for touched files.
- [x] Whitespace check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release validation logic for improved npm package publishing accuracy
  * Refined release notes generation and formatting workflow
  
* **Tests**
  * Added test coverage for release pipelines and release notes processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->