### PR TITLE
fix(cli): prevent duplicate session initialization

### DIFF
--- a/docs/en/commands/index.md
+++ b/docs/en/commands/index.md
@@ -44,7 +44,7 @@ All 1MCP commands support the following global options:
 - **`--version`** - Show version information
 - **`--config, -c <path>`** - Specify configuration file path
 - **`--config-dir, -d <path>`** - Path to the config directory
-- **`--cli-session-cache-path <path>`** - Path template for the `run`/`inspect` CLI session cache file
+- **`--cli-session-cache-path <path>`** - Path template for the `run`/`inspect` CLI session cache file; supports `{pid}` and `{scope}`
 
 **Environment Variables**: All global options can be set via environment variables with the `ONE_MCP_` prefix:
 

--- a/docs/en/commands/inspect.md
+++ b/docs/en/commands/inspect.md
@@ -62,7 +62,7 @@ This is the command that turns the broad inventory from `instructions` into a sc
 ### Related Global Options
 
 - **`--config-dir, -d <path>`** - Config directory for auth profile lookup and server discovery
-- **`--cli-session-cache-path <path>`** - Override the session cache path template used by `inspect` and `run`
+- **`--cli-session-cache-path <path>`** - Override the session cache path template used by `inspect` and `run`; supports `{pid}` and `{scope}`
 
 ## Examples
 

--- a/docs/en/commands/run.md
+++ b/docs/en/commands/run.md
@@ -63,7 +63,7 @@ If `--args` is omitted and stdin is provided, `run` tries to map stdin automatic
 ### Related Global Options
 
 - **`--config-dir, -d <path>`** - Config directory for auth profile lookup and server discovery
-- **`--cli-session-cache-path <path>`** - Override the session cache path template used by `run` and `inspect`
+- **`--cli-session-cache-path <path>`** - Override the session cache path template used by `run` and `inspect`; supports `{pid}` and `{scope}`
 
 ## Examples
 
@@ -94,7 +94,7 @@ npx -y @1mcp/agent run filesystem/read_file --args '{"path":"./README.md"}' --fo
 ### Use a Custom Session Cache Path
 
 ```bash
-ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid} \
+ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid}.{scope} \
   npx -y @1mcp/agent run filesystem/read_file --args '{"path":"./README.md"}'
 ```
 

--- a/docs/en/guide/essentials/configuration.md
+++ b/docs/en/guide/essentials/configuration.md
@@ -38,7 +38,7 @@ All available command-line options and their corresponding environment variables
 | `--transport`, `-t`             | `ONE_MCP_TRANSPORT`                   | Choose transport type ("stdio", "http", or "sse")                                               |   "http"   |
 | `--config`, `-c`                | `ONE_MCP_CONFIG`                      | Use a specific config file                                                                      |            |
 | `--config-dir`, `-d`            | `ONE_MCP_CONFIG_DIR`                  | Path to the config directory (overrides default config location)                                |            |
-| `--cli-session-cache-path`      | `ONE_MCP_CLI_SESSION_CACHE_PATH`      | Path template for the `run`/`inspect` CLI session cache file, supports `{pid}`                  |            |
+| `--cli-session-cache-path`      | `ONE_MCP_CLI_SESSION_CACHE_PATH`      | Path template for the `run`/`inspect` CLI session cache file, supports `{pid}` and `{scope}`    |            |
 | `--port`, `-P`                  | `ONE_MCP_PORT`                        | Change HTTP port                                                                                |    3050    |
 | `--host`, `-H`                  | `ONE_MCP_HOST`                        | Change HTTP host                                                                                | localhost  |
 | `--external-url`, `-u`          | `ONE_MCP_EXTERNAL_URL`                | External URL for OAuth callbacks and public URLs (e.g., https://example.com)                    |            |
@@ -88,14 +88,14 @@ Control how the agent communicates with clients and backend servers.
 
 The `run` and `inspect` commands keep a lightweight session cache file outside the config directory by default.
 
-- **Default**: `${os.tmpdir()}/1mcp/.cli-session.{pid}`
+- **Default**: `${os.tmpdir()}/1mcp/.cli-session.{pid}.{scope}`
 - **Environment**: `ONE_MCP_CLI_SESSION_CACHE_PATH`
-- **Placeholder**: `{pid}` resolves to the discovered `1mcp serve` process PID when available; for the built-in default path, 1MCP falls back to a stable server-specific token derived from the server URL when no PID is available
+- **Placeholders**: `{pid}` resolves to the discovered `1mcp serve` process PID when available; `{scope}` isolates the target URL and CLI context. For the built-in default path, 1MCP falls back to a stable server-specific token when no PID is available.
 
 Example:
 
 ```bash
-ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid} npx -y @1mcp/agent run filesystem/read_file --args '{"path":"./README.md"}'
+ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid}.{scope} npx -y @1mcp/agent run filesystem/read_file --args '{"path":"./README.md"}'
 ```
 
 ```bash

--- a/docs/zh/commands/index.md
+++ b/docs/zh/commands/index.md
@@ -44,7 +44,7 @@ head:
 
 - `ONE_MCP_CONFIG=/path/to/config.json`
 - `ONE_MCP_CONFIG_DIR=/path/to/config/dir`
-- `ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid}`
+- `ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid}.{scope}`
 
 ### 命令特定选项
 

--- a/docs/zh/commands/index.md
+++ b/docs/zh/commands/index.md
@@ -38,7 +38,7 @@ head:
 - **`--version`** - 显示版本信息
 - **`--config, -c <path>`** - 指定配置文件路径
 - **`--config-dir, -d <path>`** - 配置目录路径
-- **`--cli-session-cache-path <path>`** - `run` / `inspect` 使用的 CLI 会话缓存路径模板
+- **`--cli-session-cache-path <path>`** - `run` / `inspect` 使用的 CLI 会话缓存路径模板；支持 `{pid}` 与 `{scope}`
 
 **环境变量**：所有全局选项都可以通过带有 `ONE_MCP_` 前缀的环境变量来设置：
 

--- a/docs/zh/commands/inspect.md
+++ b/docs/zh/commands/inspect.md
@@ -47,7 +47,7 @@ npx -y @1mcp/agent inspect [target] [选项]
 ### 相关全局选项
 
 - **`--config-dir, -d <path>`** - 用于鉴权配置和服务器发现的配置目录
-- **`--cli-session-cache-path <path>`** - 覆盖 `inspect` 与 `run` 使用的会话缓存路径模板
+- **`--cli-session-cache-path <path>`** - 覆盖 `inspect` 与 `run` 使用的会话缓存路径模板；支持 `{pid}` 与 `{scope}`
 
 ## 示例
 

--- a/docs/zh/commands/run.md
+++ b/docs/zh/commands/run.md
@@ -48,7 +48,7 @@ npx -y @1mcp/agent run <server>/<tool> [选项]
 ### 相关全局选项
 
 - **`--config-dir, -d <path>`** - 用于鉴权配置和服务器发现的配置目录
-- **`--cli-session-cache-path <path>`** - 覆盖 `run` 与 `inspect` 使用的会话缓存路径模板
+- **`--cli-session-cache-path <path>`** - 覆盖 `run` 与 `inspect` 使用的会话缓存路径模板；支持 `{pid}` 与 `{scope}`
 
 ## 示例
 
@@ -79,7 +79,7 @@ npx -y @1mcp/agent run filesystem/read_file --args '{"path":"./README.md"}' --fo
 ### 使用自定义会话缓存路径
 
 ```bash
-ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid} \
+ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid}.{scope} \
   npx -y @1mcp/agent run filesystem/read_file --args '{"path":"./README.md"}'
 ```
 

--- a/docs/zh/guide/essentials/configuration.md
+++ b/docs/zh/guide/essentials/configuration.md
@@ -27,40 +27,40 @@ Agent 支持三种配置方法，按以下优先级顺序应用：
 
 所有可用的命令行选项及其对应的环境变量：
 
-| 选项 (CLI)                      | 环境变量                              | 描述                                                             |   默认值   |
-| :------------------------------ | :------------------------------------ | :--------------------------------------------------------------- | :--------: |
-| `--transport`, `-t`             | `ONE_MCP_TRANSPORT`                   | 选择传输类型（"stdio"、"http" 或 "sse"）                         |   "http"   |
-| `--config`, `-c`                | `ONE_MCP_CONFIG`                      | 使用特定的配置文件                                               |            |
-| `--config-dir`, `-d`            | `ONE_MCP_CONFIG_DIR`                  | 配置目录路径（覆盖默认配置位置）                                 |            |
-| `--cli-session-cache-path`      | `ONE_MCP_CLI_SESSION_CACHE_PATH`      | `run` / `inspect` CLI 会话缓存路径模板，支持 `{pid}`             |            |
-| `--port`, `-P`                  | `ONE_MCP_PORT`                        | 更改 HTTP 端口                                                   |    3050    |
-| `--host`, `-H`                  | `ONE_MCP_HOST`                        | 更改 HTTP 主机                                                   | localhost  |
-| `--external-url`, `-u`          | `ONE_MCP_EXTERNAL_URL`                | OAuth 回调和公共 URL 的外部 URL（例如 https://example.com）      |            |
-| `--trust-proxy`                 | `ONE_MCP_TRUST_PROXY`                 | 客户端 IP 检测的信任代理配置（布尔值、IP、CIDR、预设）           | "loopback" |
-| `--filter`, `-f`                | `ONE_MCP_FILTER`                      | 按简单逗号分隔标签或高级布尔逻辑筛选运行时暴露的服务器           |            |
-| `--pagination`, `-p`            | `ONE_MCP_PAGINATION`                  | 为客户端/服务器列表启用分页（布尔值）                            |   false    |
-| `--enable-auth`                 | `ONE_MCP_ENABLE_AUTH`                 | 启用身份验证（OAuth 2.1）                                        |   false    |
-| `--enable-scope-validation`     | `ONE_MCP_ENABLE_SCOPE_VALIDATION`     | 启用基于标签的范围验证（布尔值）                                 |    true    |
-| `--enable-enhanced-security`    | `ONE_MCP_ENABLE_ENHANCED_SECURITY`    | 启用增强安全中间件（布尔值）                                     |   false    |
-| `--session-ttl`                 | `ONE_MCP_SESSION_TTL`                 | 会话过期时间（分钟）（数字）                                     |    1440    |
-| `--session-storage-path`        | `ONE_MCP_SESSION_STORAGE_PATH`        | 自定义会话存储目录路径（字符串）                                 |            |
-| `--rate-limit-window`           | `ONE_MCP_RATE_LIMIT_WINDOW`           | OAuth 速率限制窗口（分钟）（数字）                               |     15     |
-| `--rate-limit-max`              | `ONE_MCP_RATE_LIMIT_MAX`              | 每个 OAuth 速率限制窗口的最大请求数（数字）                      |    100     |
-| `--enable-async-loading`        | `ONE_MCP_ENABLE_ASYNC_LOADING`        | 启用异步 MCP 服务器加载（布尔值）                                |   false    |
-| `--enable-config-reload`        | `ONE_MCP_ENABLE_CONFIG_RELOAD`        | 启用配置文件热重载（布尔值）                                     |    true    |
-| `--config-reload-debounce`      | `ONE_MCP_CONFIG_RELOAD_DEBOUNCE`      | 配置重载防抖时间（毫秒）（数字）                                 |    500     |
-| `--enable-env-substitution`     | `ONE_MCP_ENABLE_ENV_SUBSTITUTION`     | 在配置文件中启用环境变量替换（布尔值）                           |    true    |
-| `--enable-session-persistence`  | `ONE_MCP_ENABLE_SESSION_PERSISTENCE`  | 启用 HTTP 会话持久化（布尔值）                                   |    true    |
-| `--session-persist-requests`    | `ONE_MCP_SESSION_PERSIST_REQUESTS`    | 会话持久化请求阈值（数字）                                       |    100     |
-| `--session-persist-interval`    | `ONE_MCP_SESSION_PERSIST_INTERVAL`    | 会话持久化间隔（分钟）（数字）                                   |     5      |
-| `--session-background-flush`    | `ONE_MCP_SESSION_BACKGROUND_FLUSH`    | 会话后台刷新间隔（秒）（数字）                                   |     60     |
-| `--enable-client-notifications` | `ONE_MCP_ENABLE_CLIENT_NOTIFICATIONS` | 启用实时客户端通知（布尔值）                                     |    true    |
-| `--enable-internal-tools`       | `ONE_MCP_ENABLE_INTERNAL_TOOLS`       | 为 AI 助手启用所有 MCP 内部工具（布尔值）                        |   false    |
-| `--internal-tools`              | `ONE_MCP_INTERNAL_TOOLS`              | 启用特定的内部工具类别（discovery,installation,management,safe） |            |
-| `--health-info-level`           | `ONE_MCP_HEALTH_INFO_LEVEL`           | 健康端点信息详细级别（"full"、"basic"、"minimal"）               | "minimal"  |
-| `--log-level`                   | `ONE_MCP_LOG_LEVEL`                   | 设置日志级别（"debug"、"info"、"warn"、"error"）                 |   "info"   |
-| `--log-file`                    | `ONE_MCP_LOG_FILE`                    | 除控制台外还将日志写入文件（仅对 stdio 传输禁用控制台日志记录）  |            |
-| `--help`, `-h`                  |                                       | 显示帮助                                                         |            |
+| 选项 (CLI)                      | 环境变量                              | 描述                                                              |   默认值   |
+| :------------------------------ | :------------------------------------ | :---------------------------------------------------------------- | :--------: |
+| `--transport`, `-t`             | `ONE_MCP_TRANSPORT`                   | 选择传输类型（"stdio"、"http" 或 "sse"）                          |   "http"   |
+| `--config`, `-c`                | `ONE_MCP_CONFIG`                      | 使用特定的配置文件                                                |            |
+| `--config-dir`, `-d`            | `ONE_MCP_CONFIG_DIR`                  | 配置目录路径（覆盖默认配置位置）                                  |            |
+| `--cli-session-cache-path`      | `ONE_MCP_CLI_SESSION_CACHE_PATH`      | `run` / `inspect` CLI 会话缓存路径模板，支持 `{pid}` 与 `{scope}` |            |
+| `--port`, `-P`                  | `ONE_MCP_PORT`                        | 更改 HTTP 端口                                                    |    3050    |
+| `--host`, `-H`                  | `ONE_MCP_HOST`                        | 更改 HTTP 主机                                                    | localhost  |
+| `--external-url`, `-u`          | `ONE_MCP_EXTERNAL_URL`                | OAuth 回调和公共 URL 的外部 URL（例如 https://example.com）       |            |
+| `--trust-proxy`                 | `ONE_MCP_TRUST_PROXY`                 | 客户端 IP 检测的信任代理配置（布尔值、IP、CIDR、预设）            | "loopback" |
+| `--filter`, `-f`                | `ONE_MCP_FILTER`                      | 按简单逗号分隔标签或高级布尔逻辑筛选运行时暴露的服务器            |            |
+| `--pagination`, `-p`            | `ONE_MCP_PAGINATION`                  | 为客户端/服务器列表启用分页（布尔值）                             |   false    |
+| `--enable-auth`                 | `ONE_MCP_ENABLE_AUTH`                 | 启用身份验证（OAuth 2.1）                                         |   false    |
+| `--enable-scope-validation`     | `ONE_MCP_ENABLE_SCOPE_VALIDATION`     | 启用基于标签的范围验证（布尔值）                                  |    true    |
+| `--enable-enhanced-security`    | `ONE_MCP_ENABLE_ENHANCED_SECURITY`    | 启用增强安全中间件（布尔值）                                      |   false    |
+| `--session-ttl`                 | `ONE_MCP_SESSION_TTL`                 | 会话过期时间（分钟）（数字）                                      |    1440    |
+| `--session-storage-path`        | `ONE_MCP_SESSION_STORAGE_PATH`        | 自定义会话存储目录路径（字符串）                                  |            |
+| `--rate-limit-window`           | `ONE_MCP_RATE_LIMIT_WINDOW`           | OAuth 速率限制窗口（分钟）（数字）                                |     15     |
+| `--rate-limit-max`              | `ONE_MCP_RATE_LIMIT_MAX`              | 每个 OAuth 速率限制窗口的最大请求数（数字）                       |    100     |
+| `--enable-async-loading`        | `ONE_MCP_ENABLE_ASYNC_LOADING`        | 启用异步 MCP 服务器加载（布尔值）                                 |   false    |
+| `--enable-config-reload`        | `ONE_MCP_ENABLE_CONFIG_RELOAD`        | 启用配置文件热重载（布尔值）                                      |    true    |
+| `--config-reload-debounce`      | `ONE_MCP_CONFIG_RELOAD_DEBOUNCE`      | 配置重载防抖时间（毫秒）（数字）                                  |    500     |
+| `--enable-env-substitution`     | `ONE_MCP_ENABLE_ENV_SUBSTITUTION`     | 在配置文件中启用环境变量替换（布尔值）                            |    true    |
+| `--enable-session-persistence`  | `ONE_MCP_ENABLE_SESSION_PERSISTENCE`  | 启用 HTTP 会话持久化（布尔值）                                    |    true    |
+| `--session-persist-requests`    | `ONE_MCP_SESSION_PERSIST_REQUESTS`    | 会话持久化请求阈值（数字）                                        |    100     |
+| `--session-persist-interval`    | `ONE_MCP_SESSION_PERSIST_INTERVAL`    | 会话持久化间隔（分钟）（数字）                                    |     5      |
+| `--session-background-flush`    | `ONE_MCP_SESSION_BACKGROUND_FLUSH`    | 会话后台刷新间隔（秒）（数字）                                    |     60     |
+| `--enable-client-notifications` | `ONE_MCP_ENABLE_CLIENT_NOTIFICATIONS` | 启用实时客户端通知（布尔值）                                      |    true    |
+| `--enable-internal-tools`       | `ONE_MCP_ENABLE_INTERNAL_TOOLS`       | 为 AI 助手启用所有 MCP 内部工具（布尔值）                         |   false    |
+| `--internal-tools`              | `ONE_MCP_INTERNAL_TOOLS`              | 启用特定的内部工具类别（discovery,installation,management,safe）  |            |
+| `--health-info-level`           | `ONE_MCP_HEALTH_INFO_LEVEL`           | 健康端点信息详细级别（"full"、"basic"、"minimal"）                | "minimal"  |
+| `--log-level`                   | `ONE_MCP_LOG_LEVEL`                   | 设置日志级别（"debug"、"info"、"warn"、"error"）                  |   "info"   |
+| `--log-file`                    | `ONE_MCP_LOG_FILE`                    | 除控制台外还将日志写入文件（仅对 stdio 传输禁用控制台日志记录）   |            |
+| `--help`, `-h`                  |                                       | 显示帮助                                                          |            |
 
 ---
 
@@ -82,14 +82,14 @@ Agent 支持三种配置方法，按以下优先级顺序应用：
 
 `run` 和 `inspect` 默认会在配置目录之外维护一个轻量级会话缓存文件。
 
-- **默认值**：`${os.tmpdir()}/1mcp/.cli-session.{pid}`
+- **默认值**：`${os.tmpdir()}/1mcp/.cli-session.{pid}.{scope}`
 - **环境变量**：`ONE_MCP_CLI_SESSION_CACHE_PATH`
-- **占位符**：`{pid}` 在可用时会解析为发现到的 `1mcp serve` 进程 PID；对于内置默认路径，如果无法得到 PID，1MCP 会退回到由服务器 URL 派生的稳定标识
+- **占位符**：`{pid}` 在可用时会解析为发现到的 `1mcp serve` 进程 PID；`{scope}` 用于隔离目标 URL 与 CLI 上下文。对于内置默认路径，如果无法得到 PID，1MCP 会退回到稳定的服务器标识。
 
 示例：
 
 ```bash
-ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid} npx -y @1mcp/agent run filesystem/read_file --args '{"path":"./README.md"}'
+ONE_MCP_CLI_SESSION_CACHE_PATH=/tmp/1mcp/.cli-session.{pid}.{scope} npx -y @1mcp/agent run filesystem/read_file --args '{"path":"./README.md"}'
 ```
 
 ```bash

--- a/src/commands/run/run.internals-invoke.test.ts
+++ b/src/commands/run/run.internals-invoke.test.ts
@@ -249,11 +249,11 @@ describe('run command internals', () => {
 
   describe('cache path resolution', () => {
     it('uses the temp-based default with server pid', () => {
-      expect(getCliSessionCachePath({ serverPid: 4242 })).toBe(join(os.tmpdir(), '1mcp', '.cli-session.4242'));
+      expect(getCliSessionCachePath({ serverPid: 4242 })).toBe(join(os.tmpdir(), '1mcp', '.cli-session.4242.default'));
     });
 
     it('falls back to unknown when no pid is available', () => {
-      expect(getCliSessionCachePath()).toBe(join(os.tmpdir(), '1mcp', '.cli-session.unknown'));
+      expect(getCliSessionCachePath()).toBe(join(os.tmpdir(), '1mcp', '.cli-session.unknown.default'));
     });
 
     it('uses a stable server-url token when no pid is available in the default path', () => {
@@ -262,10 +262,49 @@ describe('run command internals', () => {
       expect(cachePath).toBe(getCliSessionCachePath({ serverUrl: 'http://127.0.0.1:3050/mcp' }));
     });
 
+    it('scopes the default cache by target URL and context hash', () => {
+      const grafanaPath = getCliSessionCachePath({
+        serverPid: 4242,
+        serverUrl: 'http://127.0.0.1:3050/mcp?tags=grafana',
+        contextHash: 'context-a',
+      });
+      const presetPath = getCliSessionCachePath({
+        serverPid: 4242,
+        serverUrl: 'http://127.0.0.1:3050/mcp?preset=dev-backend',
+        contextHash: 'context-a',
+      });
+      const otherContextPath = getCliSessionCachePath({
+        serverPid: 4242,
+        serverUrl: 'http://127.0.0.1:3050/mcp?tags=grafana',
+        contextHash: 'context-b',
+      });
+
+      expect(grafanaPath).not.toBe(presetPath);
+      expect(grafanaPath).not.toBe(otherContextPath);
+      expect(grafanaPath).toBe(
+        getCliSessionCachePath({
+          serverPid: 4242,
+          serverUrl: 'http://127.0.0.1:3050/mcp?tags=grafana',
+          contextHash: 'context-a',
+        }),
+      );
+    });
+
     it('expands {pid} in explicit cache templates', () => {
       expect(getCliSessionCachePath({ cachePathTemplate: '/tmp/custom/.cli-session.{pid}', serverPid: 99 })).toBe(
         '/tmp/custom/.cli-session.99',
       );
+    });
+
+    it('expands {scope} in explicit cache templates when requested', () => {
+      const cachePath = getCliSessionCachePath({
+        cachePathTemplate: '/tmp/custom/.cli-session.{pid}.{scope}',
+        serverPid: 99,
+        serverUrl: 'http://127.0.0.1:3050/mcp?tags=grafana',
+        contextHash: 'context-a',
+      });
+
+      expect(cachePath).toMatch(/^\/tmp\/custom\/\.cli-session\.99\.[0-9a-f]{12}$/);
     });
   });
 });

--- a/src/commands/run/run.rest-primary.test.ts
+++ b/src/commands/run/run.rest-primary.test.ts
@@ -374,7 +374,7 @@ describe('runCommand REST-first path', () => {
     expect(cache?.hasRestEndpoint).toBe(true);
   });
 
-  it('uses the same canonical session id for fresh MCP fallback initialize', async () => {
+  it('initializes a fresh MCP transport while preserving the logical context session id', async () => {
     mockFetch.mockResolvedValueOnce(makeTextResponse(404, 'Not Found'));
     mockFetch.mockResolvedValueOnce(makeTextResponse(404, 'Cannot POST /api/v1/tool-invocations'));
 
@@ -399,7 +399,7 @@ describe('runCommand REST-first path', () => {
       'tools/call',
     ]);
     expect(initializeContext.context.sessionId).toMatch(/^rest-[a-f0-9]{16}$/);
-    expect(instance.initialSessionId).toBe(initializeContext.context.sessionId);
+    expect(instance.initialSessionId).toBeUndefined();
   });
 
   it('falls back to MCP when REST endpoint is missing', async () => {

--- a/src/commands/shared/clientSurfaceAttachment.test.ts
+++ b/src/commands/shared/clientSurfaceAttachment.test.ts
@@ -154,7 +154,7 @@ describe('attachReusableClientSurface', () => {
       },
     });
     const rest = unusedAdapter();
-    const mcp = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
+    const mcp = vi.fn(async ({ sessionId }: { sessionId?: string }) => ({
       status: 'success' as const,
       sessionId,
       value: 'mcp-value',
@@ -202,7 +202,7 @@ describe('attachReusableClientSurface', () => {
       status: 'fallback',
       reason: 'endpoint_missing',
     }));
-    const mcp = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
+    const mcp = vi.fn(async ({ sessionId }: { sessionId?: string }) => ({
       status: 'success' as const,
       sessionId,
       value: 'mcp-value',
@@ -248,7 +248,7 @@ describe('attachReusableClientSurface', () => {
       status: 'fallback',
       reason: 'transient_failure',
     }));
-    const mcp = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
+    const mcp = vi.fn(async ({ sessionId }: { sessionId?: string }) => ({
       status: 'success' as const,
       sessionId,
       value: 'mcp-value',
@@ -273,6 +273,36 @@ describe('attachReusableClientSurface', () => {
     expect(ports.writeSessionCache).toHaveBeenCalledWith(
       '/tmp/cache/.cli-session.4242',
       expect.objectContaining({ hasRestEndpoint: true }),
+    );
+  });
+
+  it('initializes MCP without a transport session when REST transiently fails without a cache', async () => {
+    const ports = makePorts();
+    const rest = vi.fn(async (): Promise<ClientSurfaceRestResponse<string>> => ({
+      status: 'fallback',
+      reason: 'transient_failure',
+    }));
+    const mcp = vi.fn(async () => ({
+      status: 'success' as const,
+      sessionId: 'fresh-session',
+      value: 'mcp-value',
+    }));
+
+    const result = await attachReusableClientSurface({
+      clientSurface: 'run',
+      version: 'run',
+      options: {},
+      ports,
+      rest,
+      mcp,
+    });
+
+    expect(result.status).toBe('success');
+    expect(mcp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: undefined,
+        sendInitialize: true,
+      }),
     );
   });
 
@@ -302,7 +332,7 @@ describe('attachReusableClientSurface', () => {
     expect(ports.writeSessionCache).not.toHaveBeenCalled();
   });
 
-  it('deletes stale cached sessions and retries MCP with initialize on the same canonical session', async () => {
+  it('deletes stale cached sessions and retries MCP without reusing the stale transport session', async () => {
     const ports = makePorts({
       cachedSession: {
         sessionId: 'cached-session',
@@ -338,10 +368,7 @@ describe('attachReusableClientSurface', () => {
       1,
       expect.objectContaining({ sessionId: 'cached-session', sendInitialize: false }),
     );
-    expect(mcp).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ sessionId: 'cached-session', sendInitialize: true }),
-    );
+    expect(mcp).toHaveBeenNthCalledWith(2, expect.objectContaining({ sessionId: undefined, sendInitialize: true }));
   });
 
   it('passes auth profile token and project-config environment into attachment context', async () => {

--- a/src/commands/shared/clientSurfaceAttachment.ts
+++ b/src/commands/shared/clientSurfaceAttachment.ts
@@ -153,7 +153,10 @@ export interface AttachReusableClientSurfaceOptions<TOptions extends ResolvableS
   ports?: Partial<ClientSurfaceAttachmentPorts<TOptions>>;
   rest: (context: ClientSurfaceAttachmentContext<TOptions>) => Promise<ClientSurfaceRestResponse<TValue>>;
   mcp: (
-    context: ClientSurfaceAttachmentContext<TOptions> & { sendInitialize: boolean },
+    context: Omit<ClientSurfaceAttachmentContext<TOptions>, 'sessionId'> & {
+      sessionId?: string;
+      sendInitialize: boolean;
+    },
   ) => Promise<ClientSurfaceMcpResponse<TValue>>;
 }
 
@@ -216,6 +219,7 @@ export async function attachReusableClientSurface<TOptions extends ResolvableSer
     cachePathTemplate: options['cli-session-cache-path'],
     serverPid: target.serverPid,
     serverUrl: target.serverUrl.toString(),
+    contextHash,
   });
   const baseUrl = stripMcpSuffix(target.discoveredUrl);
   const [authProfile, cachedSession] = await Promise.all([
@@ -293,17 +297,12 @@ export async function attachReusableClientSurface<TOptions extends ResolvableSer
 
     if (restResponse.reason === 'endpoint_missing') {
       restSupport = false;
-      await persistSession(ports, cachePath, {
-        sessionId: cachedSession?.sessionId ?? requestSessionId,
-        serverUrl: target.serverUrl.toString(),
-        contextHash,
-        restSupport,
-      });
     }
   }
 
   let mcpResponse = await input.mcp({
     ...attachmentContext,
+    sessionId: cachedSession?.sessionId,
     restSupport,
     sendInitialize: !cachedSession?.sessionId,
   });
@@ -312,6 +311,7 @@ export async function attachReusableClientSurface<TOptions extends ResolvableSer
     await ports.deleteSessionCache(cachePath);
     mcpResponse = await input.mcp({
       ...attachmentContext,
+      sessionId: undefined,
       restSupport,
       sendInitialize: true,
     });

--- a/src/commands/shared/serveClient.ts
+++ b/src/commands/shared/serveClient.ts
@@ -70,6 +70,7 @@ export interface CliSessionCachePathOptions {
   cachePathTemplate?: string;
   serverPid?: number;
   serverUrl?: string;
+  contextHash?: string;
 }
 
 export const SESSION_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -254,7 +255,7 @@ export function buildServerUrl(baseUrl: string, options: ServeUrlOptions): URL {
 }
 
 export function getDefaultCliSessionCachePathTemplate(): string {
-  return path.join(os.tmpdir(), '1mcp', '.cli-session.{pid}');
+  return path.join(os.tmpdir(), '1mcp', '.cli-session.{pid}.{scope}');
 }
 
 export function resolveCliSessionCachePathTemplate(cachePathTemplate?: string): string {
@@ -269,7 +270,14 @@ export function getCliSessionCachePath(options: CliSessionCachePathOptions = {})
       : options.serverUrl
         ? `server-${createHash('sha256').update(options.serverUrl).digest('hex').slice(0, 12)}`
         : 'unknown';
-  return resolvedTemplate.replaceAll('{pid}', pidToken);
+  const scopeToken =
+    options.serverUrl || options.contextHash
+      ? createHash('sha256')
+          .update(`${options.serverUrl ?? ''}\0${options.contextHash ?? ''}`)
+          .digest('hex')
+          .slice(0, 12)
+      : 'default';
+  return resolvedTemplate.replaceAll('{pid}', pidToken).replaceAll('{scope}', scopeToken);
 }
 
 export function getCliSessionContextHash(context: ContextData): string {

--- a/src/globalOptions.ts
+++ b/src/globalOptions.ts
@@ -24,7 +24,7 @@ export const globalOptions = {
   },
   'cli-session-cache-path': {
     describe:
-      'Path template for the run/inspect CLI session cache file, supports {pid} (env: ONE_MCP_CLI_SESSION_CACHE_PATH)',
+      'Path template for the run/inspect CLI session cache file, supports {pid} and {scope} (env: ONE_MCP_CLI_SESSION_CACHE_PATH)',
     type: 'string' as const,
     default: undefined,
   },

--- a/src/transport/http/storage/streamableSessionRepository.test.ts
+++ b/src/transport/http/storage/streamableSessionRepository.test.ts
@@ -380,6 +380,31 @@ describe('StreamableSessionRepository', () => {
   });
 
   describe('stopPeriodicFlush', () => {
+    it('isolates background persistence failures without throwing from the timer', () => {
+      repository.stopPeriodicFlush();
+      vi.useFakeTimers();
+      vi.setSystemTime(1000);
+
+      const flushingRepository = new StreamableSessionRepository(mockFileStorageService as any);
+      mockFileStorageService.readData.mockReturnValue({
+        expires: 2000,
+        createdAt: 0,
+        lastAccessedAt: 0,
+      });
+      flushingRepository.updateAccess('collision-probe-1784035498852');
+      mockFileStorageService.writeData.mockImplementation(() => {
+        throw new Error('Invalid ID format: collision-probe-1784035498852');
+      });
+
+      try {
+        expect(() => vi.advanceTimersToNextTimer()).not.toThrow();
+      } finally {
+        mockFileStorageService.writeData.mockReset();
+        flushingRepository.stopPeriodicFlush();
+        vi.useRealTimers();
+      }
+    });
+
     it('should stop periodic flush without errors', () => {
       // Act & Assert - should not throw
       expect(() => repository.stopPeriodicFlush()).not.toThrow();

--- a/src/transport/http/storage/streamableSessionRepository.ts
+++ b/src/transport/http/storage/streamableSessionRepository.ts
@@ -372,7 +372,17 @@ export class StreamableSessionRepository {
     for (const sessionId of sessionsToFlush) {
       const lastAccess = this.lastAccessTimes.get(sessionId);
       if (lastAccess) {
-        this.persistSessionAccess(sessionId, lastAccess);
+        try {
+          this.persistSessionAccess(sessionId, lastAccess);
+        } catch (error) {
+          logError('Failed to persist background session access', {
+            method: 'flushDirtySessions',
+            path: 'streamableSessionRepository',
+            sessionId,
+            phase: 'disk write',
+            error,
+          });
+        }
       }
     }
 

--- a/src/transport/http/streamableSessionLifecycle.test.ts
+++ b/src/transport/http/streamableSessionLifecycle.test.ts
@@ -137,15 +137,31 @@ describe('StreamableSessionLifecycle', () => {
 
   it('recovers a missing POST session only for initialize requests', async () => {
     const config: InboundConnectionConfig = { tags: ['init'], enablePagination: false };
+    const sessionId = 'rest-0123456789abcdef';
 
     const result = await lifecycle.resolvePostSession({
-      sessionId: 'client-provided-session',
+      sessionId,
       isInitializeRequest: true,
       createSessionData: () => ({ config }),
     });
 
     expect(result.status).toBe(StreamableSessionStatus.InitializeRecovered);
-    expect(sessionRepository.create).toHaveBeenCalledWith('client-provided-session', expect.objectContaining(config));
+    expect(sessionRepository.create).toHaveBeenCalledWith(sessionId, expect.objectContaining(config));
+  });
+
+  it('rejects invalid client-provided session ids before initialization recovery', async () => {
+    const result = await lifecycle.resolvePostSession({
+      sessionId: 'collision-probe-1784035498852',
+      isInitializeRequest: true,
+      createSessionData: () => ({ config: { tags: [], enablePagination: false } }),
+    });
+
+    expect(result).toMatchObject({
+      status: StreamableSessionStatus.Missing,
+      sessionId: 'collision-probe-1784035498852',
+      reason: StreamableSessionMissingReason.InvalidSession,
+    });
+    expect(sessionRepository.create).not.toHaveBeenCalled();
   });
 
   it('keeps non-initialize requests for missing sessions as missing', async () => {

--- a/src/transport/http/streamableSessionLifecycle.ts
+++ b/src/transport/http/streamableSessionLifecycle.ts
@@ -97,6 +97,15 @@ function isValidSessionId(sessionId: string): boolean {
   return typeof sessionId === 'string' && sessionId.trim().length > 0;
 }
 
+function isPersistableSessionId(sessionId: string): boolean {
+  const streamPrefix = AUTH_CONFIG.SERVER.STREAMABLE_SESSION.ID_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const streamSessionPattern = new RegExp(
+    `^${streamPrefix}[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
+    'i',
+  );
+  return streamSessionPattern.test(sessionId) || /^rest-[0-9a-f]{16}$/.test(sessionId);
+}
+
 function defaultIsStreamableTransport(transport: unknown): transport is StreamableTransport {
   return (
     transport instanceof StreamableHTTPServerTransport || transport instanceof RestorableStreamableHTTPServerTransport
@@ -169,6 +178,14 @@ export class StreamableSessionLifecycle {
         status: StreamableSessionStatus.Missing,
         sessionId: input.sessionId,
         reason: StreamableSessionMissingReason.InitializeRequired,
+      };
+    }
+
+    if (!isPersistableSessionId(input.sessionId)) {
+      return {
+        status: StreamableSessionStatus.Missing,
+        sessionId: input.sessionId,
+        reason: StreamableSessionMissingReason.InvalidSession,
       };
     }
 


### PR DESCRIPTION
## Summary
- scope CLI session cache files by server URL and client context to prevent cross-target reuse
- reuse cached session IDs without sending a second initialize request, while recovering cleanly from stale sessions
- reject non-persistable session IDs and isolate background persistence failures
- document the new `{scope}` cache-path placeholder in English and Chinese docs

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit` (256 files, 3810 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CLI session cache path templates now support `{pid}` and `{scope}` placeholders.
  - Cache paths are further scoped by the target and CLI context for stronger session isolation.

- **Bug Fixes**
  - Improved behavior when cached/transport sessions are stale, including correct re-initialization.
  - Invalid session identifiers are rejected earlier during session handling.
  - Background session persistence failures no longer interrupt other flush operations.

- **Documentation**
  - Updated English and Chinese `run`/`inspect` and configuration docs to describe `{scope}` support and adjusted examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->