### PR TITLE
fix(auth): honor pre-registered oauth clientId to skip DCR

### DIFF
--- a/src/auth/sdkOAuthClientProvider.test.ts
+++ b/src/auth/sdkOAuthClientProvider.test.ts
@@ -161,11 +161,82 @@ describe('SDKOAuthClientProvider', () => {
     it('should handle missing session data gracefully', () => {
       mockClientSessionRepository.get.mockReturnValue(null);
 
-      provider = new SDKOAuthClientProvider('test-server', mockConfig);
+      const dcrConfig: OAuthClientConfig = { redirectUrl: 'http://localhost:3000/callback' };
+      provider = new SDKOAuthClientProvider('test-server', dcrConfig);
 
       expect(provider.clientInformation()).toBeUndefined();
       expect(provider.tokens()).toBeUndefined();
       expect(provider.codeVerifier()).toBe('');
+    });
+  });
+
+  describe('pre-registered client seeding', () => {
+    it('should seed client information from config.clientId when no persisted data exists', () => {
+      mockClientSessionRepository.get.mockReturnValue(null);
+
+      provider = new SDKOAuthClientProvider('test-server', mockConfig);
+
+      expect(provider.clientInformation()).toEqual({
+        ...provider.clientMetadata,
+        client_id: 'test-client-id',
+        client_secret: 'test-client-secret',
+      });
+    });
+
+    it('should seed client information without client_secret when only clientId is set', () => {
+      mockClientSessionRepository.get.mockReturnValue(null);
+
+      const publicClientConfig: OAuthClientConfig = {
+        clientId: 'public-client-id',
+        scopes: ['read'],
+        redirectUrl: 'http://localhost:3000/callback',
+      };
+      provider = new SDKOAuthClientProvider('test-server', publicClientConfig);
+
+      const info = provider.clientInformation();
+      expect(info?.client_id).toBe('public-client-id');
+      expect(info?.client_secret).toBeUndefined();
+      expect(info?.token_endpoint_auth_method).toBe('none');
+    });
+
+    it('should not seed client information when config.clientId is absent (DCR path)', () => {
+      mockClientSessionRepository.get.mockReturnValue(null);
+
+      const dcrConfig: OAuthClientConfig = { redirectUrl: 'http://localhost:3000/callback' };
+      provider = new SDKOAuthClientProvider('test-server', dcrConfig);
+
+      expect(provider.clientInformation()).toBeUndefined();
+    });
+
+    it('should prefer persisted client information over config.clientId', () => {
+      const persistedClientInfo: OAuthClientInformationFull = {
+        ...mockClientInfo,
+        client_id: 'persisted-client-id',
+      };
+      const mockSessionData: ClientSessionData = {
+        serverName: 'test-server',
+        clientInfo: JSON.stringify(persistedClientInfo),
+        expires: Date.now() + 3600000,
+        createdAt: Date.now(),
+      };
+      mockClientSessionRepository.get.mockReturnValue(mockSessionData);
+
+      provider = new SDKOAuthClientProvider('test-server', mockConfig);
+
+      expect(provider.clientInformation()).toEqual(persistedClientInfo);
+    });
+
+    it('should let saveClientInformation override a seeded client', () => {
+      mockClientSessionRepository.get.mockReturnValue(null);
+      provider = new SDKOAuthClientProvider('test-server', mockConfig);
+
+      const registered: OAuthClientInformationFull = {
+        ...mockClientInfo,
+        client_id: 'registered-client-id',
+      };
+      provider.saveClientInformation(registered);
+
+      expect(provider.clientInformation()).toEqual(registered);
     });
   });
 
@@ -189,7 +260,9 @@ describe('SDKOAuthClientProvider', () => {
     });
 
     it('should return undefined when no client info is set', () => {
-      expect(provider.clientInformation()).toBeUndefined();
+      const dcrConfig: OAuthClientConfig = { redirectUrl: 'http://localhost:3000/callback' };
+      const dcrProvider = new SDKOAuthClientProvider('test-server', dcrConfig);
+      expect(dcrProvider.clientInformation()).toBeUndefined();
     });
   });
 
@@ -482,7 +555,8 @@ describe('SDKOAuthClientProvider', () => {
 
       mockClientSessionRepository.get.mockReturnValue(mockSessionData);
 
-      provider = new SDKOAuthClientProvider('test-server', mockConfig);
+      const dcrConfig: OAuthClientConfig = { redirectUrl: 'http://localhost:3000/callback' };
+      provider = new SDKOAuthClientProvider('test-server', dcrConfig);
 
       expect(provider.clientInformation()).toBeUndefined();
       expect(provider.tokens()).toBeUndefined();

--- a/src/auth/sdkOAuthClientProvider.ts
+++ b/src/auth/sdkOAuthClientProvider.ts
@@ -67,6 +67,17 @@ export class SDKOAuthClientProvider implements OAuthClientProvider {
 
     // Load existing client info and tokens if available
     this.loadPersistedData();
+
+    // Seed client info from a pre-registered clientId so the SDK skips Dynamic
+    // Client Registration for servers without a registration_endpoint (e.g. Slack).
+    // Guarded so persisted client info always wins.
+    if (!this._clientInfo && config.clientId) {
+      this._clientInfo = {
+        ...this._clientMetadata,
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+      };
+    }
   }
 
   get redirectUrl(): string {


### PR DESCRIPTION
## Description

`oauth.clientId` is defined in the transport config schema but never applied: `SDKOAuthClientProvider.clientInformation()` only ever returns persisted/dynamically-registered client info, so a configured pre-registered client is dropped. Because the MCP SDK only performs Dynamic Client Registration when `clientInformation()` is falsy, a configured `clientId` is ignored and the flow always attempts DCR — which fails against servers that expose no `registration_endpoint`.

This seeds client information from `config.clientId` (plus `clientSecret` when present) when no persisted client info exists, so the SDK skips DCR for pre-registered clients. Servers that rely on DCR are unaffected: seeding happens only when `clientId` is set and no persisted/registered client info exists; persisted client info always takes precedence.

Fixes #377

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tests pass locally
- [x] Added tests for new functionality
- [x] Manual testing completed

New unit tests in `src/auth/sdkOAuthClientProvider.test.ts`:
- seeds client info from `config.clientId` (with `client_secret` when a secret is configured)
- seeds a public client (no `client_secret`, `token_endpoint_auth_method: 'none'`) when only `clientId` is set
- does not seed when `clientId` is absent (DCR path unchanged)
- persisted client info takes precedence over `config.clientId`
- `saveClientInformation` overrides a seeded client

## Checklist

- [x] Code follows the style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No console.log statements left


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authentication setup for pre-registered clients by using configured client credentials when no saved registration data is available.
  * Preserved saved client registration details when they exist.
  * Improved handling of incomplete saved session data without errors.
  * Expanded coverage for dynamic client registration and client information updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->