### PR TITLE
fix(config): ignore backup file watcher events

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -30,6 +30,7 @@ export default [
       'docs/.vitepress/dist',
       'docs/.vitepress/cache',
       '.claude/**',
+      '.agents/**',
     ],
   },
   prettierConfig,

--- a/src/commands/shared/clientSurfaceAttachment.test.ts
+++ b/src/commands/shared/clientSurfaceAttachment.test.ts
@@ -198,12 +198,10 @@ describe('attachReusableClientSurface', () => {
         hasRestEndpoint: true,
       },
     });
-    const rest = vi.fn(
-      async (): Promise<ClientSurfaceRestResponse<string>> => ({
-        status: 'fallback',
-        reason: 'endpoint_missing',
-      }),
-    );
+    const rest = vi.fn(async (): Promise<ClientSurfaceRestResponse<string>> => ({
+      status: 'fallback',
+      reason: 'endpoint_missing',
+    }));
     const mcp = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
       status: 'success' as const,
       sessionId,
@@ -246,12 +244,10 @@ describe('attachReusableClientSurface', () => {
         hasRestEndpoint: true,
       },
     });
-    const rest = vi.fn(
-      async (): Promise<ClientSurfaceRestResponse<string>> => ({
-        status: 'fallback',
-        reason: 'transient_failure',
-      }),
-    );
+    const rest = vi.fn(async (): Promise<ClientSurfaceRestResponse<string>> => ({
+      status: 'fallback',
+      reason: 'transient_failure',
+    }));
     const mcp = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
       status: 'success' as const,
       sessionId,
@@ -282,12 +278,10 @@ describe('attachReusableClientSurface', () => {
 
   it('surfaces REST authentication errors without MCP fallback', async () => {
     const ports = makePorts();
-    const rest = vi.fn(
-      async (): Promise<ClientSurfaceRestResponse<string>> => ({
-        status: 'auth_required',
-        message: 'Authentication required.',
-      }),
-    );
+    const rest = vi.fn(async (): Promise<ClientSurfaceRestResponse<string>> => ({
+      status: 'auth_required',
+      message: 'Authentication required.',
+    }));
     const mcp = unusedAdapter();
 
     const result = await attachReusableClientSurface({

--- a/src/config/configWatcher.test.ts
+++ b/src/config/configWatcher.test.ts
@@ -8,14 +8,27 @@ import { ConfigWatcher } from '@src/config/configWatcher.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockWatchClose = vi.hoisted(() => vi.fn());
+const watchMock = vi.hoisted(() => ({
+  callback: undefined as ((eventType: string, filename: string | null) => void) | undefined,
+  close: vi.fn(),
+}));
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
+  const existsSync = vi.fn(() => true);
+  const watch = vi.fn((_path, callback) => {
+    watchMock.callback = callback;
+    return { close: watchMock.close, on: vi.fn() };
+  });
   return {
     ...actual,
-    existsSync: vi.fn(() => true),
-    watch: vi.fn(() => ({ close: mockWatchClose })),
+    existsSync,
+    watch,
+    default: {
+      ...actual,
+      existsSync,
+      watch,
+    },
   };
 });
 
@@ -77,7 +90,9 @@ describe('ConfigWatcher', () => {
     } catch {
       // Ignore cleanup errors
     }
+    vi.useRealTimers();
     vi.clearAllMocks();
+    watchMock.callback = undefined;
   });
 
   describe('startWatching and stopWatching', () => {
@@ -96,6 +111,45 @@ describe('ConfigWatcher', () => {
   });
 
   describe('reload event', () => {
+    it('should reload for an exact config filename event', () => {
+      vi.useFakeTimers();
+      const reloadSpy = vi.fn();
+      vi.spyOn(configLoader, 'checkFileModified').mockReturnValue(false);
+      configWatcher.on('reload', reloadSpy);
+
+      configWatcher.startWatching();
+      watchMock.callback?.('change', 'mcp.json');
+      vi.advanceTimersByTime(100);
+
+      expect(reloadSpy).toHaveBeenCalledOnce();
+    });
+
+    it('should ignore backup files prefixed with the config filename', () => {
+      vi.useFakeTimers();
+      const reloadSpy = vi.fn();
+      vi.spyOn(configLoader, 'checkFileModified').mockReturnValue(false);
+      configWatcher.on('reload', reloadSpy);
+
+      configWatcher.startWatching();
+      watchMock.callback?.('rename', 'mcp.json.backup.test');
+      vi.advanceTimersByTime(100);
+
+      expect(reloadSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reload when modification polling confirms an unmatched event', () => {
+      vi.useFakeTimers();
+      const reloadSpy = vi.fn();
+      vi.spyOn(configLoader, 'checkFileModified').mockReturnValue(true);
+      configWatcher.on('reload', reloadSpy);
+
+      configWatcher.startWatching();
+      watchMock.callback?.('rename', null);
+      vi.advanceTimersByTime(100);
+
+      expect(reloadSpy).toHaveBeenCalledOnce();
+    });
+
     it('should emit reload event when config file changes', async () => {
       const reloadSpy = vi.fn();
       configWatcher.on('reload', reloadSpy);

--- a/src/config/configWatcher.ts
+++ b/src/config/configWatcher.ts
@@ -87,10 +87,7 @@ export class ConfigWatcher extends EventEmitter {
       meta: { eventType, filename, configDir, configFileName },
     }));
 
-    const isConfigFileEvent =
-      filename === configFileName ||
-      (filename && filename.startsWith(configFileName)) ||
-      (eventType === 'rename' && filename && filename.includes(path.parse(configFileName).name));
+    const isConfigFileEvent = filename === configFileName;
 
     if (isConfigFileEvent || this.loader.checkFileModified()) {
       debugIf(() => ({

--- a/src/core/filtering/filterSelection.ts
+++ b/src/core/filtering/filterSelection.ts
@@ -70,8 +70,7 @@ export type FilterSelectionError =
     };
 
 export type FilterSelectionResult =
-  | { ok: true; selection: FilterSelection }
-  | { ok: false; error: FilterSelectionError };
+  { ok: true; selection: FilterSelection } | { ok: false; error: FilterSelectionError };
 
 export interface ResolveFilterSelectionOptions {
   presetLookup?: FilterSelectionPresetLookup;

--- a/src/core/server/serverManagerHotReload.test.ts
+++ b/src/core/server/serverManagerHotReload.test.ts
@@ -8,8 +8,7 @@ import { ServerManager } from './serverManager.js';
 
 const mockState = vi.hoisted(() => ({
   contextChangedHandler: undefined as
-    | ((data: { newContext?: unknown; sessionIdChanged: boolean }) => Promise<void>)
-    | undefined,
+    ((data: { newContext?: unknown; sessionIdChanged: boolean }) => Promise<void>) | undefined,
   reprocessTemplatesWithNewContext: vi.fn(),
   updateServersWithNewConfig: vi.fn(),
 }));


### PR DESCRIPTION
## Summary
- match config watcher events by exact filename
- ignore backup files unless the real config modification time changed
- add deterministic watcher regression tests
- exclude repo-local `.agents` tooling from product lint

Fixes #371

## Test Plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test:unit`
- [x] `pnpm format:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file change detection by requiring an exact filename match, preventing reloads for backup/rotated filenames while still allowing reload when the loader reports modified content.
* **Tests**
  * Strengthened watcher tests with deterministic event handling, including exact match, ignored backup files, and unmatched event scenarios, plus improved per-test cleanup and timer control.
* **Chores**
  * Excluded agent-related files from linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->