### PR TITLE
fix: release pipeline validation speed

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -13,12 +13,12 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: .node-version
         cache: pnpm

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -91,7 +91,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_sha || format('refs/heads/{0}', inputs.release_ref || 'main') }}
           persist-credentials: false
@@ -133,7 +133,7 @@ jobs:
         run: pnpm archive
 
       - name: Upload compressed archive artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: |

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -139,4 +139,5 @@ jobs:
           path: |
             *.tar.gz
             *.zip
+          if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -33,7 +33,8 @@ concurrency:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    name: docker (${{ matrix.target }}, ${{ matrix.platform_name }})
+    runs-on: ${{ matrix.runner }}
     environment: release
     permissions:
       contents: read
@@ -41,13 +42,31 @@ jobs:
       security-events: write
 
     strategy:
+      fail-fast: false
       matrix:
-        target: [basic, extended]
         include:
           - target: basic
+            platform: linux/amd64
+            platform_name: amd64
+            runner: ubuntu-latest
             suffix: -lite
             raw_tag: lite
           - target: extended
+            platform: linux/amd64
+            platform_name: amd64
+            runner: ubuntu-latest
+            suffix: ''
+            raw_tag: latest
+          - target: basic
+            platform: linux/arm64
+            platform_name: arm64
+            runner: ubuntu-24.04-arm
+            suffix: -lite
+            raw_tag: lite
+          - target: extended
+            platform: linux/arm64
+            platform_name: arm64
+            runner: ubuntu-24.04-arm
             suffix: ''
             raw_tag: latest
 
@@ -103,7 +122,7 @@ jobs:
           fi
 
       - name: Checkout release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_sha }}
           persist-credentials: false
@@ -131,7 +150,7 @@ jobs:
           fi
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -139,7 +158,7 @@ jobs:
 
       - name: Extract metadata for Docker image
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -153,25 +172,102 @@ jobs:
         run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        id: build
+        uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
           target: ${{ matrix.target }}
           build-args: |
             NODE_VERSION=${{ steps.node-version.outputs.version }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          cache-from: |
-            type=gha,scope=${{ matrix.target }}
-            type=gha,scope=shared
-          cache-to: |
-            type=gha,mode=max,scope=${{ matrix.target }}
-            type=gha,mode=max,scope=shared
-          platforms: linux/amd64,linux/arm64
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.target }}-${{ matrix.platform_name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.platform_name }}
+          platforms: ${{ matrix.platform }}
           provenance: false
           sbom: false
+
+      - name: Export Docker build metadata
+        run: |
+          set -euo pipefail
+          mkdir -p "docker-metadata/${{ matrix.target }}/tags" "docker-metadata/${{ matrix.target }}/digests"
+          printf '%s\n' '${{ steps.meta.outputs.tags }}' > "docker-metadata/${{ matrix.target }}/tags/${{ matrix.platform_name }}.txt"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "docker-metadata/${{ matrix.target }}/digests/${digest#sha256:}"
+
+      - name: Upload Docker metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: docker-${{ matrix.target }}-${{ matrix.platform_name }}
+          path: docker-metadata/${{ matrix.target }}
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-manifest:
+    name: docker manifest (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    needs: docker
+    environment: release
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: basic
+          - target: extended
+
+    steps:
+      - name: Download Docker metadata
+        uses: actions/download-artifact@v8
+        with:
+          pattern: docker-${{ matrix.target }}-*
+          path: docker-metadata
+          merge-multiple: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Create multi-platform Docker manifests
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t tags < <(cat docker-metadata/tags/*.txt | sort -u)
+          if (( ${#tags[@]} == 0 )); then
+            echo "::error::No Docker tags were produced for ${{ matrix.target }}"
+            exit 1
+          fi
+
+          mapfile -t digests < <(find docker-metadata/digests -maxdepth 1 -type f -print | sort)
+          if (( ${#digests[@]} == 0 )); then
+            echo "::error::No Docker digests were produced for ${{ matrix.target }}"
+            exit 1
+          fi
+
+          sources=()
+          for digest_file in "${digests[@]}"; do
+            digest="$(basename "$digest_file")"
+            sources+=("${IMAGE}@sha256:${digest}")
+          done
+
+          tag_args=()
+          for tag in "${tags[@]}"; do
+            tag_args+=("--tag" "$tag")
+          done
+
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
           cache: pnpm
@@ -52,7 +52,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Build with VitePress
         run: |
@@ -60,7 +60,7 @@ jobs:
           touch docs/.vitepress/dist/.nojekyll
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   deploy_cf:
     environment:
@@ -83,7 +83,7 @@ jobs:
     needs: build
     steps:
       - name: Download github pages artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: github-pages
       - name: Extract files
@@ -91,7 +91,7 @@ jobs:
           mkdir public
           tar -xvf artifact.tar -C public
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -101,7 +101,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_sha }}
           fetch-depth: 0
@@ -147,12 +147,12 @@ jobs:
           echo "path=release-notes.md" >> "$GITHUB_OUTPUT"
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: binaries/
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version_tag }}
           target_commitish: ${{ inputs.release_sha }}

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       npm_tag: ${{ steps.validate.outputs.npm_tag }}
       docker_raw_tag: ${{ steps.validate.outputs.docker_raw_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -118,7 +118,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v10
         with:
           # General settings
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-and-validate.yml
+++ b/.github/workflows/test-and-validate.yml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout_ref || github.ref }}
 
@@ -56,7 +56,7 @@ jobs:
         run: pnpm test:unit
 
   # Parallel E2E tests - run automatically on every push/PR
-  # Using 4 shards for ~75% faster execution (~4min total runtime)
+  # Using 6 shards to keep the growing suite latency bounded
   # Shard count is optimized for the current test suite size and CI runner capacity
   # To adjust shards: update E2E_SHARD_COUNT and matrix.shard array
   # Skip E2E tests for tag events to speed up releases
@@ -65,15 +65,15 @@ jobs:
     needs: ci
     if: github.ref_type != 'tag'
     env:
-      E2E_SHARD_COUNT: 4 # Configure number of parallel shards (adjust based on test suite size)
+      E2E_SHARD_COUNT: 6 # Configure number of parallel shards (adjust based on test suite size)
     strategy:
       matrix:
-        shard: [1, 2, 3, 4] # Update this array when changing E2E_SHARD_COUNT
+        shard: [1, 2, 3, 4, 5, 6] # Update this array when changing E2E_SHARD_COUNT
       fail-fast: false # Run all shards even if one fails for comprehensive results
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.checkout_ref || github.ref }}
 
@@ -85,8 +85,12 @@ jobs:
 
       - name: Test E2E - Shard ${{ matrix.shard }}/${{ env.E2E_SHARD_COUNT }}
         run: |
+          started_at=$(date +%s)
           # Run E2E tests with sharding for maximum parallelism
           # Each shard runs a portion of the tests in parallel
           pnpm test:e2e --shard=${{ matrix.shard }}/${{ env.E2E_SHARD_COUNT }} --reporter=minimal
+          finished_at=$(date +%s)
+          duration=$((finished_at - started_at))
+          echo "E2E shard ${{ matrix.shard }}/${{ env.E2E_SHARD_COUNT }} took ${duration}s" >> "$GITHUB_STEP_SUMMARY"
         env:
           CI: true

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -43,7 +43,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: refs/heads/${{ inputs.release_ref }}
           fetch-depth: 0

--- a/scripts/archive.cjs
+++ b/scripts/archive.cjs
@@ -20,6 +20,14 @@ function detectPlatform() {
   return 'linux';
 }
 
+function createArchiver(archiveFormat) {
+  if (archiveFormat === 'zip') {
+    return new archiver.ZipArchive({ zlib: { level: 9 } });
+  }
+
+  return new archiver.TarArchive({ gzip: true, gzipOptions: { level: 9 } });
+}
+
 function createArchive(binaryPath, options = {}) {
   return new Promise((resolve, reject) => {
     const {
@@ -61,15 +69,8 @@ function createArchive(binaryPath, options = {}) {
       fs.unlinkSync(archivePath);
     }
 
-    // Create output stream
     const output = fs.createWriteStream(archivePath);
-    let archive;
-
-    if (archiveFormat === 'zip') {
-      archive = archiver('zip', { zlib: { level: 9 } });
-    } else {
-      archive = archiver('tar', { gzip: true, gzipOptions: { level: 9 } });
-    }
+    const archive = createArchiver(archiveFormat);
 
     // Handle errors
     archive.on('error', (err) => {
@@ -103,7 +104,9 @@ function createArchive(binaryPath, options = {}) {
     archive.file(binaryPath, { name: binaryName });
 
     // Finalize the archive
-    archive.finalize();
+    archive.finalize().catch((error) => {
+      reject(new Error(`Archive finalization failed: ${error.message}`));
+    });
   });
 }
 
@@ -127,20 +130,29 @@ async function archiveAllBinaries(directory = '.', options = {}) {
   binaries.push(...platformBinaries);
 
   if (binaries.length === 0) {
-    console.log('📂 No binaries found to archive');
-    return [];
+    throw new Error('No binaries found to archive.');
   }
 
   console.log(`📦 Found ${binaries.length} binaries to archive`);
 
   const archives = [];
+  const failures = [];
   for (const binary of binaries) {
     try {
       const archive = await createArchive(binary, options);
       archives.push(archive);
     } catch (error) {
       console.error(`❌ Failed to archive ${binary}:`, error.message);
+      failures.push(`${binary}: ${error.message}`);
     }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Failed to archive ${failures.length} binaries: ${failures.join('; ')}`);
+  }
+
+  if (archives.length === 0) {
+    throw new Error('No archives were created.');
   }
 
   return archives;

--- a/src/domains/registry/mcpRegistryClient.test.ts
+++ b/src/domains/registry/mcpRegistryClient.test.ts
@@ -106,6 +106,58 @@ describe('MCPRegistryClient', () => {
       envClient.destroy();
     });
 
+    it('uses the e2e test registry URL when no CLI URL is provided', async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalTestRegistryUrl = process.env.TEST_MCP_REGISTRY_URL;
+      process.env.NODE_ENV = 'test';
+      process.env.TEST_MCP_REGISTRY_URL = 'http://127.0.0.1:54321';
+
+      const envClient = createRegistryClient();
+      mockAxiosInstance.get.mockResolvedValueOnce({ data: { status: 'ok' } });
+
+      await envClient.getRegistryStatus();
+
+      expect(mockAxiosInstance.get).toHaveBeenLastCalledWith('http://127.0.0.1:54321/v0.1/health');
+
+      envClient.destroy();
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+      if (originalTestRegistryUrl === undefined) {
+        delete process.env.TEST_MCP_REGISTRY_URL;
+      } else {
+        process.env.TEST_MCP_REGISTRY_URL = originalTestRegistryUrl;
+      }
+    });
+
+    it('prefers CLI registry URL over the e2e test registry URL', async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalTestRegistryUrl = process.env.TEST_MCP_REGISTRY_URL;
+      process.env.NODE_ENV = 'test';
+      process.env.TEST_MCP_REGISTRY_URL = 'http://127.0.0.1:54321';
+
+      const envClient = createRegistryClient({ url: 'http://127.0.0.1:12345' });
+      mockAxiosInstance.get.mockResolvedValueOnce({ data: { status: 'ok' } });
+
+      await envClient.getRegistryStatus();
+
+      expect(mockAxiosInstance.get).toHaveBeenLastCalledWith('http://127.0.0.1:12345/v0.1/health');
+
+      envClient.destroy();
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+      if (originalTestRegistryUrl === undefined) {
+        delete process.env.TEST_MCP_REGISTRY_URL;
+      } else {
+        process.env.TEST_MCP_REGISTRY_URL = originalTestRegistryUrl;
+      }
+    });
+
     it('falls back to defaults when no CLI options are provided', () => {
       const envClient = createRegistryClient();
 

--- a/src/domains/registry/mcpRegistryClient.ts
+++ b/src/domains/registry/mcpRegistryClient.ts
@@ -622,6 +622,11 @@ function parseProxyFromStandardEnv(): RegistryClientOptions['proxy'] | undefined
  * Create a registry client instance with CLI options or defaults
  */
 export function createRegistryClient(cliOptions?: RegistryOptions): MCPRegistryClient {
-  const clientOptions = convertCliOptionsToClientOptions(cliOptions);
+  const testRegistryUrl =
+    process.env.NODE_ENV === 'test' && typeof process.env.TEST_MCP_REGISTRY_URL === 'string'
+      ? process.env.TEST_MCP_REGISTRY_URL
+      : undefined;
+  const effectiveOptions = testRegistryUrl && !cliOptions?.url ? { ...cliOptions, url: testRegistryUrl } : cliOptions;
+  const clientOptions = convertCliOptionsToClientOptions(effectiveOptions);
   return new MCPRegistryClient(clientOptions);
 }

--- a/src/release/archive.test.ts
+++ b/src/release/archive.test.ts
@@ -1,0 +1,50 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { createRequire } from 'module';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { archiveAllBinaries, createArchive } = require('../../scripts/archive.cjs') as {
+  archiveAllBinaries: (directory?: string, options?: { format?: string; outputDir?: string }) => Promise<string[]>;
+  createArchive: (binaryPath: string, options?: { format?: string; outputDir?: string }) => Promise<string>;
+};
+
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), '1mcp-archive-'));
+  tempRoots.push(tempRoot);
+  return tempRoot;
+}
+
+afterEach(() => {
+  for (const tempRoot of tempRoots.splice(0)) {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe('archive release artifacts', () => {
+  it('creates a non-empty tar archive with archiver v8 constructors', async () => {
+    const tempRoot = createTempRoot();
+    const binaryPath = path.join(tempRoot, '1mcp-linux-x64');
+    fs.writeFileSync(binaryPath, 'release binary');
+
+    const archivePath = await createArchive(binaryPath, { format: 'tar', outputDir: tempRoot });
+
+    expect(path.basename(archivePath)).toBe('1mcp-linux-x64.tar.gz');
+    expect(fs.statSync(archivePath).size).toBeGreaterThan(0);
+
+    const listing = execFileSync('tar', ['-tzf', archivePath], { encoding: 'utf8' });
+    expect(listing.trim()).toBe('1mcp-linux-x64');
+  });
+
+  it('fails instead of succeeding with no archived binaries', async () => {
+    const tempRoot = createTempRoot();
+    fs.writeFileSync(path.join(tempRoot, 'not-a-release-binary'), 'ignored');
+
+    await expect(archiveAllBinaries(tempRoot)).rejects.toThrow('No binaries found to archive.');
+  });
+});

--- a/test/e2e/internal-tools-mcp-protocol.test.ts
+++ b/test/e2e/internal-tools-mcp-protocol.test.ts
@@ -145,6 +145,7 @@ describe('Internal MCP Tools Protocol E2E Tests', () => {
       args: [resolve(__dirname, '../../build/index.js'), '--transport', 'stdio', '--enable-internal-tools'],
       env: {
         ...environment.getEnvironmentVariables(),
+        TEST_MCP_REGISTRY_URL: environment.getRegistryUrl() ?? '',
         NODE_ENV: 'test',
       },
     });

--- a/test/e2e/utils/CliTestRunner.ts
+++ b/test/e2e/utils/CliTestRunner.ts
@@ -125,6 +125,12 @@ export class CliTestRunner {
       args.push(...options.args);
     }
 
+    const registryUrl = this.environment.getRegistryUrl();
+    const hasRegistryUrlArg = args.some((arg) => arg === '--url' || arg.startsWith('--url='));
+    if (registryUrl && !hasRegistryUrlArg) {
+      args.push('--url', registryUrl);
+    }
+
     return this.executeCommand(args, options);
   }
 


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions to Node 24-compatible major versions
- split Docker release builds by target/platform and publish multi-arch manifests from native amd64/arm64 jobs
- increase e2e CI to 6 shards and route registry e2e tests to the mock registry to avoid timeout-driven slowdowns

## Verification
- pnpm exec prettier --check .github/actions/setup-node-pnpm/action.yml .github/workflows/test-and-validate.yml .github/workflows/build-docker-images.yml .github/workflows/build-binaries.yml .github/workflows/update-version.yml .github/workflows/release-pipeline.yml .github/workflows/publish-to-npm.yml .github/workflows/deploy-documentation.yml .github/workflows/stale.yml src/domains/registry/mcpRegistryClient.ts src/domains/registry/mcpRegistryClient.test.ts test/e2e/utils/CliTestRunner.ts test/e2e/internal-tools-mcp-protocol.test.ts
- /tmp/actionlint .github/workflows/test-and-validate.yml .github/workflows/build-docker-images.yml .github/workflows/build-binaries.yml .github/workflows/update-version.yml .github/workflows/release-pipeline.yml .github/workflows/publish-to-npm.yml .github/workflows/deploy-documentation.yml .github/workflows/stale.yml
- git diff --check
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm exec vitest run src/domains/registry/mcpRegistryClient.test.ts --reporter=default
- pnpm test:e2e --shard=1/6 --reporter=minimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and archive handling so packaging fails clearly when no artifacts are produced.
  * Registry connections in test environments now use the expected service URL when one is available.

* **Chores**
  * Updated multiple automation and CI workflows to newer versions for builds, releases, documentation, and deployment.
  * Improved Docker publishing to better support multi-platform image delivery.

* **Tests**
  * Added coverage for registry URL selection and archive creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->