### PR TITLE
feat(admin): add route-based OAuth operations

### DIFF
--- a/src/domains/admin/adminDomain.test.ts
+++ b/src/domains/admin/adminDomain.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import type { OAuthAuthorizationFlow } from '@src/auth/oauthAuthorizationFlow.js';
 import type { ConfigChangeService } from '@src/domains/config-change/configChange.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -127,6 +128,33 @@ describe('createAdminDomain', () => {
     });
   });
 
+  it('wires backend OAuth Admin Operations from the runtime authorization flow', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.startBackendOAuth).mockResolvedValue({
+      status: 'redirect',
+      redirectUrl: 'https://provider.example/authorize',
+    });
+    const domain = createAdminDomain({
+      runtimeScopeId: 'scope_123',
+      storageDir,
+      sessionTtlMs: 60_000,
+      configChangeService: fakeConfigChangeService(),
+      readConfigDocument: () => ({ mcpServers: {} }),
+      oauthFlow,
+    });
+
+    const result = await domain.oauthService?.authorizeService({
+      context: context({ target: { type: 'backend_oauth_service', id: 'github' } }),
+      serviceId: 'github',
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      operationName: 'authorizeBackendOAuth',
+      result: { serviceId: 'github', redirectUrl: 'https://provider.example/authorize' },
+    });
+  });
+
   function context(overrides: Partial<AdminOperationContext> = {}): AdminOperationContext {
     return {
       actor: { type: 'admin_session', accountId: 'acct_1', sessionId: 'sess_1' },
@@ -150,3 +178,14 @@ describe('createAdminDomain', () => {
     } as unknown as ConfigChangeService;
   }
 });
+
+function createOAuthFlow(): OAuthAuthorizationFlow {
+  return {
+    submitConsent: vi.fn(),
+    createLocalhostCliToken: vi.fn(),
+    startBackendOAuth: vi.fn(),
+    restartBackendOAuth: vi.fn(),
+    completeBackendOAuthCallback: vi.fn(),
+    getBackendOAuthDashboard: vi.fn(),
+  };
+}

--- a/src/domains/admin/adminDomain.ts
+++ b/src/domains/admin/adminDomain.ts
@@ -1,3 +1,4 @@
+import type { OAuthAuthorizationFlow } from '@src/auth/oauthAuthorizationFlow.js';
 import type { MCPServerParams } from '@src/core/types/index.js';
 import type { ConfigChangeService } from '@src/domains/config-change/configChange.js';
 import type { PresetManager } from '@src/domains/preset/manager/presetManager.js';
@@ -14,6 +15,7 @@ import {
   type ConfiguredServerConnectivityChecker,
 } from './adminConfiguredServerService.js';
 import { AdminIdentityService } from './adminIdentityService.js';
+import { type AdminOAuthOperations, AdminOAuthService } from './adminOAuthService.js';
 import { AdminOperationService } from './adminOperationService.js';
 import { type AdminPresetOperations, AdminPresetService } from './adminPresetService.js';
 import type { AdminMutationAvailability } from './runtimeScopeAdminLock.js';
@@ -31,6 +33,7 @@ export interface AdminDomainOptions {
   presetManager?: PresetManager;
   readServerTargets?: () => Record<string, MCPServerParams>;
   runtimeBackendRestartService?: RuntimeBackendRestartService;
+  oauthFlow?: OAuthAuthorizationFlow;
 }
 
 export interface AdminDomain {
@@ -39,6 +42,7 @@ export interface AdminDomain {
   configuredServerService: AdminConfiguredServerOperations;
   presetService?: AdminPresetOperations;
   backendRestartService?: AdminBackendRestartOperations;
+  oauthService?: AdminOAuthOperations;
 }
 
 export function createAdminDomain(options: AdminDomainOptions): AdminDomain {
@@ -75,6 +79,9 @@ export function createAdminDomain(options: AdminDomainOptions): AdminDomain {
           readServerTargets: options.readServerTargets,
         })
       : undefined;
+  const oauthService = options.oauthFlow
+    ? new AdminOAuthService({ operationService, oauthFlow: options.oauthFlow })
+    : undefined;
 
   return {
     adminService,
@@ -82,5 +89,6 @@ export function createAdminDomain(options: AdminDomainOptions): AdminDomain {
     configuredServerService,
     backendRestartService,
     presetService,
+    oauthService,
   };
 }

--- a/src/domains/admin/adminOAuthService.test.ts
+++ b/src/domains/admin/adminOAuthService.test.ts
@@ -1,0 +1,258 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { OAuthAuthorizationFlow } from '@src/auth/oauthAuthorizationFlow.js';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AdminOAuthService } from './adminOAuthService.js';
+import type { AdminOperationContext } from './adminOperationService.js';
+import { AdminOperationService } from './adminOperationService.js';
+
+describe('AdminOAuthService', () => {
+  let storageDir: string;
+
+  beforeEach(() => {
+    storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'admin-oauth-service-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(storageDir, { recursive: true, force: true });
+  });
+
+  it('authorizes the exact backend OAuth service identity as an audited Admin Operation', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.startBackendOAuth).mockResolvedValue({
+      status: 'redirect',
+      redirectUrl: 'https://provider.example/authorize',
+    });
+    const operationService = new AdminOperationService({
+      runtimeScopeId: 'scope_123',
+      storageDir,
+      now: () => new Date('2026-07-27T00:00:00.000Z'),
+      createOperationId: () => 'op_oauth_authorize',
+    });
+    const service = new AdminOAuthService({ operationService, oauthFlow });
+
+    const result = await service.authorizeService({
+      context: context(),
+      serviceId: 'context7:0123456789abcdef',
+    });
+
+    expect(oauthFlow.startBackendOAuth).toHaveBeenCalledWith({ serverName: 'context7:0123456789abcdef' });
+    expect(result).toMatchObject({
+      ok: true,
+      operationId: 'op_oauth_authorize',
+      operationName: 'authorizeBackendOAuth',
+      result: {
+        serviceId: 'context7:0123456789abcdef',
+        redirectUrl: 'https://provider.example/authorize',
+      },
+    });
+    expect(operationService.getRecentAuditFacts()).toMatchObject([
+      {
+        operationName: 'authorizeBackendOAuth',
+        result: 'completed',
+        target: { type: 'backend_oauth_service', id: 'context7:0123456789abcdef' },
+      },
+    ]);
+  });
+
+  it('restarts backend OAuth and returns its authorization redirect as operation result data', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.restartBackendOAuth).mockResolvedValue({
+      status: 'restarted',
+      redirectUrl: 'https://provider.example/restart',
+    });
+    const operationService = new AdminOperationService({
+      runtimeScopeId: 'scope_123',
+      storageDir,
+      createOperationId: () => 'op_oauth_restart',
+    });
+    const service = new AdminOAuthService({ operationService, oauthFlow });
+
+    const result = await service.restartService({
+      context: context(),
+      serviceId: 'context7:0123456789abcdef',
+    });
+
+    expect(oauthFlow.restartBackendOAuth).toHaveBeenCalledWith({ serverName: 'context7:0123456789abcdef' });
+    expect(result).toMatchObject({
+      ok: true,
+      operationId: 'op_oauth_restart',
+      operationName: 'restartBackendOAuth',
+      result: {
+        serviceId: 'context7:0123456789abcdef',
+        redirectUrl: 'https://provider.example/restart',
+      },
+    });
+    expect(operationService.getRecentAuditFacts()).toMatchObject([
+      {
+        operationName: 'restartBackendOAuth',
+        target: { type: 'backend_oauth_service', id: 'context7:0123456789abcdef' },
+      },
+    ]);
+  });
+
+  it('maps a missing backend OAuth service to a stable operation error', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.startBackendOAuth).mockResolvedValue({
+      status: 'service_not_found',
+      errorDescription: 'Service details that must not cross the admin boundary',
+    });
+    const service = new AdminOAuthService({
+      operationService: new AdminOperationService({ runtimeScopeId: 'scope_123', storageDir }),
+      oauthFlow,
+    });
+
+    const result = await service.authorizeService({
+      context: context(),
+      serviceId: 'missing-service',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'mutation_failed',
+      error: 'backend_oauth_service_not_found',
+    });
+    expect(JSON.stringify(result)).not.toContain('Service details');
+  });
+
+  it('maps an unavailable backend OAuth runtime to a stable operation error', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.startBackendOAuth).mockResolvedValue({
+      status: 'runtime_unavailable',
+      errorDescription: 'Internal runtime details',
+    });
+    const service = new AdminOAuthService({
+      operationService: new AdminOperationService({ runtimeScopeId: 'scope_123', storageDir }),
+      oauthFlow,
+    });
+
+    const result = await service.authorizeService({
+      context: context(),
+      serviceId: 'github',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'mutation_failed',
+      error: 'backend_oauth_runtime_unavailable',
+    });
+    expect(JSON.stringify(result)).not.toContain('Internal runtime details');
+  });
+
+  it('does not expose errors thrown while backend authorization starts', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.startBackendOAuth).mockRejectedValue(new Error('provider_secret=do-not-expose'));
+    const service = new AdminOAuthService({
+      operationService: new AdminOperationService({ runtimeScopeId: 'scope_123', storageDir }),
+      oauthFlow,
+    });
+
+    const result = await service.authorizeService({
+      context: context(),
+      serviceId: 'github',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'mutation_failed',
+      error: 'backend_oauth_authorization_start_failed',
+    });
+    expect(JSON.stringify(result)).not.toContain('provider_secret');
+  });
+
+  it('uses the same stable error taxonomy when backend OAuth restart cannot find the service', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.restartBackendOAuth).mockResolvedValue({
+      status: 'service_not_found',
+      errorDescription: 'Backend lookup details',
+    });
+    const service = new AdminOAuthService({
+      operationService: new AdminOperationService({ runtimeScopeId: 'scope_123', storageDir }),
+      oauthFlow,
+    });
+
+    const result = await service.restartService({
+      context: context(),
+      serviceId: 'missing-service',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'mutation_failed',
+      error: 'backend_oauth_service_not_found',
+    });
+    expect(JSON.stringify(result)).not.toContain('Backend lookup details');
+  });
+
+  it('maps an unavailable backend OAuth runtime during restart to a stable operation error', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.restartBackendOAuth).mockResolvedValue({
+      status: 'runtime_unavailable',
+      errorDescription: 'Internal restart runtime details',
+    });
+    const service = new AdminOAuthService({
+      operationService: new AdminOperationService({ runtimeScopeId: 'scope_123', storageDir }),
+      oauthFlow,
+    });
+
+    const result = await service.restartService({
+      context: context(),
+      serviceId: 'github',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'mutation_failed',
+      error: 'backend_oauth_runtime_unavailable',
+    });
+    expect(JSON.stringify(result)).not.toContain('Internal restart runtime details');
+  });
+
+  it('does not expose errors thrown while backend OAuth restart starts authorization', async () => {
+    const oauthFlow = createOAuthFlow();
+    vi.mocked(oauthFlow.restartBackendOAuth).mockRejectedValue(new Error('refresh_token=do-not-expose'));
+    const service = new AdminOAuthService({
+      operationService: new AdminOperationService({ runtimeScopeId: 'scope_123', storageDir }),
+      oauthFlow,
+    });
+
+    const result = await service.restartService({
+      context: context(),
+      serviceId: 'github',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'mutation_failed',
+      error: 'backend_oauth_authorization_start_failed',
+    });
+    expect(JSON.stringify(result)).not.toContain('refresh_token');
+  });
+
+  function context(): AdminOperationContext {
+    return {
+      actor: { type: 'admin_session', accountId: 'acct_1', sessionId: 'sess_1' },
+      origin: 'browser',
+      target: { type: 'backend_oauth_service', id: 'context7:0123456789abcdef' },
+      runtimeIdentity: { runtimeScopeId: 'scope_123', runtimeVersion: '1.2.3' },
+      request: { requestId: 'req_1', jsonMode: true },
+      idempotencyKey: 'idem_1',
+      requestFingerprint: 'fingerprint_1',
+    };
+  }
+});
+
+function createOAuthFlow(): OAuthAuthorizationFlow {
+  return {
+    submitConsent: vi.fn(),
+    createLocalhostCliToken: vi.fn(),
+    startBackendOAuth: vi.fn(),
+    restartBackendOAuth: vi.fn(),
+    completeBackendOAuthCallback: vi.fn(),
+    getBackendOAuthDashboard: vi.fn(),
+  };
+}

--- a/src/domains/admin/adminOAuthService.ts
+++ b/src/domains/admin/adminOAuthService.ts
@@ -1,0 +1,95 @@
+import type { OAuthAuthorizationFlow } from '@src/auth/oauthAuthorizationFlow.js';
+
+import type { AdminOperationContext, AdminOperationResult, AdminOperationService } from './adminOperationService.js';
+
+interface AdminOAuthServiceOptions {
+  operationService: AdminOperationService;
+  oauthFlow: OAuthAuthorizationFlow;
+}
+
+interface AdminOAuthOperationInput {
+  context: AdminOperationContext;
+  serviceId: string;
+}
+
+export interface AdminOAuthRedirectResult {
+  serviceId: string;
+  redirectUrl: string;
+}
+
+export interface AdminOAuthOperations {
+  authorizeService(input: AdminOAuthOperationInput): Promise<AdminOperationResult<AdminOAuthRedirectResult>>;
+  restartService(input: AdminOAuthOperationInput): Promise<AdminOperationResult<AdminOAuthRedirectResult>>;
+}
+
+export class AdminOAuthService implements AdminOAuthOperations {
+  constructor(private readonly options: AdminOAuthServiceOptions) {}
+
+  async authorizeService(input: AdminOAuthOperationInput): Promise<AdminOperationResult<AdminOAuthRedirectResult>> {
+    const context = {
+      ...input.context,
+      target: { type: 'backend_oauth_service', id: input.serviceId },
+    };
+
+    return this.options.operationService.executeMutation({
+      context,
+      operationName: 'authorizeBackendOAuth',
+      run: async () => {
+        let result;
+        try {
+          result = await this.options.oauthFlow.startBackendOAuth({ serverName: input.serviceId });
+        } catch {
+          throw new Error('backend_oauth_authorization_start_failed');
+        }
+        if (result.status === 'service_not_found') {
+          throw new Error('backend_oauth_service_not_found');
+        }
+        if (result.status === 'runtime_unavailable') {
+          throw new Error('backend_oauth_runtime_unavailable');
+        }
+        if (result.status !== 'redirect') {
+          throw new Error('backend_oauth_authorization_start_failed');
+        }
+
+        return {
+          serviceId: input.serviceId,
+          redirectUrl: result.redirectUrl,
+        };
+      },
+    });
+  }
+
+  async restartService(input: AdminOAuthOperationInput): Promise<AdminOperationResult<AdminOAuthRedirectResult>> {
+    const context = {
+      ...input.context,
+      target: { type: 'backend_oauth_service', id: input.serviceId },
+    };
+
+    return this.options.operationService.executeMutation({
+      context,
+      operationName: 'restartBackendOAuth',
+      run: async () => {
+        let result;
+        try {
+          result = await this.options.oauthFlow.restartBackendOAuth({ serverName: input.serviceId });
+        } catch {
+          throw new Error('backend_oauth_authorization_start_failed');
+        }
+        if (result.status === 'service_not_found') {
+          throw new Error('backend_oauth_service_not_found');
+        }
+        if (result.status === 'runtime_unavailable') {
+          throw new Error('backend_oauth_runtime_unavailable');
+        }
+        if (result.status !== 'restarted' || !result.redirectUrl) {
+          throw new Error('backend_oauth_authorization_start_failed');
+        }
+
+        return {
+          serviceId: input.serviceId,
+          redirectUrl: result.redirectUrl,
+        };
+      },
+    });
+  }
+}

--- a/src/domains/admin/adminOperationService.test.ts
+++ b/src/domains/admin/adminOperationService.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -85,6 +86,80 @@ describe('AdminOperationService', () => {
         expect.objectContaining({ type: 'audit', operationName: 'enableConfiguredServer' }),
       ]),
     );
+  });
+
+  it('replays a retained journal entry written with legacy idempotency hashes', async () => {
+    const seedService = createService();
+    await seedService.executeMutation({
+      context: context({ idempotencyKey: 'seed', requestFingerprint: 'seed' }),
+      operationName: 'seedJournal',
+      run: async () => ({ seeded: true }),
+    });
+
+    const operationContext = context();
+    const operationName = 'enableConfiguredServer';
+    const scopedKeyHash = legacyHash(
+      JSON.stringify({
+        runtimeScopeId: 'scope_a',
+        actorType: operationContext.actor.type,
+        accountId: operationContext.actor.accountId,
+        sessionId: operationContext.actor.sessionId,
+        operationName,
+        idempotencyKey: operationContext.idempotencyKey,
+      }),
+    );
+    const fingerprintHash = legacyHash(operationContext.requestFingerprint!);
+    const legacyRecords = [
+      {
+        schemaVersion: 1,
+        type: 'reserved',
+        runtimeScopeId: 'scope_a',
+        timestamp: currentTime.toISOString(),
+        operationId: 'op_legacy',
+        operationName,
+        scopedKeyHash,
+        fingerprintHash,
+        target: operationContext.target,
+        actor: { type: 'admin_session', accountIdHash: 'legacy_account', sessionIdHash: 'legacy_session' },
+        origin: operationContext.origin,
+        request: operationContext.request,
+        runtimeIdentity: operationContext.runtimeIdentity,
+      },
+      {
+        schemaVersion: 1,
+        type: 'completed',
+        runtimeScopeId: 'scope_a',
+        timestamp: currentTime.toISOString(),
+        operationId: 'op_legacy',
+        operationName,
+        scopedKeyHash,
+        fingerprintHash,
+        result: { enabled: true, source: 'legacy' },
+      },
+    ];
+    fs.writeFileSync(journalPath(), `${legacyRecords.map((record) => JSON.stringify(record)).join('\n')}\n`, {
+      mode: 0o600,
+    });
+
+    const restarted = createService();
+    let executionCount = 0;
+    const replay = await restarted.executeMutation({
+      context: operationContext,
+      operationName,
+      run: async () => {
+        executionCount += 1;
+        return { enabled: false };
+      },
+    });
+
+    expect(replay).toMatchObject({
+      ok: true,
+      status: 'completed',
+      operationId: 'op_legacy',
+      replayed: true,
+      result: { enabled: true, source: 'legacy' },
+    });
+    expect(executionCount).toBe(0);
   });
 
   it('conflicts when the same idempotency key is reused with a different fingerprint', async () => {
@@ -1065,4 +1140,8 @@ async function waitUntil(predicate: () => boolean): Promise<void> {
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function legacyHash(secret: string): string {
+  return createHash('sha256').update(secret).digest('base64url');
 }

--- a/src/domains/admin/adminOperationService.ts
+++ b/src/domains/admin/adminOperationService.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash, createHmac, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -393,15 +393,26 @@ export class AdminOperationService {
     }
 
     const scopedKeyHash = this.scopedKeyHash(input.context, input.operationName, idempotencyKey);
-    const fingerprintHash = hashSecret(requestFingerprint);
-    let existing = this.idempotency.get(scopedKeyHash);
+    const legacyScopedKeyHash = this.legacyScopedKeyHash(input.context, input.operationName, idempotencyKey);
+    const fingerprintHash = keyedSecretFingerprint(idempotencyKey, 'request', requestFingerprint);
+    const legacyFingerprintHash = legacySecretHash(requestFingerprint);
+    let existingKeyHash = scopedKeyHash;
+    let existing = this.idempotency.get(existingKeyHash);
+    if (!existing) {
+      existingKeyHash = legacyScopedKeyHash;
+      existing = this.idempotency.get(existingKeyHash);
+    }
 
     if (existing && this.isExpiredTerminal(existing)) {
-      this.idempotency.delete(scopedKeyHash);
+      this.idempotency.delete(existingKeyHash);
       existing = undefined;
     }
 
-    if (existing && existing.fingerprintHash !== fingerprintHash) {
+    if (
+      existing &&
+      existing.fingerprintHash !== fingerprintHash &&
+      existing.fingerprintHash !== legacyFingerprintHash
+    ) {
       return {
         ok: false,
         status: 'idempotency_conflict',
@@ -438,7 +449,7 @@ export class AdminOperationService {
     }
 
     if (existing?.state === 'in_flight') {
-      return (await this.waitForActiveMutation(scopedKeyHash, input.operationName)) as AdminOperationResult<T>;
+      return (await this.waitForActiveMutation(existingKeyHash, input.operationName)) as AdminOperationResult<T>;
     }
 
     const activePreparation = this.mutationState.activePreparations.get(scopedKeyHash);
@@ -905,7 +916,7 @@ export class AdminOperationService {
       scopedKeyHash: entry.scopedKeyHash,
       fingerprintHash: entry.fingerprintHash,
       target: entry.target,
-      actor: sanitizeActor(context.actor),
+      actor: sanitizeActor(context.actor, this.runtimeScopeId),
       origin: context.origin,
       request: sanitizeRequest(context.request),
       runtimeIdentity: sanitizeRuntimeIdentity(context.runtimeIdentity),
@@ -922,7 +933,7 @@ export class AdminOperationService {
       operationId: entry.operationId,
       operationName: entry.operationName,
       result,
-      actor: sanitizeActor(context.actor),
+      actor: sanitizeActor(context.actor, this.runtimeScopeId),
       origin: context.origin,
       target: entry.target,
       request: { requestId: context.request.requestId },
@@ -961,7 +972,21 @@ export class AdminOperationService {
   }
 
   private scopedKeyHash(context: AdminOperationContext, operationName: string, idempotencyKey: string): string {
-    return hashSecret(
+    return keyedSecretFingerprint(
+      idempotencyKey,
+      'idempotency-scope',
+      JSON.stringify({
+        runtimeScopeId: this.runtimeScopeId,
+        actorType: context.actor.type,
+        accountId: context.actor.accountId,
+        sessionId: context.actor.sessionId,
+        operationName,
+      }),
+    );
+  }
+
+  private legacyScopedKeyHash(context: AdminOperationContext, operationName: string, idempotencyKey: string): string {
+    return legacySecretHash(
       JSON.stringify({
         runtimeScopeId: this.runtimeScopeId,
         actorType: context.actor.type,
@@ -1030,17 +1055,21 @@ export class AdminOperationService {
   }
 
   private journalFilePath(): string {
-    return path.join(this.storageDir, `admin-operations-${hashSecret(this.runtimeScopeId).slice(0, 24)}.jsonl`);
+    return path.join(
+      this.storageDir,
+      `admin-operations-${stableIdentifierHash(this.runtimeScopeId).slice(0, 24)}.jsonl`,
+    );
   }
 }
 
 function sanitizeActor(
   actor: AdminOperationContext['actor'],
+  runtimeScopeId: string,
 ): Extract<JournalRecord, { type: 'reserved' | 'audit' }>['actor'] {
   return {
     type: actor.type,
-    accountIdHash: hashSecret(actor.accountId),
-    sessionIdHash: actor.sessionId ? hashSecret(actor.sessionId) : undefined,
+    accountIdHash: keyedSecretFingerprint(runtimeScopeId, 'account-id', actor.accountId),
+    sessionIdHash: actor.sessionId ? keyedSecretFingerprint(runtimeScopeId, 'session-id', actor.sessionId) : undefined,
   };
 }
 
@@ -1077,8 +1106,17 @@ function sanitizeConfirmationFacts(facts: Record<string, unknown> | undefined): 
   );
 }
 
-function hashSecret(secret: string): string {
+function stableIdentifierHash(identifier: string): string {
+  return createHash('sha256').update(identifier).digest('base64url');
+}
+
+// Retained v1 journal entries use unkeyed SHA-256. Keep this only for bounded replay compatibility.
+function legacySecretHash(secret: string): string {
   return createHash('sha256').update(secret).digest('base64url');
+}
+
+function keyedSecretFingerprint(key: string, domain: string, secret: string): string {
+  return createHmac('sha256', key).update(domain).update('\0').update(secret).digest('base64url');
 }
 
 function auditFactFromRecord(record: Extract<JournalRecord, { type: 'audit' }>): AdminAuditFact {

--- a/src/transport/http/routes/adminRoutes.test.ts
+++ b/src/transport/http/routes/adminRoutes.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import type { BackendOAuthDashboardResult, OAuthAuthorizationFlow } from '@src/auth/oauthAuthorizationFlow.js';
 import type { AdminBackendRestartOperations } from '@src/domains/admin/adminBackendRestartService.js';
 import {
   AdminConfiguredServerNotFoundError,
@@ -9,6 +10,7 @@ import {
   type ConfiguredServerConfigDocument,
 } from '@src/domains/admin/adminConfiguredServerService.js';
 import { AdminIdentityService } from '@src/domains/admin/adminIdentityService.js';
+import { AdminOAuthService } from '@src/domains/admin/adminOAuthService.js';
 import { type AdminAuditFact, AdminOperationService } from '@src/domains/admin/adminOperationService.js';
 import { createConfigChangeService } from '@src/domains/config-change/configChange.js';
 
@@ -39,6 +41,7 @@ function cookieValue(setCookieHeader: string): string {
 
 describe('admin routes', () => {
   let adminService: AdminIdentityService;
+  let oauthFlow: OAuthAuthorizationFlow;
   let storageDir: string;
   let configuredServerService: {
     listConfiguredServers: ReturnType<typeof vi.fn<AdminConfiguredServerOperations['listConfiguredServers']>>;
@@ -63,6 +66,7 @@ describe('admin routes', () => {
       now: () => new Date('2026-07-06T00:00:00.000Z'),
       sessionTtlMs: 60 * 60 * 1000,
     });
+    oauthFlow = createOAuthFlow();
     configuredServerService = {
       listConfiguredServers: vi.fn<AdminConfiguredServerOperations['listConfiguredServers']>(),
       getConfiguredServerDetail: vi.fn<AdminConfiguredServerOperations['getConfiguredServerDetail']>(),
@@ -88,6 +92,7 @@ describe('admin routes', () => {
       backendRestartService?: AdminBackendRestartOperations | null;
       adminConsoleAssetsDir?: string;
       adminMutationAvailability?: { available: boolean; reason?: 'writer_lock_unavailable' };
+      oauthDashboard?: BackendOAuthDashboardResult;
     } = {},
   ) {
     const app = express();
@@ -106,17 +111,26 @@ describe('admin routes', () => {
         externalUrl: options.externalUrl ?? runtimeIdentity.externalUrl,
       }),
       adminMutationAvailability: options.adminMutationAvailability,
-      getOAuthDashboard: () => ({
-        status: 'ready',
-        services: [
-          {
-            name: 'github',
-            status: 'awaiting_oauth',
-            requiresOAuth: true,
-            lastError: 'token: [REDACTED]',
-          },
-        ],
+      oauthService: new AdminOAuthService({
+        operationService: new AdminOperationService({
+          runtimeScopeId: 'scope_123',
+          storageDir,
+          now: () => new Date('2026-07-06T00:00:00.000Z'),
+        }),
+        oauthFlow,
       }),
+      getOAuthDashboard: () =>
+        options.oauthDashboard ?? {
+          status: 'ready',
+          services: [
+            {
+              name: 'github',
+              status: 'awaiting_oauth',
+              requiresOAuth: true,
+              lastError: 'token: [REDACTED]',
+            },
+          ],
+        },
       adminConsoleAssetsDir: options.adminConsoleAssetsDir,
     });
 
@@ -142,8 +156,8 @@ describe('admin routes', () => {
     });
   }
 
-  function createAdminAssetFixture(): string {
-    const assetsRoot = `${storageDir}/admin-assets`;
+  function createAdminAssetFixture(parentDir = storageDir): string {
+    const assetsRoot = `${parentDir}/admin-assets`;
     fs.mkdirSync(`${assetsRoot}/assets`, { recursive: true });
     fs.writeFileSync(
       `${assetsRoot}/index.html`,
@@ -311,6 +325,17 @@ describe('admin routes', () => {
     expect(response.text).not.toMatch(/<script(?![^>]*\bsrc=)[^>]*>/i);
     expect(response.text).not.toMatch(/<style[\s>]/i);
     expect(response.text).not.toMatch(/account create|disable account|delete account|password reset/i);
+  });
+
+  it('serves the packaged entrypoint when its absolute path includes a dot-directory', async () => {
+    await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+    const app = mountAdminRoutes({ adminConsoleAssetsDir: createAdminAssetFixture(`${storageDir}/.worktrees`) });
+
+    const response = await request(app).get('/admin');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('text/html');
+    expect(response.text).toContain('<div id="admin-root"></div>');
   });
 
   it('falls browser admin subroutes back to the SPA entrypoint', async () => {
@@ -2091,6 +2116,8 @@ describe('admin routes', () => {
         services: [
           {
             name: 'github',
+            id: 'github',
+            displayName: 'github',
             status: 'awaiting_oauth',
             requiresOAuth: true,
             lastError: 'token: [REDACTED]',
@@ -2164,6 +2191,222 @@ describe('admin routes', () => {
     expect(response.status).toBe(200);
     expect(JSON.stringify(response.body)).not.toContain('raw-secret');
     expect(response.body.oauth.services[0].lastError).toBe('token: [REDACTED]');
+  });
+
+  it('projects full OAuth service ids separately from compact operator display names', async () => {
+    await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+    const app = mountAdminRoutes({
+      oauthDashboard: {
+        status: 'ready',
+        services: [
+          {
+            name: 'context7:0123456789abcdef',
+            status: 'awaiting_oauth',
+            requiresOAuth: true,
+          },
+          {
+            name: 'github',
+            status: 'connected',
+            requiresOAuth: false,
+          },
+          {
+            name: 'context7:short',
+            status: 'awaiting_oauth',
+            requiresOAuth: true,
+          },
+          {
+            name: 'invalid:template:identity',
+            status: 'awaiting_oauth',
+            requiresOAuth: true,
+          },
+        ],
+      },
+    });
+    const loginResponse = await request(app)
+      .post('/admin/api/session/login')
+      .send({ username: 'operator', password: 'correct horse battery staple' });
+    const cookie = loginResponse.headers['set-cookie']?.[0] as string;
+
+    const response = await request(app).get('/admin/api/status').set('Cookie', cookie);
+
+    expect(response.status).toBe(200);
+    expect(response.body.oauth.services).toMatchObject([
+      {
+        id: 'context7:0123456789abcdef',
+        displayName: 'context7:0123456789ab',
+      },
+      {
+        id: 'github',
+        displayName: 'github',
+      },
+      {
+        id: 'context7:short',
+        displayName: 'context7:short',
+      },
+      {
+        id: 'invalid:template:identity',
+        displayName: 'invalid:template:identity',
+      },
+    ]);
+  });
+
+  it('authorizes the exact backend OAuth service through authenticated, CSRF-protected Admin Operations', async () => {
+    await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+    vi.mocked(oauthFlow.startBackendOAuth).mockResolvedValue({
+      status: 'redirect',
+      redirectUrl: 'https://provider.example/authorize',
+    });
+    const app = mountAdminRoutes();
+
+    const unauthenticatedResponse = await request(app)
+      .post('/admin/api/oauth/context7%3A0123456789abcdef/authorize')
+      .set('X-CSRF-Token', 'csrf_invalid')
+      .set('Idempotency-Key', 'oauth-authorize-unauthenticated');
+
+    expect(unauthenticatedResponse.status).toBe(401);
+    expect(oauthFlow.startBackendOAuth).not.toHaveBeenCalled();
+
+    const loginResponse = await request(app)
+      .post('/admin/api/session/login')
+      .send({ username: 'operator', password: 'correct horse battery staple' });
+    const cookie = loginResponse.headers['set-cookie']?.[0] as string;
+    const csrfToken = loginResponse.body.csrfToken as string;
+
+    const missingCsrfResponse = await request(app)
+      .post('/admin/api/oauth/context7%3A0123456789abcdef/authorize')
+      .set('Cookie', cookie)
+      .set('Idempotency-Key', 'oauth-authorize-no-csrf');
+
+    expect(missingCsrfResponse.status).toBe(403);
+    expect(oauthFlow.startBackendOAuth).not.toHaveBeenCalled();
+
+    const response = await request(app)
+      .post('/admin/api/oauth/context7%3A0123456789abcdef/authorize')
+      .set('Cookie', cookie)
+      .set('X-CSRF-Token', csrfToken)
+      .set('Idempotency-Key', 'oauth-authorize-success');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      replayed: false,
+      result: {
+        serviceId: 'context7:0123456789abcdef',
+        redirectUrl: 'https://provider.example/authorize',
+      },
+    });
+    expect(oauthFlow.startBackendOAuth).toHaveBeenCalledWith({ serverName: 'context7:0123456789abcdef' });
+  });
+
+  it('restarts the exact backend OAuth service through authenticated, CSRF-protected Admin Operations', async () => {
+    await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+    vi.mocked(oauthFlow.restartBackendOAuth).mockResolvedValue({
+      status: 'restarted',
+      redirectUrl: 'https://provider.example/restart',
+    });
+    const app = mountAdminRoutes();
+
+    const unauthenticatedResponse = await request(app)
+      .post('/admin/api/oauth/context7%3A0123456789abcdef/restart')
+      .set('X-CSRF-Token', 'csrf_invalid')
+      .set('Idempotency-Key', 'oauth-restart-unauthenticated');
+    expect(unauthenticatedResponse.status).toBe(401);
+
+    const loginResponse = await request(app)
+      .post('/admin/api/session/login')
+      .send({ username: 'operator', password: 'correct horse battery staple' });
+    const cookie = loginResponse.headers['set-cookie']?.[0] as string;
+    const csrfToken = loginResponse.body.csrfToken as string;
+    const missingCsrfResponse = await request(app)
+      .post('/admin/api/oauth/context7%3A0123456789abcdef/restart')
+      .set('Cookie', cookie)
+      .set('Idempotency-Key', 'oauth-restart-no-csrf');
+    expect(missingCsrfResponse.status).toBe(403);
+    expect(oauthFlow.restartBackendOAuth).not.toHaveBeenCalled();
+
+    const response = await request(app)
+      .post('/admin/api/oauth/context7%3A0123456789abcdef/restart')
+      .set('Cookie', cookie)
+      .set('X-CSRF-Token', csrfToken)
+      .set('Idempotency-Key', 'oauth-restart-success');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      result: {
+        serviceId: 'context7:0123456789abcdef',
+        redirectUrl: 'https://provider.example/restart',
+      },
+    });
+    expect(oauthFlow.restartBackendOAuth).toHaveBeenCalledWith({ serverName: 'context7:0123456789abcdef' });
+  });
+
+  it.each(['authorize', 'restart'] as const)(
+    'rejects invalid OAuth service IDs before %s operations',
+    async (action) => {
+      await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+      const app = mountAdminRoutes();
+      const loginResponse = await request(app)
+        .post('/admin/api/session/login')
+        .send({ username: 'operator', password: 'correct horse battery staple' });
+      const serviceId = 'a'.repeat(257);
+
+      const response = await request(app)
+        .post(`/admin/api/oauth/${serviceId}/${action}`)
+        .set('Cookie', loginResponse.headers['set-cookie']?.[0] as string)
+        .set('X-CSRF-Token', loginResponse.body.csrfToken as string)
+        .set('Idempotency-Key', `oauth-${action}-invalid-service`);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ error: 'backend_oauth_service_id_invalid' });
+      expect(oauthFlow.startBackendOAuth).not.toHaveBeenCalled();
+      expect(oauthFlow.restartBackendOAuth).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      flowResult: {
+        status: 'service_not_found' as const,
+        errorDescription: 'Missing service internal detail',
+      },
+      expectedStatus: 404,
+      expectedError: 'backend_oauth_service_not_found',
+    },
+    {
+      flowResult: {
+        status: 'runtime_unavailable' as const,
+        errorDescription: 'Runtime internal detail',
+      },
+      expectedStatus: 503,
+      expectedError: 'backend_oauth_runtime_unavailable',
+    },
+    {
+      flowResult: {
+        status: 'oauth_url_unavailable' as const,
+        errorDescription: 'provider_secret=do-not-expose',
+      },
+      expectedStatus: 502,
+      expectedError: 'backend_oauth_authorization_start_failed',
+    },
+  ])('maps backend OAuth failures to $expectedError without exposing details', async (testCase) => {
+    await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+    vi.mocked(oauthFlow.startBackendOAuth).mockResolvedValue(testCase.flowResult);
+    const app = mountAdminRoutes();
+    const loginResponse = await request(app)
+      .post('/admin/api/session/login')
+      .send({ username: 'operator', password: 'correct horse battery staple' });
+    const cookie = loginResponse.headers['set-cookie']?.[0] as string;
+
+    const response = await request(app)
+      .post('/admin/api/oauth/github/authorize')
+      .set('Cookie', cookie)
+      .set('X-CSRF-Token', loginResponse.body.csrfToken as string)
+      .set('Idempotency-Key', `oauth-error-${testCase.expectedError}`);
+
+    expect(response.status).toBe(testCase.expectedStatus);
+    expect(response.body).toEqual({ ok: false, error: testCase.expectedError });
+    expect(JSON.stringify(response.body)).not.toContain(testCase.flowResult.errorDescription);
   });
 
   it('enables and disables configured servers through CSRF-protected admin API mutations', async () => {
@@ -2273,6 +2516,17 @@ describe('admin routes', () => {
     expect(bootstrapSpy).toHaveBeenCalled();
   });
 });
+
+function createOAuthFlow(): OAuthAuthorizationFlow {
+  return {
+    submitConsent: vi.fn(),
+    createLocalhostCliToken: vi.fn(),
+    startBackendOAuth: vi.fn(),
+    restartBackendOAuth: vi.fn(),
+    completeBackendOAuthCallback: vi.fn(),
+    getBackendOAuthDashboard: vi.fn(),
+  };
+}
 
 describe('FailedLoginLimiter', () => {
   it('bounds active keys, fails closed at capacity, and prunes expired entries globally', () => {

--- a/src/transport/http/routes/adminRoutes.test.ts
+++ b/src/transport/http/routes/adminRoutes.test.ts
@@ -617,6 +617,14 @@ describe('admin routes', () => {
       .get('/admin/cli/v1/session/status')
       .set('Authorization', 'Bearer admin_sess_missing')
       .set('X-Request-Id', 'req_cli_status_missing');
+    const spacedResponse = await request(app)
+      .get('/admin/cli/v1/session/status')
+      .set('Authorization', `Bearer${' '.repeat(2048)}${sessionToken}`)
+      .set('X-Request-Id', 'req_cli_status_spaced');
+    const malformedResponse = await request(app)
+      .get('/admin/cli/v1/session/status')
+      .set('Authorization', `Bearer\t${sessionToken}`)
+      .set('X-Request-Id', 'req_cli_status_malformed');
 
     expect(validateSpy).toHaveBeenCalledWith(sessionToken);
     expect(authenticatedResponse.status).toBe(200);
@@ -646,6 +654,17 @@ describe('admin routes', () => {
         runtime: cliRuntimeIdentity,
       },
     });
+    expect(spacedResponse.body).toMatchObject({
+      ok: true,
+      requestId: 'req_cli_status_spaced',
+      result: { authenticated: true },
+    });
+    expect(malformedResponse.body).toMatchObject({
+      ok: true,
+      requestId: 'req_cli_status_malformed',
+      result: { authenticated: false },
+    });
+    expect(validateSpy).toHaveBeenCalledWith(undefined);
   });
 
   it('logs out through the CLI adapter by revoking the bearer session server-side', async () => {

--- a/src/transport/http/routes/adminRoutes.ts
+++ b/src/transport/http/routes/adminRoutes.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHmac } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -36,15 +36,21 @@ import {
   type AdminPresetOperations,
 } from '@src/domains/admin/adminPresetService.js';
 import type { AdminMutationAvailability } from '@src/domains/admin/runtimeScopeAdminLock.js';
+import { sensitiveOperationLimiter } from '@src/transport/http/middlewares/securityMiddleware.js';
 import { sanitizeErrorMessage } from '@src/utils/validation/sanitization.js';
 
 import express, { Request, Response, Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { createRequire } from 'node:module';
 import { z } from 'zod';
 
 const FAILED_LOGIN_LIMIT = 5;
 const FAILED_LOGIN_WINDOW_MS = 15 * 60 * 1000;
 const FAILED_LOGIN_MAX_ACTIVE_KEYS = 10_000;
+const ADMIN_AUTH_RATE_LIMIT = 30;
+const ADMIN_AUTH_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const ADMIN_STATUS_RATE_LIMIT = 120;
+const ADMIN_STATUS_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const ADMIN_USERNAME_MAX_LENGTH = 256;
 const ADMIN_PASSWORD_MAX_LENGTH = 4096;
 const CLI_ADMIN_PROTOCOL_VERSION = '1';
@@ -115,6 +121,18 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
 
   const router = Router();
   const failedLoginLimiter = new FailedLoginLimiter();
+  const authenticationLimiter = rateLimit({
+    windowMs: ADMIN_AUTH_RATE_LIMIT_WINDOW_MS,
+    max: ADMIN_AUTH_RATE_LIMIT,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+  const statusLimiter = rateLimit({
+    windowMs: ADMIN_STATUS_RATE_LIMIT_WINDOW_MS,
+    max: ADMIN_STATUS_RATE_LIMIT,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
   const adminConsoleAssets = resolveAdminConsoleAssets(options.adminConsoleAssetsDir);
   options.adminService.bootstrapFirstAdminFromEnvironment();
 
@@ -164,7 +182,7 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
     });
   });
 
-  router.post('/cli/v1/session/login', async (req, res) => {
+  router.post('/cli/v1/session/login', authenticationLimiter, async (req, res) => {
     const parsedBody = adminLoginBodySchema.safeParse(req.body);
     if (!parsedBody.success) {
       sendCliError(req, res, {
@@ -248,7 +266,7 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
     await handleCliBackendRestart(req, res, options);
   });
 
-  router.post('/api/session/login', async (req, res) => {
+  router.post('/api/session/login', authenticationLimiter, async (req, res) => {
     const parsedBody = adminLoginBodySchema.safeParse(req.body);
     if (!parsedBody.success) {
       res.status(400).json({ error: 'admin_login_request_invalid' });
@@ -318,7 +336,7 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
     res.status(200).json({ ok: true });
   });
 
-  router.get('/api/status', (req, res) => {
+  router.get('/api/status', statusLimiter, (req, res) => {
     const session = options.adminService.validateSession(getAdminSessionCookie(req));
     if (!session) {
       res.status(401).json({ authenticated: false });
@@ -347,7 +365,7 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
     });
   });
 
-  router.post('/api/oauth/:serviceId/authorize', async (req, res) => {
+  router.post('/api/oauth/:serviceId/authorize', sensitiveOperationLimiter, async (req, res) => {
     if (!options.oauthService) {
       res.status(503).json({ error: 'backend_oauth_runtime_unavailable' });
       return;
@@ -362,7 +380,7 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
     sendAdminOAuthOperationResult(res, result);
   });
 
-  router.post('/api/oauth/:serviceId/restart', async (req, res) => {
+  router.post('/api/oauth/:serviceId/restart', sensitiveOperationLimiter, async (req, res) => {
     if (!options.oauthService) {
       res.status(503).json({ error: 'backend_oauth_runtime_unavailable' });
       return;
@@ -1099,9 +1117,24 @@ function getBearerSessionToken(req: Request): string | undefined {
     return undefined;
   }
 
-  const match = authorization.match(/^Bearer\s+(.+)$/i);
-  const token = match?.[1]?.trim();
-  return token || undefined;
+  const bearerScheme = 'Bearer';
+  if (
+    authorization.length <= bearerScheme.length ||
+    authorization.slice(0, bearerScheme.length).toLowerCase() !== bearerScheme.toLowerCase()
+  ) {
+    return undefined;
+  }
+
+  let tokenStart = bearerScheme.length;
+  if (authorization.charCodeAt(tokenStart) !== 0x20) {
+    return undefined;
+  }
+  while (authorization.charCodeAt(tokenStart) === 0x20) {
+    tokenStart += 1;
+  }
+
+  const token = authorization.slice(tokenStart);
+  return token && !/\s/u.test(token) ? token : undefined;
 }
 
 function isHttpsRuntime(externalUrl: string): boolean {
@@ -1498,6 +1531,7 @@ function configuredServerRequestFingerprint(
   targetName: string | undefined,
   body?: unknown,
 ): string {
+  const previewFingerprint = getBodyString(body, 'previewFingerprint');
   const normalized = stableJsonStringify({
     schemaVersion: 1,
     operationName,
@@ -1507,10 +1541,12 @@ function configuredServerRequestFingerprint(
     },
     ...(operationName === 'applyConfiguredServerEdit'
       ? {
-          previewFingerprint: getBodyString(body, 'previewFingerprint'),
-          editDigest: createHash('sha256')
-            .update(stableJsonStringify(getBodyValue(body, 'edit') ?? {}))
-            .digest('hex'),
+          previewFingerprint,
+          editDigest: keyedRequestFingerprint(
+            previewFingerprint,
+            'configured-server-edit',
+            stableJsonStringify(getBodyValue(body, 'edit') ?? {}),
+          ),
         }
       : {}),
     ...(operationName === 'restartBackend'
@@ -1523,8 +1559,12 @@ function configuredServerRequestFingerprint(
       : {}),
   });
   return operationName === 'applyConfiguredServerEdit'
-    ? `configured_server_apply_${createHash('sha256').update(normalized).digest('hex')}`
+    ? `configured_server_apply_${keyedRequestFingerprint(previewFingerprint, 'configured-server-apply', normalized)}`
     : normalized;
+}
+
+function keyedRequestFingerprint(key: string, domain: string, value: string): string {
+  return createHmac('sha256', key).update(domain).update('\0').update(value).digest('hex');
 }
 
 function backendOAuthRequestFingerprint(operationName: string, serviceId: string | undefined): string {
@@ -1613,6 +1653,9 @@ function cliOperationErrorDetails(result: AdminOperationFailure): Record<string,
 }
 
 function operationNameForRequest(req: Request): string {
+  if (req.path.startsWith('/api/oauth/')) {
+    return req.path.endsWith('/restart') ? 'restartBackendOAuth' : 'authorizeBackendOAuth';
+  }
   if (req.path.endsWith('/restart-server')) {
     return 'restartBackend';
   }

--- a/src/transport/http/routes/adminRoutes.ts
+++ b/src/transport/http/routes/adminRoutes.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import type { BackendOAuthDashboardResult } from '@src/auth/oauthAuthorizationFlow.js';
 import { RuntimeIdentity } from '@src/core/runtime/runtimeIdentityService.js';
+import { parseTemplateConnectionKey } from '@src/core/server/templateIdentity.js';
 import type {
   AdminBackendRestartOperations,
   BackendRestartOutcome,
@@ -22,6 +23,7 @@ import {
   AdminIdentityError,
   AdminIdentityService,
 } from '@src/domains/admin/adminIdentityService.js';
+import type { AdminOAuthOperations } from '@src/domains/admin/adminOAuthService.js';
 import type {
   AdminConfirmationRequirement,
   AdminOperationContext,
@@ -51,6 +53,7 @@ const CLI_ADMIN_RESPONSE_TOO_LARGE_MESSAGE =
   'CLI Admin response exceeded the maximum supported size; use a narrower or paginated request.';
 const CLI_SESSION_OPERATIONS = ['admin.login', 'admin.status', 'admin.logout'] as const;
 const ADMIN_API_PROTOCOL_VERSION = '1';
+const TEMPLATE_INSTANCE_ID_DISPLAY_LENGTH = 12;
 const packageMetadata = createRequire(import.meta.url)('../../../../package.json') as {
   name: string;
   version: string;
@@ -65,6 +68,9 @@ const CLI_BACKEND_RESTART_OPERATION = 'mcp.restart' as const;
 const adminLoginBodySchema = z.object({
   username: z.string().trim().min(1).max(ADMIN_USERNAME_MAX_LENGTH),
   password: z.string().min(1).max(ADMIN_PASSWORD_MAX_LENGTH),
+});
+const adminOAuthServiceParamsSchema = z.object({
+  serviceId: z.string().trim().min(1).max(256),
 });
 const cliConfiguredServerMutationBodySchema = z.object({
   targetName: z.string().trim().min(1).max(256),
@@ -94,6 +100,7 @@ interface AdminRoutesOptions {
   configuredServerService?: AdminConfiguredServerOperations;
   backendRestartService?: AdminBackendRestartOperations;
   presetService?: AdminPresetOperations;
+  oauthService?: AdminOAuthOperations;
   adminMutationAvailability?: AdminMutationAvailability;
   getRuntimeIdentity: () => RuntimeIdentity;
   getOAuthDashboard?: () => BackendOAuthDashboardResult;
@@ -340,6 +347,36 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
     });
   });
 
+  router.post('/api/oauth/:serviceId/authorize', async (req, res) => {
+    if (!options.oauthService) {
+      res.status(503).json({ error: 'backend_oauth_runtime_unavailable' });
+      return;
+    }
+
+    const serviceId = parseAdminOAuthServiceId(req, res);
+    if (!serviceId) return;
+    const result = await options.oauthService.authorizeService({
+      context: buildAdminOperationContext(req, options, { type: 'backend_oauth_service', id: serviceId }),
+      serviceId,
+    });
+    sendAdminOAuthOperationResult(res, result);
+  });
+
+  router.post('/api/oauth/:serviceId/restart', async (req, res) => {
+    if (!options.oauthService) {
+      res.status(503).json({ error: 'backend_oauth_runtime_unavailable' });
+      return;
+    }
+
+    const serviceId = parseAdminOAuthServiceId(req, res);
+    if (!serviceId) return;
+    const result = await options.oauthService.restartService({
+      context: buildAdminOperationContext(req, options, { type: 'backend_oauth_service', id: serviceId }),
+      serviceId,
+    });
+    sendAdminOAuthOperationResult(res, result);
+  });
+
   router.get('/api/presets', async (req, res) => {
     if (!options.presetService) return void res.status(404).json({ error: 'admin_presets_unavailable' });
     const result = await options.presetService.listPresets({
@@ -512,7 +549,7 @@ function sendAdminConsoleIndex(res: Response, indexPath: string): void {
     return;
   }
 
-  res.status(200).sendFile(indexPath);
+  res.status(200).sendFile(indexPath, { dotfiles: 'allow' });
 }
 
 function unauthenticatedAdminApiResponse(options: AdminRoutesOptions): {
@@ -1206,6 +1243,30 @@ function sendAdminOperationResult<T>(res: Response, result: AdminOperationResult
   res.status(status).json(result);
 }
 
+function sendAdminOAuthOperationResult<T>(res: Response, result: AdminOperationResult<T>): void {
+  if (!result.ok && result.status === 'mutation_failed') {
+    const status =
+      result.error === 'backend_oauth_service_not_found'
+        ? 404
+        : result.error === 'backend_oauth_runtime_unavailable'
+          ? 503
+          : 502;
+    res.status(status).json({ ok: false, error: result.error });
+    return;
+  }
+
+  sendAdminOperationResult(res, result);
+}
+
+function parseAdminOAuthServiceId(req: Request, res: Response): string | null {
+  const parsed = adminOAuthServiceParamsSchema.safeParse(req.params);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'backend_oauth_service_id_invalid' });
+    return null;
+  }
+  return parsed.data.serviceId;
+}
+
 async function handlePresetMutation(
   req: Request,
   res: Response,
@@ -1330,7 +1391,10 @@ function buildAdminOperationContext(
       jsonMode: true,
     },
     idempotencyKey: req.header('Idempotency-Key'),
-    requestFingerprint: configuredServerRequestFingerprint(operationName, target.id, req.body),
+    requestFingerprint:
+      target.type === 'backend_oauth_service'
+        ? backendOAuthRequestFingerprint(operationName, target.id)
+        : configuredServerRequestFingerprint(operationName, target.id, req.body),
     confirmationFacts: getBodyRecord(req.body, 'confirmationFacts'),
   };
 }
@@ -1461,6 +1525,17 @@ function configuredServerRequestFingerprint(
   return operationName === 'applyConfiguredServerEdit'
     ? `configured_server_apply_${createHash('sha256').update(normalized).digest('hex')}`
     : normalized;
+}
+
+function backendOAuthRequestFingerprint(operationName: string, serviceId: string | undefined): string {
+  return stableJsonStringify({
+    schemaVersion: 1,
+    operationName,
+    target: {
+      type: 'backend_oauth_service',
+      id: serviceId ?? '',
+    },
+  });
 }
 
 function stableJsonStringify(value: unknown): string {
@@ -1598,9 +1673,20 @@ function sanitizeOAuthDashboard(dashboard: BackendOAuthDashboardResult): Backend
     ...dashboard,
     services: dashboard.services.map((service) => ({
       ...service,
+      id: service.name,
+      displayName: backendOAuthServiceDisplayName(service.name),
       lastError: service.lastError ? sanitizeErrorMessage(service.lastError) : undefined,
     })),
   };
+}
+
+function backendOAuthServiceDisplayName(serviceId: string): string {
+  const identity = parseTemplateConnectionKey(serviceId);
+  if (identity.kind !== 'rendered' || identity.renderedHash.length <= TEMPLATE_INSTANCE_ID_DISPLAY_LENGTH) {
+    return serviceId;
+  }
+
+  return `${identity.templateName}:${identity.renderedHash.slice(0, TEMPLATE_INSTANCE_ID_DISPLAY_LENGTH)}`;
 }
 
 function getBodyValue(body: unknown, key: string): unknown {

--- a/src/transport/http/routes/oauthRoutes.test.ts
+++ b/src/transport/http/routes/oauthRoutes.test.ts
@@ -182,7 +182,7 @@ describe('OAuth Routes', () => {
       const response = await request(app).get('/oauth');
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/admin');
+      expect(response.headers.location).toBe('/admin/oauth');
       expect(mockOAuthProvider.oauthFlow.getBackendOAuthDashboard).not.toHaveBeenCalled();
     });
 
@@ -482,7 +482,7 @@ describe('OAuth Routes', () => {
         serverName: 'test-server',
         code: 'auth-code-123',
       });
-      expect(mockResponse.redirect).toHaveBeenCalledWith('/oauth?success=1');
+      expect(mockResponse.redirect).toHaveBeenCalledWith('/admin/oauth?success=1');
     });
 
     it('should delegate loading-ready callback handling to the OAuth flow', async () => {
@@ -511,7 +511,7 @@ describe('OAuth Routes', () => {
         code: 'auth-code-123',
       });
       expect(mockStateTracker.updateServerState).not.toHaveBeenCalled();
-      expect(mockResponse.redirect).toHaveBeenCalledWith('/oauth?success=1');
+      expect(mockResponse.redirect).toHaveBeenCalledWith('/admin/oauth?success=1');
     });
 
     it('should handle OAuth error', async () => {
@@ -533,7 +533,7 @@ describe('OAuth Routes', () => {
         serverName: 'test-server',
         error: 'access_denied',
       });
-      expect(mockResponse.redirect).toHaveBeenCalledWith('/oauth?error=access_denied');
+      expect(mockResponse.redirect).toHaveBeenCalledWith('/admin/oauth?error=access_denied');
     });
   });
 });

--- a/src/transport/http/routes/oauthRoutes.ts
+++ b/src/transport/http/routes/oauthRoutes.ts
@@ -26,9 +26,12 @@ const consentBodySchema = z.object({
 /**
  * Creates OAuth routes with the provided OAuth provider
  */
-export function createOAuthRoutes(oauthProvider: SDKOAuthServerProvider, loadingManager?: McpLoadingManager): Router {
+export function createOAuthRoutes(
+  oauthProvider: SDKOAuthServerProvider,
+  loadingManager?: McpLoadingManager,
+  oauthFlow: OAuthAuthorizationFlow = createBackendOAuthAuthorizationFlow(oauthProvider, loadingManager),
+): Router {
   const router: Router = Router();
-  const oauthFlow = getOAuthFlow(oauthProvider, loadingManager);
 
   // Rate limiter for OAuth endpoints
   const createOAuthLimiter = () => {
@@ -48,7 +51,7 @@ export function createOAuthRoutes(oauthProvider: SDKOAuthServerProvider, loading
    * OAuth Dashboard - Shows all services and their OAuth status
    */
   router.get('/', (_req: Request, res: Response) => {
-    res.redirect('/admin');
+    res.redirect('/admin/oauth');
   });
 
   /**
@@ -95,14 +98,14 @@ export function createOAuthRoutes(oauthProvider: SDKOAuthServerProvider, loading
       if (result.status !== 'completed') {
         logger.error(`OAuth callback failed for ${serverName}:`, result.errorDescription);
         const errorCode = result.status === 'provider_error' ? result.errorDescription : result.status;
-        return res.redirect(`/oauth?error=${encodeURIComponent(errorCode)}`);
+        return res.redirect(`/admin/oauth?error=${encodeURIComponent(errorCode)}`);
       }
 
       // Redirect back to dashboard with success
-      res.redirect('/oauth?success=1');
+      res.redirect('/admin/oauth?success=1');
     } catch (error) {
       logger.error(`Error handling OAuth callback for ${serverName}:`, error);
-      res.redirect(`/oauth?error=callback_failed`);
+      res.redirect('/admin/oauth?error=callback_failed');
     }
   });
 
@@ -182,8 +185,16 @@ export function createOAuthRoutes(oauthProvider: SDKOAuthServerProvider, loading
 export function createBackendOAuthDashboardProvider(
   oauthProvider: SDKOAuthServerProvider & OAuthAuthorizationFlowProvider,
   loadingManager?: McpLoadingManager,
+  oauthFlow: OAuthAuthorizationFlow = createBackendOAuthAuthorizationFlow(oauthProvider, loadingManager),
 ): () => ReturnType<OAuthAuthorizationFlow['getBackendOAuthDashboard']> {
-  return () => getOAuthFlow(oauthProvider, loadingManager).getBackendOAuthDashboard();
+  return () => oauthFlow.getBackendOAuthDashboard();
+}
+
+export function createBackendOAuthAuthorizationFlow(
+  oauthProvider: SDKOAuthServerProvider & OAuthAuthorizationFlowProvider,
+  loadingManager?: McpLoadingManager,
+): OAuthAuthorizationFlow {
+  return getOAuthFlow(oauthProvider, loadingManager);
 }
 
 function getOAuthFlow(

--- a/src/transport/http/server.test.ts
+++ b/src/transport/http/server.test.ts
@@ -68,6 +68,7 @@ vi.mock('./middlewares/errorHandler.js', () => ({
 }));
 
 vi.mock('./middlewares/securityMiddleware.js', () => ({
+  sensitiveOperationLimiter: vi.fn((_req, _res, next) => next()),
   setupSecurityMiddleware: vi.fn(() => [vi.fn()]),
 }));
 

--- a/src/transport/http/server.test.ts
+++ b/src/transport/http/server.test.ts
@@ -89,6 +89,9 @@ vi.mock('./routes/sseRoutes.js', () => ({
 
 vi.mock('./routes/oauthRoutes.js', () => ({
   default: vi.fn(() => 'oauth-routes'),
+  createBackendOAuthAuthorizationFlow: vi.fn(() => ({
+    getBackendOAuthDashboard: vi.fn(() => ({ status: 'ready', services: [] })),
+  })),
   createBackendOAuthDashboardProvider: vi.fn(() => vi.fn(() => ({ status: 'ready', services: [] }))),
 }));
 
@@ -367,6 +370,24 @@ describe('ExpressServer', () => {
       ).resolves.toMatchObject({
         target: { name: 'initial' },
       });
+    });
+
+    it('constructs one backend OAuth flow for protocol routes, status, and Admin Operations', async () => {
+      expressServer = new ExpressServer(mockServerManager);
+
+      const oauthRoutesModule = await import('./routes/oauthRoutes.js');
+      const { createAdminDomain } = await import('@src/domains/admin/adminDomain.js');
+      const createFlow = vi.mocked(oauthRoutesModule.createBackendOAuthAuthorizationFlow);
+      const oauthFlow = createFlow.mock.results[0]?.value;
+
+      expect(createFlow).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(oauthRoutesModule.default)).toHaveBeenCalledWith(expect.any(Object), undefined, oauthFlow);
+      expect(vi.mocked(oauthRoutesModule.createBackendOAuthDashboardProvider)).toHaveBeenCalledWith(
+        expect.any(Object),
+        undefined,
+        oauthFlow,
+      );
+      expect(vi.mocked(createAdminDomain)).toHaveBeenCalledWith(expect.objectContaining({ oauthFlow }));
     });
 
     it('should redirect the server root to admin when admin surfaces are enabled', async () => {

--- a/src/transport/http/server.ts
+++ b/src/transport/http/server.ts
@@ -40,7 +40,10 @@ import { setupSecurityMiddleware } from './middlewares/securityMiddleware.js';
 import { createAdminRoutes } from './routes/adminRoutes.js';
 import { createApiRoutes, createCliTokenRoute, rejectBrowserOriginRequests } from './routes/apiRoutes.js';
 import createHealthRoutes from './routes/healthRoutes.js';
-import createOAuthRoutes, { createBackendOAuthDashboardProvider } from './routes/oauthRoutes.js';
+import createOAuthRoutes, {
+  createBackendOAuthAuthorizationFlow,
+  createBackendOAuthDashboardProvider,
+} from './routes/oauthRoutes.js';
 import { createRuntimeIdentityRoutes } from './routes/runtimeIdentityRoutes.js';
 import { setupSseRoutes } from './routes/sseRoutes.js';
 import { setupStreamableHttpRoutes } from './routes/streamableHttpRoutes.js';
@@ -381,8 +384,9 @@ export class ExpressServer {
     this.app.use(authRouter);
 
     // Setup OAuth management routes (no auth required)
-    this.app.use('/oauth', createOAuthRoutes(this.oauthProvider, this.loadingManager));
-    const getOAuthDashboard = createBackendOAuthDashboardProvider(this.oauthProvider, this.loadingManager);
+    const oauthFlow = createBackendOAuthAuthorizationFlow(this.oauthProvider, this.loadingManager);
+    this.app.use('/oauth', createOAuthRoutes(this.oauthProvider, this.loadingManager, oauthFlow));
+    const getOAuthDashboard = createBackendOAuthDashboardProvider(this.oauthProvider, this.loadingManager, oauthFlow);
 
     // Setup health check routes (no auth required for monitoring)
     this.app.use('/health', createHealthRoutes(this.loadingManager));
@@ -414,6 +418,7 @@ export class ExpressServer {
         serverManager: this.serverManager,
         resolveTarget: resolveServerTarget,
       }),
+      oauthFlow,
     });
     const adminRoutes = createAdminRoutes({
       adminEnabled,
@@ -421,6 +426,7 @@ export class ExpressServer {
       configuredServerService: adminDomain.configuredServerService,
       presetService: adminDomain.presetService,
       backendRestartService: adminDomain.backendRestartService,
+      oauthService: adminDomain.oauthService,
       adminMutationAvailability,
       getRuntimeIdentity,
       getOAuthDashboard,

--- a/test/e2e/admin-spa-browser-smoke.e2e.test.ts
+++ b/test/e2e/admin-spa-browser-smoke.e2e.test.ts
@@ -114,13 +114,29 @@ describe('admin SPA browser smoke', () => {
 
       await expectText(page, 'Runtime operations');
       await expectVisible(page.getByRole('navigation', { name: 'Operations navigation' }));
-      await expectText(page, 'Operations overview');
+      await expectText(page, 'Operations dashboard');
       await expectText(page, 'Runtime online');
-      await expectText(page, 'Server inventory');
       await expectText(page, 'Enabled servers');
       await expectText(page, 'Disabled servers');
       await expectText(page, 'OAuth attention');
       await expectText(page, 'Failed audits');
+      expect(await page.getByRole('heading', { name: 'Server inventory' }).count()).toBe(0);
+
+      await page.goto(`${baseUrl}/admin/audit`);
+      await expectVisible(page.getByRole('heading', { name: 'Audit trail' }));
+
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers`);
+      await expectVisible(page.getByRole('heading', { name: 'Server inventory' }));
+
+      await page.goBack();
+      await page.waitForURL(`${baseUrl}/admin/audit`);
+      await expectVisible(page.getByRole('heading', { name: 'Audit trail' }));
+      await page.goForward();
+      await page.waitForURL(`${baseUrl}/admin/servers`);
+      await expectVisible(page.getByRole('heading', { name: 'Server inventory' }));
+      await page.reload();
+      await expectVisible(page.getByRole('heading', { name: 'Server inventory' }));
 
       await page.getByLabel('Search servers').fill('github');
       await waitForRowCount(page, 1);
@@ -144,14 +160,26 @@ describe('admin SPA browser smoke', () => {
     try {
       await expectCenteredLoginGate(page);
       await login(page, { skipNavigation: true });
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers`);
 
       await page.getByRole('button', { name: 'Edit github server' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers/github`);
       await expectVisible(page.getByRole('heading', { name: 'github', exact: true }));
 
       const tags = page.getByRole('textbox', { name: 'Tags' });
       await tags.fill('verified');
       await tags.press('Enter');
       await expectText(page, 'Unsaved changes');
+
+      await page.getByRole('link', { name: 'OAuth services' }).click();
+      const leaveDialog = page.getByRole('dialog');
+      await expectVisible(leaveDialog);
+      await expectVisible(leaveDialog.getByText('Discard unsaved changes?'));
+      await leaveDialog.getByRole('button', { name: 'Cancel' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers/github`);
+      await expectText(page, 'Unsaved changes');
+
       await page.getByRole('button', { name: 'Preview change' }).click();
 
       await expectText(page, 'Preview result');
@@ -165,7 +193,8 @@ describe('admin SPA browser smoke', () => {
       await expectVisible(dialog.getByText('This writes the validated configuration and reloads the Runtime Scope.'));
       await page.keyboard.press('Escape');
       await dialog.waitFor({ state: 'hidden' });
-      expect(await applyButton.evaluate((element) => element === globalThis.document.activeElement)).toBe(true);
+      const applyButtonHandle = await applyButton.elementHandle();
+      await page.waitForFunction((element) => element === globalThis.document.activeElement, applyButtonHandle);
       expect(await page.getByText('Changes applied to github.').count()).toBe(0);
 
       const applyResponsePromise = page.waitForResponse((response) =>
@@ -201,10 +230,17 @@ describe('admin SPA browser smoke', () => {
         await login(page, { skipNavigation: true });
 
         await expectText(page, 'Runtime operations');
-        await expectText(page, 'Operations overview');
+        await expectText(page, 'Operations dashboard');
         await expectVisible(page.getByRole('button', { name: 'Refresh' }));
         await expectVisible(page.getByRole('button', { name: 'Log out' }));
         await expectNoPageOverflow(page);
+
+        const navigationToggle = page.getByRole('button', { name: 'Open operations navigation' });
+        await expectVisible(navigationToggle);
+        await navigationToggle.click();
+        await expectVisible(page.getByRole('navigation', { name: 'Operations navigation' }));
+        await page.getByRole('link', { name: 'Server inventory' }).click();
+        await page.waitForURL(`${baseUrl}/admin/servers`);
 
         if (compactInventory) {
           await expectVisible(page.locator('.server-mobile-card').first());
@@ -214,13 +250,11 @@ describe('admin SPA browser smoke', () => {
           expect(await page.locator('.server-mobile-card').count()).toBe(0);
         }
 
-        const navigationToggle = page.getByRole('button', { name: 'Open operations navigation' });
-        await expectVisible(navigationToggle);
-        await navigationToggle.click();
+        await page.getByRole('button', { name: 'Open operations navigation' }).click();
         await expectVisible(page.getByRole('navigation', { name: 'Operations navigation' }));
-        await page.getByRole('button', { name: 'OAuth services' }).click();
-        await page.waitForFunction(() => globalThis.location.hash === '#oauth');
-        await page.waitForFunction(() => globalThis.document.activeElement?.id === 'oauth');
+        await page.getByRole('link', { name: 'OAuth services' }).click();
+        await page.waitForURL(`${baseUrl}/admin/oauth`);
+        await expectVisible(page.getByRole('heading', { name: 'OAuth services' }));
         await expectVisible(page.getByRole('button', { name: 'Open operations navigation' }));
         await expectNoPageOverflow(page);
       } finally {
@@ -235,6 +269,8 @@ describe('admin SPA browser smoke', () => {
     try {
       await expectCenteredLoginGate(page);
       await login(page, { skipNavigation: true });
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers`);
       await expectNoPageOverflow(page);
 
       const layout = await page.locator('.workspace-grid').evaluate((element) => {
@@ -267,8 +303,20 @@ describe('admin SPA browser smoke', () => {
   }
 
   async function expectCenteredLoginGate(page: Page): Promise<void> {
-    await page.goto(`${baseUrl}/admin`);
-    await expectVisible(page.getByRole('heading', { name: 'Operator login' }));
+    const browserErrors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') browserErrors.push(message.text());
+    });
+    page.on('pageerror', (error) => browserErrors.push(error.message));
+    const response = await page.goto(`${baseUrl}/admin`);
+    try {
+      await expectVisible(page.getByRole('heading', { name: 'Operator login' }));
+    } catch (error) {
+      throw new Error(
+        `Admin login gate did not render (HTTP ${response?.status() ?? 'unknown'}). Browser errors: ${browserErrors.join(' | ') || 'none'}. Body: ${await page.locator('body').innerText()}`,
+        { cause: error },
+      );
+    }
     expect(await page.locator('.admin-app-header').count()).toBe(0);
     expect(await page.locator('.status-strip').count()).toBe(0);
 

--- a/test/e2e/http/http-oauth-notifications.test.ts
+++ b/test/e2e/http/http-oauth-notifications.test.ts
@@ -88,7 +88,7 @@ describe('HTTP OAuth Notifications E2E', () => {
 
     // Assert
     expect(mockCompleteOAuthAndReconnect).toHaveBeenCalledWith('test-oauth-server', 'auth-code-123');
-    expect(mockResponse.redirect).toHaveBeenCalledWith('/oauth?success=1');
+    expect(mockResponse.redirect).toHaveBeenCalledWith('/admin/oauth?success=1');
     expect(mockLoadingManager.getStateTracker).toHaveBeenCalled();
     expect(mockUpdateServerState).toHaveBeenCalledWith('test-oauth-server', LoadingState.Ready);
   });
@@ -107,7 +107,7 @@ describe('HTTP OAuth Notifications E2E', () => {
     await callbackRoute.route.stack[0].handle(mockRequest, mockResponse, mockNext);
 
     // Assert
-    expect(mockResponse.redirect).toHaveBeenCalledWith('/oauth?error=access_denied');
+    expect(mockResponse.redirect).toHaveBeenCalledWith('/admin/oauth?error=access_denied');
     expect(mockUpdateServerState).not.toHaveBeenCalled();
   });
 
@@ -126,7 +126,7 @@ describe('HTTP OAuth Notifications E2E', () => {
 
     // Assert
     expect(mockCompleteOAuthAndReconnect).toHaveBeenCalledWith('test-oauth-server', 'auth-code-123');
-    expect(mockResponse.redirect).toHaveBeenCalledWith('/oauth?success=1');
+    expect(mockResponse.redirect).toHaveBeenCalledWith('/admin/oauth?success=1');
     expect(mockLoadingManager.getStateTracker).not.toHaveBeenCalled();
   });
 });

--- a/web/admin/src/api/adminApi.test.ts
+++ b/web/admin/src/api/adminApi.test.ts
@@ -77,6 +77,67 @@ describe('admin API client', () => {
     });
   });
 
+  it('authorizes and restarts full OAuth service ids with CSRF, unique idempotency, and redirect results', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const api = createAdminApi({
+      idempotencyKey: ({ action, targetName }) => `key-${action}-${targetName}`,
+      fetch: async (input, init) => {
+        calls.push({ input, init });
+        return jsonResponse({
+          ok: true,
+          operationId: actionOperationId(String(input)),
+          result: {
+            serviceId: 'context7:0123456789abcdef',
+            redirectUrl: String(input).endsWith('/authorize')
+              ? 'https://provider.example/authorize'
+              : 'https://provider.example/restart',
+          },
+        });
+      },
+    });
+
+    const authorized = await api.authorizeOAuthService({
+      serviceId: 'context7:0123456789abcdef',
+      csrfToken: 'csrf_authorize',
+    });
+    const restarted = await api.restartOAuthService({
+      serviceId: 'context7:0123456789abcdef',
+      csrfToken: 'csrf_restart',
+    });
+
+    expect(calls).toMatchObject([
+      {
+        input: '/admin/api/oauth/context7%3A0123456789abcdef/authorize',
+        init: {
+          method: 'POST',
+          headers: {
+            'X-CSRF-Token': 'csrf_authorize',
+            'Idempotency-Key': 'key-oauth-authorize-context7:0123456789abcdef',
+          },
+        },
+      },
+      {
+        input: '/admin/api/oauth/context7%3A0123456789abcdef/restart',
+        init: {
+          method: 'POST',
+          headers: {
+            'X-CSRF-Token': 'csrf_restart',
+            'Idempotency-Key': 'key-oauth-restart-context7:0123456789abcdef',
+          },
+        },
+      },
+    ]);
+    expect(calls[0].init?.headers).not.toEqual(calls[1].init?.headers);
+    expect(authorized).toEqual({
+      serviceId: 'context7:0123456789abcdef',
+      redirectUrl: 'https://provider.example/authorize',
+    });
+    expect(restarted).toEqual({
+      serviceId: 'context7:0123456789abcdef',
+      redirectUrl: 'https://provider.example/restart',
+    });
+  });
+
   it('loads configured-server detail with an encoded target id', async () => {
     const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
     const api = createAdminApi({
@@ -354,3 +415,7 @@ describe('admin API client', () => {
     });
   });
 });
+
+function actionOperationId(input: string): string {
+  return input.endsWith('/authorize') ? 'op_authorize' : 'op_restart';
+}

--- a/web/admin/src/api/adminApi.ts
+++ b/web/admin/src/api/adminApi.ts
@@ -26,6 +26,8 @@ export interface RuntimeIdentity {
 
 export interface OAuthServiceStatus {
   name: string;
+  id: string;
+  displayName: string;
   status: string;
   requiresOAuth?: boolean;
   lastError?: string;
@@ -319,7 +321,15 @@ export interface ConfiguredServerApplyResponse {
 
 export interface AdminApiOptions {
   fetch?: typeof fetch;
-  idempotencyKey?: (input: { action: 'enable' | 'disable'; targetName: string }) => string;
+  idempotencyKey?: (input: {
+    action: 'enable' | 'disable' | 'oauth-authorize' | 'oauth-restart';
+    targetName: string;
+  }) => string;
+}
+
+export interface OAuthAuthorizationRedirectResult {
+  serviceId: string;
+  redirectUrl: string;
 }
 
 export class AdminApiError extends Error {
@@ -414,6 +424,42 @@ export function createAdminApi(options: AdminApiOptions = {}) {
 
     getStatus(): Promise<AdminStatus> {
       return request('/admin/api/status');
+    },
+
+    async authorizeOAuthService(input: {
+      serviceId: string;
+      csrfToken: string;
+    }): Promise<OAuthAuthorizationRedirectResult> {
+      const response = await request<{ result: OAuthAuthorizationRedirectResult }>(
+        `/admin/api/oauth/${encodeURIComponent(input.serviceId)}/authorize`,
+        {
+          method: 'POST',
+          headers: {
+            'X-CSRF-Token': input.csrfToken,
+            'Idempotency-Key': idempotencyKey({ action: 'oauth-authorize', targetName: input.serviceId }),
+          },
+          body: '{}',
+        },
+      );
+      return response.result;
+    },
+
+    async restartOAuthService(input: {
+      serviceId: string;
+      csrfToken: string;
+    }): Promise<OAuthAuthorizationRedirectResult> {
+      const response = await request<{ result: OAuthAuthorizationRedirectResult }>(
+        `/admin/api/oauth/${encodeURIComponent(input.serviceId)}/restart`,
+        {
+          method: 'POST',
+          headers: {
+            'X-CSRF-Token': input.csrfToken,
+            'Idempotency-Key': idempotencyKey({ action: 'oauth-restart', targetName: input.serviceId }),
+          },
+          body: '{}',
+        },
+      );
+      return response.result;
     },
 
     async listPresets(): Promise<{ revision: string; presets: AdminPresetListItem[]; targets: AdminPresetTarget[] }> {
@@ -692,6 +738,12 @@ function friendlyAdminError(error: AdminApiError, code: string): string {
       return 'Refresh the console and retry the action with a new request.';
     case 'admin_configured_servers_unavailable':
       return 'Configured-server operations are not available on this runtime.';
+    case 'backend_oauth_service_not_found':
+      return 'The OAuth service is no longer available. Refresh the OAuth status and try again.';
+    case 'backend_oauth_runtime_unavailable':
+      return 'Backend OAuth operations are not available on this runtime.';
+    case 'backend_oauth_authorization_start_failed':
+      return 'The runtime could not start backend OAuth authorization. Refresh the OAuth status and try again.';
     case 'mutation_failed':
       return 'The runtime could not apply the server change. Refresh the console and inspect the current state.';
     case 'configured_server_stale_preview':
@@ -738,7 +790,10 @@ function readBodyMessage(body: unknown): string | null {
   return typeof message === 'string' && message.trim().length > 0 ? message.trim() : null;
 }
 
-function defaultIdempotencyKey(input: { action: 'enable' | 'disable'; targetName: string }): string {
+function defaultIdempotencyKey(input: {
+  action: 'enable' | 'disable' | 'oauth-authorize' | 'oauth-restart';
+  targetName: string;
+}): string {
   const random = crypto.getRandomValues(new Uint32Array(2)).join('-');
   return `admin-console-${input.action}-${encodeIdempotencyKeyPart(input.targetName)}-${Date.now()}-${random}`;
 }

--- a/web/admin/src/components/AdminConsoleApp.fixtures.tsx
+++ b/web/admin/src/components/AdminConsoleApp.fixtures.tsx
@@ -32,6 +32,7 @@ interface SessionOverrides {
   refresh?: AdminConsoleSessionModel['refresh'];
   navigation?: Partial<AdminConsoleSessionModel['navigation']>;
   configuredServers?: ConfiguredServerOverrides;
+  oauth?: Partial<AdminConsoleSessionModel['oauth']>;
   presets?: Partial<AdminConsoleSessionModel['presets']>;
 }
 
@@ -75,14 +76,19 @@ export function fixtureSession(
     logout: overrides.logout ?? (() => undefined),
     refresh: overrides.refresh ?? (() => undefined),
     navigation: {
-      route: overrides.navigation?.route ?? 'overview',
-      section: overrides.navigation?.section ?? null,
+      route: overrides.navigation?.route ?? 'dashboard',
       navigate: overrides.navigation?.navigate ?? (() => undefined),
     },
     configuredServers: {
       edit,
       mutate: overrides.configuredServers?.mutate ?? (() => undefined),
       copy: overrides.configuredServers?.copy ?? (() => undefined),
+    },
+    oauth: {
+      busy: overrides.oauth?.busy ?? null,
+      callbackFeedback: overrides.oauth?.callbackFeedback ?? null,
+      operationFeedback: overrides.oauth?.operationFeedback ?? null,
+      operate: overrides.oauth?.operate ?? (() => undefined),
     },
     presets: {
       items: overrides.presets?.items ?? [],
@@ -146,6 +152,8 @@ export function consoleState(): AdminConsoleState {
         services: [
           {
             name: 'github',
+            id: 'github',
+            displayName: 'github',
             status: 'awaiting_oauth',
             requiresOAuth: true,
             lastError: 'token: [REDACTED]',

--- a/web/admin/src/components/AdminConsoleApp.test.tsx
+++ b/web/admin/src/components/AdminConsoleApp.test.tsx
@@ -47,18 +47,15 @@ describe('AdminConsoleApp', () => {
     expect(screen.getByLabelText(/username/i)).toBeDisabled();
   });
 
-  it('shows runtime, OAuth, audit, counters, search, and enabled filtering', async () => {
+  it('renders a summary-only dashboard with direct workspace links', async () => {
     const user = userEvent.setup();
-    const onServerAction = vi.fn();
     const onCopyText = vi.fn();
 
-    renderApp(consoleState(), { configuredServers: { mutate: onServerAction, copy: onCopyText } });
+    renderApp(consoleState(), { configuredServers: { copy: onCopyText } });
 
-    expect(screen.getByRole('navigation', { name: /operations navigation/i })).toBeInTheDocument();
+    const navigation = screen.getByRole('navigation', { name: /operations navigation/i });
     expect(screen.getByRole('banner', { name: /admin console/i })).toHaveTextContent(/runtime online/i);
-    expect(screen.getByRole('heading', { name: /operations overview/i })).toBeInTheDocument();
-    expect(screen.getByText(/runtime health/i)).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /operations dashboard/i })).toBeInTheDocument();
     expect(screen.getByText('Enabled servers')).toBeInTheDocument();
     expect(screen.getAllByText('1').length).toBeGreaterThanOrEqual(4);
     expect(screen.getByText('Disabled servers')).toBeInTheDocument();
@@ -66,16 +63,40 @@ describe('AdminConsoleApp', () => {
     expect(screen.getByText('Failed audits')).toBeInTheDocument();
     expect(screen.getAllByText('https://runtime.example.com').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('1.2.3').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText(/Identity details/i)).toBeInTheDocument();
     expect(screen.getAllByText('scope_123').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('github').length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText('local / storage')).toBeInTheDocument();
-    expect(screen.getByText('npx -y @modelcontextprotocol/server-filesystem /tmp/project')).toBeInTheDocument();
-    expect(screen.getByText('awaiting_oauth')).toBeInTheDocument();
-    expect(screen.getByText('enableConfiguredServer')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /server inventory/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /oauth services/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /audit trail/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('npx -y @modelcontextprotocol/server-filesystem /tmp/project')).not.toBeInTheDocument();
+    expect(screen.queryByText('awaiting_oauth')).not.toBeInTheDocument();
+    expect(screen.queryByText('enableConfiguredServer')).not.toBeInTheDocument();
+
+    expect(within(navigation).getByRole('link', { name: 'Dashboard' })).toHaveAttribute('href', '/admin');
+    expect(within(navigation).getByRole('link', { name: 'Server inventory' })).toHaveAttribute(
+      'href',
+      '/admin/servers',
+    );
+    expect(within(navigation).getByRole('link', { name: 'OAuth services' })).toHaveAttribute('href', '/admin/oauth');
+    expect(within(navigation).getByRole('link', { name: 'Audit trail' })).toHaveAttribute('href', '/admin/audit');
+    expect(within(navigation).getByRole('link', { name: 'Presets' })).toHaveAttribute('href', '/admin/presets');
+    expect(within(navigation).getByRole('link', { name: 'About' })).toHaveAttribute('href', '/admin/about');
 
     await user.click(screen.getByRole('button', { name: /copy runtime scope/i }));
     expect(onCopyText).toHaveBeenCalledWith('runtimeScopeId', 'scope_123');
+  });
+
+  it('renders the full inventory and editor only in the servers workspace', async () => {
+    const user = userEvent.setup();
+    const onServerAction = vi.fn();
+
+    renderApp(consoleState(), {
+      navigation: { route: 'servers' },
+      configuredServers: { mutate: onServerAction },
+    });
+
+    expect(screen.getByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
+    expect(screen.getByText('local / storage')).toBeInTheDocument();
+    expect(screen.getByText('npx -y @modelcontextprotocol/server-filesystem /tmp/project')).toBeInTheDocument();
 
     await user.type(screen.getByRole('searchbox', { name: /search servers/i }), 'git');
     expect(within(screen.getByRole('table')).queryByText('filesystem')).not.toBeInTheDocument();
@@ -89,33 +110,97 @@ describe('AdminConsoleApp', () => {
     expect(onServerAction).toHaveBeenCalledWith('github', 'enable');
   });
 
-  it('navigates to Presets and About as final top-level items', async () => {
+  it('navigates with real links and keeps Presets and About as final top-level items', async () => {
     const user = userEvent.setup();
     const onNavigate = vi.fn();
     renderApp(consoleState(), { navigation: { navigate: onNavigate } });
 
     const navigation = screen.getByRole('navigation', { name: /operations navigation/i });
-    const buttons = within(navigation).getAllByRole('button');
-    expect(buttons.at(-1)).toHaveTextContent('About');
-    await user.click(screen.getByRole('button', { name: 'Presets' }));
-    await user.click(screen.getByRole('button', { name: 'About' }));
+    const links = within(navigation).getAllByRole('link');
+    expect(links.at(-1)).toHaveTextContent('About');
+    await user.click(screen.getByRole('link', { name: 'Presets' }));
+    await user.click(screen.getByRole('link', { name: 'About' }));
     expect(onNavigate).toHaveBeenNthCalledWith(1, 'presets');
     expect(onNavigate).toHaveBeenNthCalledWith(2, 'about');
   });
 
-  it('navigates to overview sections and exposes the current section', async () => {
+  it('exposes the current direct workspace and navigates without hash sections', async () => {
     const user = userEvent.setup();
     const onNavigate = vi.fn();
-    renderApp(consoleState(), { navigation: { section: 'oauth', navigate: onNavigate } });
+    renderApp(consoleState(), { navigation: { route: 'oauth', navigate: onNavigate } });
 
-    expect(screen.getByRole('button', { name: 'OAuth services' })).toHaveAttribute('aria-current', 'page');
-    expect(document.querySelector('#oauth')).toHaveFocus();
+    expect(screen.getByRole('link', { name: 'OAuth services' })).toHaveAttribute('aria-current', 'page');
 
-    await user.click(screen.getByRole('button', { name: 'Server inventory' }));
-    await user.click(screen.getByRole('button', { name: 'Audit trail' }));
+    await user.click(screen.getByRole('link', { name: 'Server inventory' }));
+    await user.click(screen.getByRole('link', { name: 'Audit trail' }));
 
-    expect(onNavigate).toHaveBeenNthCalledWith(1, 'overview', 'inventory');
-    expect(onNavigate).toHaveBeenNthCalledWith(2, 'overview', 'audit');
+    expect(onNavigate).toHaveBeenNthCalledWith(1, 'servers');
+    expect(onNavigate).toHaveBeenNthCalledWith(2, 'audit');
+  });
+
+  it('operates OAuth services by full identity while keeping template labels compact', async () => {
+    const user = userEvent.setup();
+    const state = consoleState();
+    const onCopyText = vi.fn();
+    const onOperate = vi.fn();
+    state.status!.oauth.services = [
+      {
+        name: 'context7:0123456789abcdef',
+        id: 'context7:0123456789abcdef',
+        displayName: 'context7:0123456789ab',
+        status: 'awaiting_oauth',
+        requiresOAuth: true,
+      },
+      {
+        name: 'github',
+        id: 'github',
+        displayName: 'github',
+        status: 'connected',
+        requiresOAuth: true,
+      },
+    ];
+
+    renderApp(state, {
+      navigation: { route: 'oauth' },
+      configuredServers: { copy: onCopyText },
+      oauth: { operate: onOperate },
+    });
+
+    expect(screen.getByRole('heading', { name: /^oauth services$/i })).toBeInTheDocument();
+    expect(screen.getByText('context7:0123456789ab')).toBeInTheDocument();
+    expect(screen.getByText('context7:0123456789abcdef')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /copy full service id for context7:0123456789ab/i }));
+    expect(onCopyText).toHaveBeenCalledWith('serviceId', 'context7:0123456789abcdef');
+
+    await user.click(screen.getByRole('button', { name: /authorize context7:0123456789ab/i }));
+    await user.click(screen.getByRole('button', { name: /restart github/i }));
+    expect(onOperate).toHaveBeenNthCalledWith(1, 'context7:0123456789abcdef', 'authorize');
+    expect(onOperate).toHaveBeenNthCalledWith(2, 'github', 'restart');
+  });
+
+  it('shows OAuth callback, busy, and operation feedback in the OAuth workspace', () => {
+    const state = consoleState();
+    state.status!.oauth.services.push({
+      name: 'gitlab',
+      id: 'gitlab',
+      displayName: 'gitlab',
+      status: 'connected',
+      requiresOAuth: true,
+    });
+    renderApp(state, {
+      navigation: { route: 'oauth' },
+      oauth: {
+        busy: { serviceId: 'github', action: 'authorize' },
+        callbackFeedback: { kind: 'success', message: 'OAuth authorization completed.' },
+        operationFeedback: { kind: 'error', message: 'Authorization could not be started.' },
+      },
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('OAuth authorization completed.');
+    expect(screen.getByRole('alert')).toHaveTextContent('Authorization could not be started.');
+    expect(screen.getByRole('button', { name: /authorize github/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /restart gitlab/i })).toBeDisabled();
+    expect(screen.getByText('Starting authorization...')).toBeInTheDocument();
   });
 
   it('opens and closes the accessible mobile navigation control', async () => {
@@ -325,7 +410,10 @@ describe('AdminConsoleApp', () => {
     const user = userEvent.setup();
     const onOpenServerDetail = vi.fn();
 
-    renderApp(consoleState(), { configuredServers: { open: onOpenServerDetail } });
+    renderApp(consoleState(), {
+      navigation: { route: 'servers' },
+      configuredServers: { open: onOpenServerDetail },
+    });
 
     await user.click(screen.getByRole('button', { name: /edit github server/i }));
 
@@ -337,6 +425,7 @@ describe('AdminConsoleApp', () => {
     const onPreviewServerEdit = vi.fn();
 
     renderApp(consoleState(), {
+      navigation: { route: 'servers' },
       configuredServers: { editor: configuredServerDetailState(), preview: onPreviewServerEdit },
     });
 
@@ -363,7 +452,7 @@ describe('AdminConsoleApp', () => {
   });
 
   it('explains how to start editing when no configured server is selected', () => {
-    renderApp(consoleState());
+    renderApp(consoleState(), { navigation: { route: 'servers' } });
 
     expect(screen.getByText(/Select Edit server to change target settings/i)).toBeInTheDocument();
     expect(screen.getByText(/Edit fields -> Preview change -> Review result/i)).toBeInTheDocument();
@@ -374,6 +463,7 @@ describe('AdminConsoleApp', () => {
     const onPreviewServerEdit = vi.fn();
 
     renderApp(consoleState(), {
+      navigation: { route: 'servers' },
       configuredServers: {
         editor: configuredServerDetailState({
           fieldGroups: [
@@ -475,6 +565,7 @@ describe('AdminConsoleApp', () => {
   it('switches configured-server fields with the selected transport type', async () => {
     const user = userEvent.setup();
     renderApp(consoleState(), {
+      navigation: { route: 'servers' },
       configuredServers: {
         editor: configuredServerDetailState({
           schemaVersion: 2,
@@ -578,6 +669,7 @@ describe('AdminConsoleApp', () => {
     const onCloseServerDetail = vi.fn();
 
     renderApp(consoleState(), {
+      navigation: { route: 'servers' },
       configuredServers: { editor: configuredServerDetailState(), close: onCloseServerDetail },
     });
 
@@ -593,6 +685,7 @@ describe('AdminConsoleApp', () => {
     const onPreviewServerEdit = vi.fn();
 
     renderApp(consoleState(), {
+      navigation: { route: 'servers' },
       configuredServers: {
         editor: {
           ...configuredServerDetailState(),
@@ -626,6 +719,7 @@ describe('AdminConsoleApp', () => {
 
   it('renders preview validation, diff, config-change, and connectivity facts', () => {
     renderApp(consoleState(), {
+      navigation: { route: 'servers' },
       configuredServers: {
         editor: {
           ...configuredServerDetailState(),
@@ -690,7 +784,7 @@ describe('AdminConsoleApp', () => {
           } as any,
         ],
       },
-      { configuredServers: { mutate: onServerAction } },
+      { navigation: { route: 'servers' }, configuredServers: { mutate: onServerAction } },
     );
 
     expect(screen.getByText('node')).toBeInTheDocument();
@@ -723,7 +817,7 @@ describe('AdminConsoleApp', () => {
           },
         ],
       },
-      { configuredServers: { mutate: onServerAction } },
+      { navigation: { route: 'servers' }, configuredServers: { mutate: onServerAction } },
     );
 
     const button = screen.getByRole('button', { name: /enable locked/i });
@@ -756,6 +850,7 @@ describe('AdminConsoleApp', () => {
             login: onLogin,
             logout: onLogout,
             refresh: onRefresh,
+            navigation: { route: 'servers' },
             configuredServers: { mutate: onServerAction },
           })}
         />

--- a/web/admin/src/components/AdminConsoleApp.tsx
+++ b/web/admin/src/components/AdminConsoleApp.tsx
@@ -15,21 +15,22 @@ import {
 } from '@mantine/core';
 
 import { Boxes, FileClock, Gauge, Info, ShieldCheck, SlidersHorizontal } from 'lucide-react';
-import { type ReactNode, useState } from 'react';
+import { type MouseEvent, type ReactNode, useState } from 'react';
 
-import type { AdminConsoleSessionModel } from '../session/AdminConsoleSessionModel';
+import type { AdminConsoleRoute, AdminConsoleSessionModel } from '../session/AdminConsoleSessionModel';
 import type { AdminConsoleState } from '../state/adminConsoleState';
 import { runtimeEndpointSummary, runtimeSummary, viewBadgeColor, viewLabel } from './adminConsoleUtils';
 import { AboutRuntimeWorkspace } from './workspaces/AboutRuntimeWorkspace';
+import { OAuthServicesWorkspace } from './workspaces/OAuthServicesWorkspace';
 import { PresetAuthoringWorkspace } from './workspaces/PresetAuthoringWorkspace';
-import { RuntimeOperationsWorkspace } from './workspaces/RuntimeOperationsWorkspace';
+import { AuditTrailWorkspace, DashboardWorkspace, ServersWorkspace } from './workspaces/RuntimeOperationsWorkspace';
 
 export interface AdminConsoleAppProps {
   session: AdminConsoleSessionModel;
 }
 
 export function AdminConsoleApp({ session }: AdminConsoleAppProps) {
-  const { state, loginBusy, navigation, configuredServers, presets } = session;
+  const { state, loginBusy, navigation } = session;
   const route = navigation.route;
   const [mobileNavigationOpened, setMobileNavigationOpened] = useState(false);
   if (state.view !== 'console') {
@@ -91,39 +92,45 @@ export function AdminConsoleApp({ session }: AdminConsoleAppProps) {
           <Text className="nav-section-label">Workspace</Text>
           <NavItem
             icon={<Gauge size={17} />}
-            label="Overview"
-            active={route === 'overview' && !navigation.section}
-            onClick={() => navigate('overview')}
+            label="Dashboard"
+            href="/admin"
+            active={route === 'dashboard'}
+            onNavigate={() => navigate('dashboard')}
           />
           <NavItem
             icon={<Boxes size={17} />}
             label="Server inventory"
-            active={route === 'overview' && navigation.section === 'inventory'}
-            onClick={() => navigate('overview', 'inventory')}
+            href="/admin/servers"
+            active={route === 'servers'}
+            onNavigate={() => navigate('servers')}
           />
           <NavItem
             icon={<ShieldCheck size={17} />}
             label="OAuth services"
-            active={route === 'overview' && navigation.section === 'oauth'}
-            onClick={() => navigate('overview', 'oauth')}
+            href="/admin/oauth"
+            active={route === 'oauth'}
+            onNavigate={() => navigate('oauth')}
           />
           <NavItem
             icon={<FileClock size={17} />}
             label="Audit trail"
-            active={route === 'overview' && navigation.section === 'audit'}
-            onClick={() => navigate('overview', 'audit')}
+            href="/admin/audit"
+            active={route === 'audit'}
+            onNavigate={() => navigate('audit')}
           />
           <NavItem
             icon={<SlidersHorizontal size={17} />}
             label="Presets"
+            href="/admin/presets"
             active={route === 'presets'}
-            onClick={() => navigate('presets')}
+            onNavigate={() => navigate('presets')}
           />
           <NavItem
             icon={<Info size={17} />}
             label="About"
+            href="/admin/about"
             active={route === 'about'}
-            onClick={() => navigate('about')}
+            onNavigate={() => navigate('about')}
           />
         </Stack>
         <Stack gap="xs" className="nav-runtime-card">
@@ -142,68 +149,87 @@ export function AdminConsoleApp({ session }: AdminConsoleAppProps) {
       <AppShell.Main className="admin-shell-main">
         <Stack gap="md" className="admin-console">
           <Banner state={state} />
-          {route === 'presets' ? (
-            <PresetAuthoringWorkspace
-              model={{
-                ...presets,
-                targets:
-                  presets.targets.length > 0
-                    ? presets.targets
-                    : state.configuredServers.map((server) => ({
-                        name: server.id,
-                        tags: server.tags,
-                        enabled: server.enabled,
-                      })),
-              }}
-              runtimeScopeId={state.status?.runtime.runtimeScopeId}
-            />
-          ) : route === 'about' ? (
-            <AboutRuntimeWorkspace state={state} />
-          ) : (
-            <RuntimeOperationsWorkspace
-              model={{ state, logout: session.logout, refresh: session.refresh, configuredServers }}
-              activeSection={navigation.section}
-            />
-          )}
+          <ConsoleWorkspace session={session} />
         </Stack>
       </AppShell.Main>
     </AppShell>
   );
 
-  function navigate(route: 'overview' | 'presets' | 'about', section?: 'inventory' | 'oauth' | 'audit') {
-    if (section) {
-      void navigation.navigate(route, section);
-    } else {
-      void navigation.navigate(route);
-    }
+  function navigate(route: AdminConsoleRoute) {
+    void navigation.navigate(route);
     setMobileNavigationOpened(false);
+  }
+}
+
+function ConsoleWorkspace({ session }: { session: AdminConsoleSessionModel }) {
+  const { state, navigation, configuredServers, presets } = session;
+  const operatorModel = { state, logout: session.logout, refresh: session.refresh, configuredServers };
+
+  switch (navigation.route) {
+    case 'servers':
+      return <ServersWorkspace model={operatorModel} />;
+    case 'oauth':
+      return <OAuthServicesWorkspace model={operatorModel} oauth={session.oauth} />;
+    case 'audit':
+      return <AuditTrailWorkspace model={operatorModel} />;
+    case 'presets':
+      return (
+        <PresetAuthoringWorkspace
+          model={{
+            ...presets,
+            targets:
+              presets.targets.length > 0
+                ? presets.targets
+                : state.configuredServers.map((server) => ({
+                    name: server.id,
+                    tags: server.tags,
+                    enabled: server.enabled,
+                  })),
+          }}
+          runtimeScopeId={state.status?.runtime.runtimeScopeId}
+        />
+      );
+    case 'about':
+      return <AboutRuntimeWorkspace state={state} />;
+    case 'dashboard':
+      return <DashboardWorkspace model={operatorModel} navigate={navigation.navigate} />;
   }
 }
 
 function NavItem({
   icon,
   label,
+  href,
   active = false,
-  onClick,
+  onNavigate,
 }: {
   icon: ReactNode;
   label: string;
+  href: string;
   active?: boolean;
-  onClick?: () => void;
+  onNavigate?: () => void;
 }) {
   return (
-    <button
-      type="button"
+    <a
+      href={href}
       aria-current={active ? 'page' : undefined}
       className={`nav-item${active ? ' nav-item-active' : ''}`}
-      onClick={onClick}
+      onClick={(event) => {
+        if (!isSamePageNavigation(event)) return;
+        event.preventDefault();
+        onNavigate?.();
+      }}
     >
       {icon}
       <Text size="sm" fw={700}>
         {label}
       </Text>
-    </button>
+    </a>
   );
+}
+
+function isSamePageNavigation(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
 }
 
 function AuthShell({ state, children }: { state: AdminConsoleState; children: ReactNode }) {

--- a/web/admin/src/components/OperationsStatusPanels.tsx
+++ b/web/admin/src/components/OperationsStatusPanels.tsx
@@ -1,73 +1,9 @@
-import { Paper, Stack, Text } from '@mantine/core';
+import { Stack } from '@mantine/core';
 
-import { Activity, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 
-import type { AdminAuditFact, OAuthServiceStatus, RuntimeIdentity } from '../api/adminApi';
+import type { AdminAuditFact } from '../api/adminApi';
 import { DetailRow, EmptyState, Panel } from './AdminConsoleShared';
-
-export function RuntimePanel({
-  runtime,
-  onCopyText,
-}: {
-  runtime?: RuntimeIdentity;
-  onCopyText?: (label: string, value: string) => Promise<void>;
-}) {
-  return (
-    <Panel title="Runtime identity" utility="Runtime health · support details" icon={<Activity size={17} />}>
-      {runtime ? (
-        <Stack gap="xs">
-          <DetailRow label="Version" value={runtime.runtimeVersion} />
-          <DetailRow
-            label="External URL"
-            value={runtime.externalUrl ?? '-'}
-            copyLabel="externalUrl"
-            onCopyText={onCopyText}
-          />
-          <Paper className="identity-details" withBorder>
-            <Stack gap={4}>
-              <Text className="eyebrow" size="xs">
-                Identity details
-              </Text>
-              <Text size="sm" c="dimmed">
-                Full runtime scope ID is support metadata. Prefer version and external URL in the main scan path.
-              </Text>
-              <DetailRow
-                label="Runtime scope"
-                value={runtime.runtimeScopeId}
-                copyLabel="runtimeScopeId"
-                onCopyText={onCopyText}
-              />
-            </Stack>
-          </Paper>
-        </Stack>
-      ) : (
-        <EmptyState message="Runtime status has not loaded." />
-      )}
-    </Panel>
-  );
-}
-
-export function OAuthPanel({ services }: { services: OAuthServiceStatus[] }) {
-  return (
-    <Panel title="OAuth status" utility={`${services.length} services`} icon={<CheckCircle2 size={17} />}>
-      {services.length === 0 ? (
-        <EmptyState message="No OAuth services reported." />
-      ) : (
-        <Stack gap="xs">
-          {services.map((service) => (
-            <DetailRow
-              key={service.name}
-              label={service.name}
-              value={service.status}
-              meta={service.requiresOAuth ? 'OAuth required' : 'No OAuth'}
-              description={service.lastError}
-            />
-          ))}
-        </Stack>
-      )}
-    </Panel>
-  );
-}
 
 export function AuditPanel({
   facts,

--- a/web/admin/src/components/adminConsoleUtils.test.ts
+++ b/web/admin/src/components/adminConsoleUtils.test.ts
@@ -3,11 +3,58 @@ import { isOAuthAttention } from './adminConsoleUtils';
 
 describe('adminConsoleUtils', () => {
   it.each([
-    [{ name: 'healthy-oauth', requiresOAuth: true, status: 'connected' }, false],
-    [{ name: 'waiting-oauth', requiresOAuth: true, status: 'awaiting_oauth' }, true],
-    [{ name: 'failed-oauth', requiresOAuth: true, status: 'connected', lastError: 'token expired' }, true],
-    [{ name: 'healthy-public', requiresOAuth: false, status: 'connected' }, false],
-    [{ name: 'failed-public', requiresOAuth: false, status: 'error', lastError: 'unavailable' }, false],
+    [
+      {
+        name: 'healthy-oauth',
+        id: 'healthy-oauth',
+        displayName: 'healthy-oauth',
+        requiresOAuth: true,
+        status: 'connected',
+      },
+      false,
+    ],
+    [
+      {
+        name: 'waiting-oauth',
+        id: 'waiting-oauth',
+        displayName: 'waiting-oauth',
+        requiresOAuth: true,
+        status: 'awaiting_oauth',
+      },
+      true,
+    ],
+    [
+      {
+        name: 'failed-oauth',
+        id: 'failed-oauth',
+        displayName: 'failed-oauth',
+        requiresOAuth: true,
+        status: 'connected',
+        lastError: 'token expired',
+      },
+      true,
+    ],
+    [
+      {
+        name: 'healthy-public',
+        id: 'healthy-public',
+        displayName: 'healthy-public',
+        requiresOAuth: false,
+        status: 'connected',
+      },
+      false,
+    ],
+    [
+      {
+        name: 'failed-public',
+        id: 'failed-public',
+        displayName: 'failed-public',
+        requiresOAuth: false,
+        status: 'error',
+        lastError: 'unavailable',
+      },
+      false,
+    ],
   ] satisfies [OAuthServiceStatus, boolean][])('classifies OAuth attention for %s', (service, expected) => {
     expect(isOAuthAttention(service)).toBe(expected);
   });

--- a/web/admin/src/components/workspaces/OAuthServicesWorkspace.tsx
+++ b/web/admin/src/components/workspaces/OAuthServicesWorkspace.tsx
@@ -127,11 +127,9 @@ function OAuthServiceRow({
             >
               {actionLabel}
             </Button>
-            {busy ? (
-              <Text size="xs" c="dimmed" aria-live="polite">
-                {busy === 'authorize' ? 'Starting authorization...' : 'Restarting authorization...'}
-              </Text>
-            ) : null}
+            <Text size="xs" c="dimmed" aria-live="polite">
+              {busy ? (busy === 'authorize' ? 'Starting authorization...' : 'Restarting authorization...') : ''}
+            </Text>
           </Stack>
         ) : null}
       </Group>

--- a/web/admin/src/components/workspaces/OAuthServicesWorkspace.tsx
+++ b/web/admin/src/components/workspaces/OAuthServicesWorkspace.tsx
@@ -1,0 +1,157 @@
+import { Alert, Badge, Button, Code, Group, Paper, Stack, Text } from '@mantine/core';
+
+import { Clipboard, KeyRound, RotateCcw } from 'lucide-react';
+import { useState } from 'react';
+
+import type { OAuthServiceStatus } from '../../api/adminApi';
+import type {
+  AdminConsoleSessionModel,
+  OAuthAdminAction,
+  OperatorWorkspaceModel,
+} from '../../session/AdminConsoleSessionModel';
+import { WorkspaceHeading } from './RuntimeOperationsWorkspace';
+
+export function OAuthServicesWorkspace({
+  model,
+  oauth,
+}: {
+  model: OperatorWorkspaceModel;
+  oauth: AdminConsoleSessionModel['oauth'];
+}) {
+  const { state, configuredServers } = model;
+  const services = state.status?.oauth.services ?? [];
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+
+  async function copyServiceId(service: OAuthServiceStatus): Promise<void> {
+    try {
+      await configuredServers.copy('serviceId', service.id);
+      setCopyFeedback('Service id copied.');
+    } catch {
+      setCopyFeedback('Could not copy service id. Select the value manually.');
+    }
+  }
+
+  return (
+    <section aria-label="OAuth services" className="operations-workspace">
+      <WorkspaceHeading
+        title="OAuth services"
+        description={`${services.length} reported services · runtime status ${state.status?.oauth.status ?? 'unavailable'}`}
+        model={model}
+      />
+      {oauth.callbackFeedback ? <FeedbackAlert feedback={oauth.callbackFeedback} /> : null}
+      {oauth.operationFeedback ? <FeedbackAlert feedback={oauth.operationFeedback} /> : null}
+      {services.length === 0 ? (
+        <Paper className="operations-panel" withBorder>
+          <Text c="dimmed">No OAuth services reported.</Text>
+        </Paper>
+      ) : (
+        <Stack gap="sm">
+          {services.map((service) => (
+            <OAuthServiceRow
+              key={service.id}
+              service={service}
+              busy={oauth.busy?.serviceId === service.id ? oauth.busy.action : null}
+              operationBlocked={oauth.busy !== null}
+              onCopy={() => void copyServiceId(service)}
+              onOperate={(action) => void oauth.operate(service.id, action)}
+            />
+          ))}
+        </Stack>
+      )}
+      {copyFeedback ? (
+        <Alert aria-live="polite" color={copyFeedback.startsWith('Could not') ? 'red' : 'teal'} mt="sm">
+          {copyFeedback}
+        </Alert>
+      ) : null}
+    </section>
+  );
+}
+
+function OAuthServiceRow({
+  service,
+  busy,
+  operationBlocked,
+  onCopy,
+  onOperate,
+}: {
+  service: OAuthServiceStatus;
+  busy: OAuthAdminAction | null;
+  operationBlocked: boolean;
+  onCopy(): void;
+  onOperate(action: OAuthAdminAction): void;
+}) {
+  const action = oauthAction(service);
+  const actionLabel = action === 'authorize' ? 'Authorize' : 'Restart';
+
+  return (
+    <Paper component="article" className="oauth-service-row" withBorder>
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <div className="oauth-service-main">
+          <Group gap="xs">
+            <Text fw={800}>{service.displayName}</Text>
+            <Badge color={service.status === 'connected' ? 'teal' : 'yellow'} variant="light">
+              {service.status}
+            </Badge>
+          </Group>
+          <Text size="xs" c="dimmed">
+            {service.requiresOAuth ? 'OAuth required' : 'No OAuth action required'}
+          </Text>
+          {service.lastError ? (
+            <Text size="sm" c="red">
+              {service.lastError}
+            </Text>
+          ) : null}
+          <details className="oauth-service-identity">
+            <summary>Full service ID</summary>
+            <Group gap="xs" wrap="nowrap">
+              <Code className="oauth-service-id">{service.id}</Code>
+              <Button
+                aria-label={`Copy full service ID for ${service.displayName}`}
+                size="compact-xs"
+                variant="subtle"
+                onClick={onCopy}
+              >
+                <Clipboard size={14} aria-hidden="true" />
+              </Button>
+            </Group>
+          </details>
+        </div>
+        {action ? (
+          <Stack gap={4} align="flex-end" className="oauth-service-action">
+            <Button
+              aria-label={`${actionLabel} ${service.displayName}`}
+              leftSection={action === 'authorize' ? <KeyRound size={15} /> : <RotateCcw size={15} />}
+              loading={busy === action}
+              disabled={operationBlocked}
+              onClick={() => onOperate(action)}
+            >
+              {actionLabel}
+            </Button>
+            {busy ? (
+              <Text size="xs" c="dimmed" aria-live="polite">
+                {busy === 'authorize' ? 'Starting authorization...' : 'Restarting authorization...'}
+              </Text>
+            ) : null}
+          </Stack>
+        ) : null}
+      </Group>
+    </Paper>
+  );
+}
+
+function oauthAction(service: OAuthServiceStatus): OAuthAdminAction | null {
+  if (!service.requiresOAuth) return null;
+  return service.status === 'awaiting_oauth' ? 'authorize' : 'restart';
+}
+
+function FeedbackAlert({ feedback }: { feedback: { kind: 'success' | 'error'; message: string } }) {
+  return (
+    <Alert
+      color={feedback.kind === 'success' ? 'teal' : 'red'}
+      role={feedback.kind === 'success' ? 'status' : 'alert'}
+      mb="sm"
+    >
+      {feedback.message}
+    </Alert>
+  );
+}

--- a/web/admin/src/components/workspaces/RuntimeOperationsWorkspace.tsx
+++ b/web/admin/src/components/workspaces/RuntimeOperationsWorkspace.tsx
@@ -233,11 +233,15 @@ function SummaryLink({
 }
 
 function CopyFeedback({ message }: { message: string | null }) {
-  return message ? (
-    <Alert aria-live="polite" color={message.startsWith('Could not') ? 'red' : 'teal'} mt="sm">
-      {message}
-    </Alert>
-  ) : null;
+  return (
+    <div aria-live="polite">
+      {message ? (
+        <Alert color={message.startsWith('Could not') ? 'red' : 'teal'} mt="sm">
+          {message}
+        </Alert>
+      ) : null}
+    </div>
+  );
 }
 
 function isSamePageNavigation(event: MouseEvent<HTMLAnchorElement>): boolean {

--- a/web/admin/src/components/workspaces/RuntimeOperationsWorkspace.tsx
+++ b/web/admin/src/components/workspaces/RuntimeOperationsWorkspace.tsx
@@ -1,43 +1,27 @@
-import { Alert, Button, Group, Paper, SimpleGrid, Text, Title } from '@mantine/core';
+import { Alert, Button, Group, Paper, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 
-import { LogOut, RefreshCw } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { ArrowRight, LogOut, RefreshCw } from 'lucide-react';
+import { type MouseEvent, useState } from 'react';
 
-import type { RuntimeOperationsModel } from '../../session/AdminConsoleSessionModel';
+import type { AdminConsoleRoute, OperatorWorkspaceModel } from '../../session/AdminConsoleSessionModel';
+import { DetailRow, Panel } from '../AdminConsoleShared';
 import { disabledServers, enabledServers, humanize, isOAuthAttention } from '../adminConsoleUtils';
 import { ConfiguredServerEditor } from '../configuredServerEditor';
 import { ConfiguredServersPanel } from '../ConfiguredServersPanel';
-import { AuditPanel, OAuthPanel, RuntimePanel } from '../OperationsStatusPanels';
+import { AuditPanel } from '../OperationsStatusPanels';
 
-type OverviewSection = 'inventory' | 'oauth' | 'audit';
-
-export function RuntimeOperationsWorkspace({
+export function DashboardWorkspace({
   model,
-  activeSection,
+  navigate,
 }: {
-  model: RuntimeOperationsModel;
-  activeSection?: OverviewSection | null;
+  model: OperatorWorkspaceModel;
+  navigate(route: AdminConsoleRoute): void | Promise<void>;
 }) {
-  const { state, logout, refresh, configuredServers } = model;
+  const { state, configuredServers } = model;
   const failedAudits = (state.status?.audit.facts ?? []).filter((fact) => fact.result === 'failed').length;
   const oauthAttention = (state.status?.oauth.services ?? []).filter(isOAuthAttention).length;
   const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
-  const inventorySectionRef = useRef<HTMLDivElement>(null);
-  const oauthSectionRef = useRef<HTMLDivElement>(null);
-  const auditSectionRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!activeSection) {
-      return;
-    }
-    const section = {
-      inventory: inventorySectionRef,
-      oauth: oauthSectionRef,
-      audit: auditSectionRef,
-    }[activeSection].current;
-    section?.scrollIntoView?.({ behavior: 'auto', block: 'start' });
-    section?.focus({ preventScroll: true });
-  }, [activeSection]);
+  const runtime = state.status?.runtime;
 
   async function copyText(label: string, value: string): Promise<void> {
     try {
@@ -53,85 +37,185 @@ export function RuntimeOperationsWorkspace({
       <Title id="runtime-operations-title" order={2} className="sr-only">
         Runtime operations
       </Title>
-      <Group justify="space-between" align="flex-start" className="workspace-heading">
-        <div>
-          <Text className="eyebrow" size="xs">
-            Operator workspace / live
-          </Text>
-          <Title order={2}>Operations overview</Title>
-          <Text c="dimmed" size="sm">
-            Runtime operations for {state.session?.account.username ?? 'operator'} · {state.configuredServers.length}{' '}
-            configured targets · updated {state.lastUpdatedAt ?? 'never'}
-          </Text>
-        </div>
-        <Group gap="xs">
-          <Button variant="default" leftSection={<RefreshCw size={16} />} onClick={() => void refresh()}>
-            Refresh
-          </Button>
-          <Button color="red" variant="light" leftSection={<LogOut size={16} />} onClick={() => void logout()}>
-            Log out
-          </Button>
-        </Group>
-      </Group>
+      <WorkspaceHeading
+        title="Operations dashboard"
+        description={`Runtime summaries for ${state.session?.account.username ?? 'operator'} · updated ${state.lastUpdatedAt ?? 'never'}`}
+        model={model}
+      />
       <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="sm" className="summary-grid">
-        <SummaryCounter label="Enabled servers" value={enabledServers(state.configuredServers)} tone="good" icon="01" />
-        <SummaryCounter
+        <SummaryLink
+          label="Enabled servers"
+          value={enabledServers(state.configuredServers)}
+          tone="good"
+          icon="01"
+          href="/admin/servers"
+          onNavigate={() => navigate('servers')}
+        />
+        <SummaryLink
           label="Disabled servers"
           value={disabledServers(state.configuredServers)}
           tone="warn"
           icon="02"
+          href="/admin/servers"
+          onNavigate={() => navigate('servers')}
         />
-        <SummaryCounter
+        <SummaryLink
           label="OAuth attention"
           value={oauthAttention}
           tone={oauthAttention > 0 ? 'warn' : 'good'}
           icon="03"
+          href="/admin/oauth"
+          onNavigate={() => navigate('oauth')}
         />
-        <SummaryCounter label="Failed audits" value={failedAudits} tone={failedAudits > 0 ? 'bad' : 'good'} icon="04" />
+        <SummaryLink
+          label="Failed audits"
+          value={failedAudits}
+          tone={failedAudits > 0 ? 'bad' : 'good'}
+          icon="04"
+          href="/admin/audit"
+          onNavigate={() => navigate('audit')}
+        />
       </SimpleGrid>
-      <div className="workspace-grid">
-        <div className="inventory-column">
-          <div id="inventory" className="overview-section-target" ref={inventorySectionRef} tabIndex={-1}>
-            <ConfiguredServersPanel
-              state={state}
-              onServerAction={configuredServers.mutate}
-              onOpenServerDetail={configuredServers.edit.open}
-            />
-          </div>
-          <div id="audit" className="overview-section-target" ref={auditSectionRef} tabIndex={-1}>
-            <AuditPanel facts={state.status?.audit.facts ?? []} onCopyText={copyText} />
-          </div>
-        </div>
-        <div className="inspector-column">
-          <ConfiguredServerEditor model={configuredServers.edit} />
-          <RuntimePanel runtime={state.status?.runtime} onCopyText={copyText} />
-          <div id="oauth" className="overview-section-target" ref={oauthSectionRef} tabIndex={-1}>
-            <OAuthPanel services={state.status?.oauth.services ?? []} />
-          </div>
-        </div>
+      <div className="dashboard-runtime-panel">
+        <Panel title="Runtime identity" utility="current target" icon={<span className="runtime-live-dot" />}>
+          {runtime ? (
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+              <DetailRow label="Version" value={runtime.runtimeVersion} />
+              <DetailRow label="External URL" value={runtime.externalUrl ?? '-'} />
+              <DetailRow
+                label="Runtime scope"
+                value={runtime.runtimeScopeId}
+                copyLabel="runtimeScopeId"
+                onCopyText={copyText}
+              />
+            </SimpleGrid>
+          ) : (
+            <Text c="dimmed">Runtime status has not loaded.</Text>
+          )}
+        </Panel>
       </div>
-      {copyFeedback ? (
-        <Alert aria-live="polite" color={copyFeedback.startsWith('Could not') ? 'red' : 'teal'} mt="sm">
-          {copyFeedback}
-        </Alert>
-      ) : null}
+      <CopyFeedback message={copyFeedback} />
     </section>
   );
 }
 
-function SummaryCounter({
+export function ServersWorkspace({ model }: { model: OperatorWorkspaceModel }) {
+  const { state, configuredServers } = model;
+
+  return (
+    <section aria-labelledby="servers-workspace-title" className="operations-workspace">
+      <WorkspaceHeading
+        title="Configured servers"
+        titleId="servers-workspace-title"
+        description={`${state.configuredServers.length} configured targets · updated ${state.lastUpdatedAt ?? 'never'}`}
+        model={model}
+      />
+      <div className="workspace-grid">
+        <div className="inventory-column">
+          <ConfiguredServersPanel
+            state={state}
+            onServerAction={configuredServers.mutate}
+            onOpenServerDetail={configuredServers.edit.open}
+          />
+        </div>
+        <div className="inspector-column">
+          <ConfiguredServerEditor model={configuredServers.edit} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function AuditTrailWorkspace({ model }: { model: OperatorWorkspaceModel }) {
+  const { state, configuredServers } = model;
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+
+  async function copyText(label: string, value: string): Promise<void> {
+    try {
+      await configuredServers.copy(label, value);
+      setCopyFeedback(`${humanize(label)} copied.`);
+    } catch {
+      setCopyFeedback(`Could not copy ${humanize(label)}. Select the value manually.`);
+    }
+  }
+
+  return (
+    <section aria-labelledby="audit-workspace-title" className="operations-workspace">
+      <WorkspaceHeading
+        title="Audit trail"
+        titleId="audit-workspace-title"
+        description={`Recent redacted Admin Operations · updated ${state.lastUpdatedAt ?? 'never'}`}
+        model={model}
+      />
+      <AuditPanel facts={state.status?.audit.facts ?? []} onCopyText={copyText} />
+      <CopyFeedback message={copyFeedback} />
+    </section>
+  );
+}
+
+export function WorkspaceHeading({
+  title,
+  titleId,
+  description,
+  model,
+}: {
+  title: string;
+  titleId?: string;
+  description: string;
+  model: Pick<OperatorWorkspaceModel, 'refresh' | 'logout'>;
+}) {
+  return (
+    <Group justify="space-between" align="flex-start" className="workspace-heading">
+      <div>
+        <Text className="eyebrow" size="xs">
+          Operator workspace / live
+        </Text>
+        <Title id={titleId} order={2}>
+          {title}
+        </Title>
+        <Text c="dimmed" size="sm">
+          {description}
+        </Text>
+      </div>
+      <Group gap="xs">
+        <Button variant="default" leftSection={<RefreshCw size={16} />} onClick={() => void model.refresh()}>
+          Refresh
+        </Button>
+        <Button color="red" variant="light" leftSection={<LogOut size={16} />} onClick={() => void model.logout()}>
+          Log out
+        </Button>
+      </Group>
+    </Group>
+  );
+}
+
+function SummaryLink({
   label,
   value,
   tone,
   icon,
+  href,
+  onNavigate,
 }: {
   label: string;
   value: number;
   tone: 'good' | 'warn' | 'bad';
   icon: string;
+  href: string;
+  onNavigate(): void;
 }) {
   return (
-    <Paper className={`summary-counter summary-${tone}`} withBorder>
+    <Paper
+      component="a"
+      href={href}
+      className={`summary-counter summary-link summary-${tone}`}
+      withBorder
+      onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+        if (!isSamePageNavigation(event)) return;
+        event.preventDefault();
+        onNavigate();
+      }}
+    >
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <div>
           <Text size="xs" c="dimmed" fw={800} tt="uppercase">
@@ -139,8 +223,23 @@ function SummaryCounter({
           </Text>
           <Text className="summary-value">{value}</Text>
         </div>
-        <Text className="summary-index">{icon}</Text>
+        <Stack gap={4} align="flex-end">
+          <Text className="summary-index">{icon}</Text>
+          <ArrowRight size={15} aria-hidden="true" />
+        </Stack>
       </Group>
     </Paper>
   );
+}
+
+function CopyFeedback({ message }: { message: string | null }) {
+  return message ? (
+    <Alert aria-live="polite" color={message.startsWith('Could not') ? 'red' : 'teal'} mt="sm">
+      {message}
+    </Alert>
+  ) : null;
+}
+
+function isSamePageNavigation(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
 }

--- a/web/admin/src/controller.test.tsx
+++ b/web/admin/src/controller.test.tsx
@@ -350,6 +350,7 @@ describe('AdminConsoleRoot', () => {
     renderRoot(api, { windowRef: routeWindow });
 
     expect(await screen.findByRole('status')).toHaveTextContent('OAuth authorization completed.');
+    expect(routeWindow.history.replaceState).toHaveBeenCalledWith(null, '', '/admin/oauth');
     const authorizeButton = screen.getByRole('button', { name: /authorize context7:0123456789ab/i });
     await user.click(authorizeButton);
     expect(authorizeOAuthService).toHaveBeenCalledWith({
@@ -436,7 +437,26 @@ describe('AdminConsoleRoot', () => {
     await user.click(screen.getByRole('button', { name: /log in/i }));
 
     expect(await screen.findByRole('button', { name: /authorize github/i })).toBeEnabled();
-    authorization.resolve({ serviceId: 'github', redirectUrl: 'https://provider.example/authorize' });
+    await act(async () => {
+      authorization.resolve({ serviceId: 'github', redirectUrl: 'https://provider.example/authorize' });
+      await authorization.promise;
+    });
+    expect(routeWindow.location.assign).not.toHaveBeenCalled();
+  });
+
+  it('uses fallback feedback for OAuth callback keys inherited from Object.prototype', async () => {
+    const routeWindow = createRouteWindow('/admin/oauth');
+    routeWindow.location.search = '?error=constructor';
+    const api = apiClient({
+      getSession: vi.fn(async () => session),
+      getStatus: vi.fn(async () => status),
+      listConfiguredServers: vi.fn(async () => []),
+    });
+
+    renderRoot(api, { windowRef: routeWindow });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('OAuth authorization did not complete.');
+    expect(routeWindow.history.replaceState).toHaveBeenCalledWith(null, '', '/admin/oauth');
   });
 
   it('prevents reentrant preset save from queueing duplicate dialogs or mutations', async () => {

--- a/web/admin/src/controller.test.tsx
+++ b/web/admin/src/controller.test.tsx
@@ -51,9 +51,9 @@ describe('AdminConsoleRoot', () => {
       logout: vi.fn(async () => ({ ok: true })),
     });
 
-    renderRoot(api);
+    renderRoot(api, { windowRef: createRouteWindow('/admin/servers') });
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     await waitFor(() => expect(api.getStatus).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(api.listConfiguredServers).toHaveBeenCalledTimes(1));
     expect(await screen.findByText('filesystem')).toBeInTheDocument();
@@ -112,6 +112,7 @@ describe('AdminConsoleRoot', () => {
 
   it('loads console read models after a successful login from the login screen', async () => {
     const user = userEvent.setup();
+    const routeWindow = createRouteWindow('/admin/servers');
     const api = apiClient({
       getSession: vi.fn(async () => {
         throw new AdminApiError(401, { authenticated: false, adminStatus: 'loginRequired' }, 'Unauthorized');
@@ -129,14 +130,14 @@ describe('AdminConsoleRoot', () => {
       ]),
     });
 
-    renderRoot(api);
+    renderRoot(api, { windowRef: routeWindow });
 
     expect(await screen.findByRole('heading', { name: /operator login/i })).toBeInTheDocument();
     await user.type(screen.getByLabelText(/username/i), 'operator');
     await user.type(screen.getByLabelText(/password/i), 'correct horse battery staple');
     await user.click(screen.getByRole('button', { name: /log in/i }));
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     expect(screen.getByText('github')).toBeInTheDocument();
     expect(api.getStatus).toHaveBeenCalledTimes(1);
     expect(api.listConfiguredServers).toHaveBeenCalledTimes(1);
@@ -144,7 +145,7 @@ describe('AdminConsoleRoot', () => {
 
   it('opens a configured-server detail route and previews an environment secret replacement', async () => {
     const user = userEvent.setup();
-    const routeWindow = createRouteWindow('/admin');
+    const routeWindow = createRouteWindow('/admin/servers');
     const api = apiClient({
       getSession: vi.fn(async () => session),
       getStatus: vi.fn(async () => status),
@@ -189,7 +190,7 @@ describe('AdminConsoleRoot', () => {
 
     renderRoot(api, { windowRef: routeWindow });
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /edit github\/api server/i }));
 
     expect(routeWindow.history.pushState).toHaveBeenCalledWith(null, '', '/admin/servers/github%2Fapi');
@@ -260,7 +261,7 @@ describe('AdminConsoleRoot', () => {
   });
 
   it('follows browser back and forward navigation for configured-server detail routes', async () => {
-    const routeWindow = createRouteWindow('/admin');
+    const routeWindow = createRouteWindow('/admin/servers');
     const api = apiClient({
       getSession: vi.fn(async () => session),
       getStatus: vi.fn(async () => status),
@@ -270,7 +271,7 @@ describe('AdminConsoleRoot', () => {
 
     renderRoot(api, { windowRef: routeWindow });
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     expect(api.getConfiguredServerDetail).not.toHaveBeenCalled();
 
     routeWindow.location.pathname = '/admin/servers/github%2Fapi';
@@ -281,7 +282,7 @@ describe('AdminConsoleRoot', () => {
     expect(await screen.findByRole('heading', { name: /github\/api/i })).toBeInTheDocument();
     expect(api.getConfiguredServerDetail).toHaveBeenCalledWith('github/api');
 
-    routeWindow.location.pathname = '/admin';
+    routeWindow.location.pathname = '/admin/servers';
     await act(async () => {
       routeWindow.emitPopState();
     });
@@ -300,10 +301,142 @@ describe('AdminConsoleRoot', () => {
     renderRoot(api, { windowRef: routeWindow });
     expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
 
+    routeWindow.location.pathname = '/admin/servers';
+    await act(async () => routeWindow.emitPopState());
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
+
+    routeWindow.location.pathname = '/admin/oauth';
+    await act(async () => routeWindow.emitPopState());
+    expect(await screen.findByRole('heading', { name: /^oauth services$/i })).toBeInTheDocument();
+
+    routeWindow.location.pathname = '/admin/audit';
+    await act(async () => routeWindow.emitPopState());
+    expect(await screen.findByRole('heading', { name: /^audit trail$/i })).toBeInTheDocument();
+
     routeWindow.location.pathname = '/admin/about';
     await act(async () => routeWindow.emitPopState());
 
     expect(await screen.findByText('About metadata is unavailable.')).toBeInTheDocument();
+  });
+
+  it('starts OAuth authorization with the full service ID and redirects only after success', async () => {
+    const user = userEvent.setup();
+    const routeWindow = createRouteWindow('/admin/oauth');
+    routeWindow.location.search = '?success=1';
+    routeWindow.location.assign = vi.fn();
+    const authorization = deferred<{ serviceId: string; redirectUrl: string }>();
+    const authorizeOAuthService = vi.fn(() => authorization.promise);
+    const api = apiClient({
+      getSession: vi.fn(async () => session),
+      getStatus: vi.fn(async () => ({
+        ...status,
+        oauth: {
+          status: 'ready',
+          services: [
+            {
+              name: 'context7:0123456789abcdef',
+              id: 'context7:0123456789abcdef',
+              displayName: 'context7:0123456789ab',
+              status: 'awaiting_oauth',
+              requiresOAuth: true,
+            },
+          ],
+        },
+      })),
+      listConfiguredServers: vi.fn(async () => []),
+      authorizeOAuthService,
+    });
+
+    renderRoot(api, { windowRef: routeWindow });
+
+    expect(await screen.findByRole('status')).toHaveTextContent('OAuth authorization completed.');
+    const authorizeButton = screen.getByRole('button', { name: /authorize context7:0123456789ab/i });
+    await user.click(authorizeButton);
+    expect(authorizeOAuthService).toHaveBeenCalledWith({
+      serviceId: 'context7:0123456789abcdef',
+      csrfToken: 'csrf_123',
+    });
+    expect(authorizeButton).toBeDisabled();
+    expect(screen.getByText('Starting authorization...')).toBeInTheDocument();
+    expect(routeWindow.location.assign).not.toHaveBeenCalled();
+
+    authorization.resolve({
+      serviceId: 'context7:0123456789abcdef',
+      redirectUrl: 'https://provider.example/authorize',
+    });
+    await waitFor(() => expect(routeWindow.location.assign).toHaveBeenCalledWith('https://provider.example/authorize'));
+  });
+
+  it('keeps the OAuth workspace open and reports a failed authorization start', async () => {
+    const user = userEvent.setup();
+    const routeWindow = createRouteWindow('/admin/oauth');
+    routeWindow.location.assign = vi.fn();
+    const api = apiClient({
+      getSession: vi.fn(async () => session),
+      getStatus: vi.fn(async () => ({
+        ...status,
+        oauth: {
+          status: 'ready',
+          services: [
+            { name: 'github', id: 'github', displayName: 'github', status: 'awaiting_oauth', requiresOAuth: true },
+          ],
+        },
+      })),
+      listConfiguredServers: vi.fn(async () => []),
+      authorizeOAuthService: vi.fn(async () => {
+        throw new AdminApiError(
+          503,
+          { error: { code: 'backend_oauth_runtime_unavailable' } },
+          'backend_oauth_runtime_unavailable',
+        );
+      }),
+    });
+
+    renderRoot(api, { windowRef: routeWindow });
+    await user.click(await screen.findByRole('button', { name: /authorize github/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Backend OAuth operations are not available on this runtime.',
+    );
+    expect(routeWindow.location.assign).not.toHaveBeenCalled();
+    expect(routeWindow.location.pathname).toBe('/admin/oauth');
+  });
+
+  it('clears an in-flight OAuth busy state when the Admin Session changes', async () => {
+    const user = userEvent.setup();
+    const routeWindow = createRouteWindow('/admin/oauth');
+    routeWindow.location.assign = vi.fn();
+    const authorization = deferred<{ serviceId: string; redirectUrl: string }>();
+    const nextSession = { ...session, csrfToken: 'csrf_456' };
+    const oauthStatus = {
+      ...status,
+      oauth: {
+        status: 'ready',
+        services: [
+          { name: 'github', id: 'github', displayName: 'github', status: 'awaiting_oauth', requiresOAuth: true },
+        ],
+      },
+    };
+    const api = apiClient({
+      getSession: vi.fn(async () => session),
+      login: vi.fn(async () => nextSession),
+      logout: vi.fn(async () => ({ ok: true })),
+      getStatus: vi.fn(async () => oauthStatus),
+      listConfiguredServers: vi.fn(async () => []),
+      authorizeOAuthService: vi.fn(() => authorization.promise),
+    });
+
+    renderRoot(api, { windowRef: routeWindow });
+    await user.click(await screen.findByRole('button', { name: /authorize github/i }));
+    expect(screen.getByRole('button', { name: /authorize github/i })).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: /log out/i }));
+    await user.type(await screen.findByLabelText(/username/i), 'operator');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+
+    expect(await screen.findByRole('button', { name: /authorize github/i })).toBeEnabled();
+    authorization.resolve({ serviceId: 'github', redirectUrl: 'https://provider.example/authorize' });
   });
 
   it('prevents reentrant preset save from queueing duplicate dialogs or mutations', async () => {
@@ -386,7 +519,7 @@ describe('AdminConsoleRoot', () => {
 
   it('keeps the current detail route when the operator cancels dirty draft discard', async () => {
     const user = userEvent.setup();
-    const routeWindow = createRouteWindow('/admin');
+    const routeWindow = createRouteWindow('/admin/servers');
     const api = apiClient({
       getSession: vi.fn(async () => session),
       getStatus: vi.fn(async () => status),
@@ -396,7 +529,7 @@ describe('AdminConsoleRoot', () => {
 
     renderRoot(api, { windowRef: routeWindow });
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /edit github\/api server/i }));
     expect(await screen.findByRole('heading', { name: /github\/api/i })).toBeInTheDocument();
     await user.clear(screen.getByLabelText('URL'));
@@ -415,7 +548,7 @@ describe('AdminConsoleRoot', () => {
 
   it('keeps the current detail route when switching servers would discard dirty draft edits', async () => {
     const user = userEvent.setup();
-    const routeWindow = createRouteWindow('/admin');
+    const routeWindow = createRouteWindow('/admin/servers');
     const api = apiClient({
       getSession: vi.fn(async () => session),
       getStatus: vi.fn(async () => status),
@@ -428,7 +561,7 @@ describe('AdminConsoleRoot', () => {
 
     renderRoot(api, { windowRef: routeWindow });
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /edit github\/api server/i }));
     expect(await screen.findByRole('heading', { name: /github\/api/i })).toBeInTheDocument();
     await user.clear(screen.getByLabelText('URL'));
@@ -444,7 +577,7 @@ describe('AdminConsoleRoot', () => {
   });
 
   it('ignores stale configured-server detail responses after navigating to another target', async () => {
-    const routeWindow = createRouteWindow('/admin');
+    const routeWindow = createRouteWindow('/admin/servers');
     const githubDetail = deferred<ReturnType<typeof configuredServerDetail>>();
     const filesystemDetail = deferred<ReturnType<typeof configuredServerDetail>>();
     const api = apiClient({
@@ -464,7 +597,7 @@ describe('AdminConsoleRoot', () => {
 
     renderRoot(api, { windowRef: routeWindow });
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     routeWindow.location.pathname = '/admin/servers/github%2Fapi';
     await act(async () => {
       routeWindow.emitPopState();
@@ -488,7 +621,7 @@ describe('AdminConsoleRoot', () => {
 
   it('ignores stale configured-server preview responses after navigating to another target', async () => {
     const user = userEvent.setup();
-    const routeWindow = createRouteWindow('/admin');
+    const routeWindow = createRouteWindow('/admin/servers');
     const stalePreview = deferred<Awaited<ReturnType<AdminApiClient['previewConfiguredServerEdit']>>>();
     const api = apiClient({
       getSession: vi.fn(async () => session),
@@ -503,7 +636,7 @@ describe('AdminConsoleRoot', () => {
 
     renderRoot(api, { windowRef: routeWindow });
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /edit github\/api server/i }));
     expect(await screen.findByRole('heading', { name: /github\/api/i })).toBeInTheDocument();
     await user.click(screen.getByRole('radio', { name: /replace url\.query\.token/i }));
@@ -546,9 +679,9 @@ describe('AdminConsoleRoot', () => {
       }),
     });
 
-    renderRoot(api);
+    renderRoot(api, { windowRef: createRouteWindow('/admin/servers') });
 
-    expect(await screen.findByRole('heading', { name: /runtime operations/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /disable filesystem/i }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
@@ -626,6 +759,8 @@ function apiClient(overrides: Partial<AdminApiClient>): AdminApiClient {
     previewConfiguredServerEdit: vi.fn(),
     applyConfiguredServerEdit: vi.fn(),
     setConfiguredServerEnabled: vi.fn(),
+    authorizeOAuthService: vi.fn(),
+    restartOAuthService: vi.fn(),
     ...overrides,
   };
 }

--- a/web/admin/src/session/AdminConsoleSession.tsx
+++ b/web/admin/src/session/AdminConsoleSession.tsx
@@ -14,7 +14,12 @@ import { ConfirmationDialogProvider, useConfirmationDialog } from '../components
 import { useConfiguredServerEdit } from '../configuredServerEdit/useConfiguredServerEdit';
 import { type AdminConsoleAction, createInitialState, reduceAdminConsoleState } from '../state/adminConsoleState';
 import { pollingDelayForVisibility, shouldPollConsole } from '../state/polling';
-import type { AdminConsoleSessionModel } from './AdminConsoleSessionModel';
+import type {
+  AdminConsoleRoute,
+  AdminConsoleSessionModel,
+  OAuthAdminAction,
+  OAuthFeedback,
+} from './AdminConsoleSessionModel';
 
 function failureMessage(error: unknown): string {
   if (error instanceof AdminApiError) return error.failure.message;
@@ -30,7 +35,7 @@ interface AdminConsoleDocument {
 interface AdminConsoleWindow {
   setTimeout: Window['setTimeout'];
   clearTimeout: Window['clearTimeout'];
-  location?: Pick<Location, 'pathname' | 'hash'>;
+  location?: Pick<Location, 'pathname' | 'search' | 'assign'>;
   history?: Pick<History, 'pushState' | 'replaceState'>;
   addEventListener?: Window['addEventListener'];
   removeEventListener?: Window['removeEventListener'];
@@ -76,7 +81,11 @@ export function useAdminConsoleSession({
   const [state, setState] = useState(createInitialState);
   const [loginBusy, setLoginBusy] = useState(false);
   const [route, setRoute] = useState(() => adminRoute(windowRef.location?.pathname ?? '/admin'));
-  const [section, setSection] = useState(() => adminSection(windowRef.location?.hash ?? ''));
+  const [oauthBusy, setOAuthBusy] = useState<{ serviceId: string; action: OAuthAdminAction } | null>(null);
+  const [oauthCallbackFeedback] = useState<OAuthFeedback | null>(() =>
+    oauthCallbackOutcome(windowRef.location?.search ?? ''),
+  );
+  const [oauthOperationFeedback, setOAuthOperationFeedback] = useState<OAuthFeedback | null>(null);
   const [presets, setPresets] = useState<AdminPresetListItem[]>([]);
   const [presetTargets, setPresetTargets] = useState<AdminPresetTarget[]>([]);
   const [presetRevision, setPresetRevision] = useState('');
@@ -86,6 +95,8 @@ export function useAdminConsoleSession({
   const configuredServerAppliedRef = useRef<() => void | Promise<void>>();
   const presetSaveBusyRef = useRef(false);
   const presetDeleteBusyRef = useRef(false);
+  const oauthOperationBusyRef = useRef(false);
+  const oauthOperationRequestRef = useRef(0);
   const formatNow = useCallback(() => nowLabel?.() ?? new Date().toLocaleTimeString(), [nowLabel]);
 
   const dispatch = useCallback((action: AdminConsoleAction) => {
@@ -105,12 +116,20 @@ export function useAdminConsoleSession({
     }
   }, [windowRef]);
 
+  const resetOAuthOperation = useCallback(() => {
+    oauthOperationRequestRef.current += 1;
+    oauthOperationBusyRef.current = false;
+    setOAuthBusy(null);
+    setOAuthOperationFeedback(null);
+  }, []);
+
   const invalidateAdminSession = useCallback(
     (adminStatus: 'setupRequired' | 'loginRequired') => {
       clearPoll();
+      resetOAuthOperation();
       dispatch({ type: 'sessionUnauthenticated', adminStatus });
     },
-    [clearPoll, dispatch],
+    [clearPoll, dispatch, resetOAuthOperation],
   );
 
   const handleUnauthenticated = useCallback(
@@ -125,7 +144,7 @@ export function useAdminConsoleSession({
 
   const configuredServerEditBrowser = useMemo(
     () => ({
-      pathname: () => `${windowRef.location?.pathname ?? '/admin'}${windowRef.location?.hash ?? ''}`,
+      pathname: () => windowRef.location?.pathname ?? '/admin',
       push: (pathname: string) => windowRef.history?.pushState(null, '', pathname),
       replace: (pathname: string) => windowRef.history?.replaceState(null, '', pathname),
       confirm,
@@ -138,10 +157,7 @@ export function useAdminConsoleSession({
   );
 
   const commitBrowserPath = useCallback((path: string) => {
-    const [pathname, hash = ''] = path.split('#');
-    const nextRoute = adminRoute(pathname);
-    setRoute(nextRoute);
-    setSection(nextRoute === 'overview' ? adminSection(hash) : null);
+    setRoute(adminRoute(path));
   }, []);
 
   const configuredServerEdit = useConfiguredServerEdit({
@@ -258,12 +274,10 @@ export function useAdminConsoleSession({
   );
 
   const navigate = useCallback(
-    async (nextRoute: 'overview' | 'presets' | 'about', nextSection: 'inventory' | 'oauth' | 'audit' | null = null) => {
-      const hash = nextRoute === 'overview' && nextSection ? `#${nextSection}` : '';
-      const pathname = `${nextRoute === 'overview' ? '/admin' : `/admin/${nextRoute}`}${hash}`;
+    async (nextRoute: AdminConsoleRoute) => {
+      const pathname = adminRoutePath(nextRoute);
       if (!(await configuredServerEdit.close(pathname))) return;
       setRoute(nextRoute);
-      setSection(nextRoute === 'overview' ? nextSection : null);
     },
     [configuredServerEdit],
   );
@@ -382,6 +396,43 @@ export function useAdminConsoleSession({
     [api, dispatch, handleUnauthenticated, isCurrentSession, refreshConsole],
   );
 
+  const operateOAuth = useCallback(
+    async (serviceId: string, action: OAuthAdminAction) => {
+      if (oauthOperationBusyRef.current) return;
+      const activeSession = stateRef.current.session;
+      if (!activeSession) return;
+      oauthOperationBusyRef.current = true;
+      const requestId = oauthOperationRequestRef.current + 1;
+      oauthOperationRequestRef.current = requestId;
+      const sessionKey = activeSession.csrfToken;
+      setOAuthBusy({ serviceId, action });
+      setOAuthOperationFeedback(null);
+      try {
+        const result =
+          action === 'authorize'
+            ? await api.authorizeOAuthService({ serviceId, csrfToken: sessionKey })
+            : await api.restartOAuthService({ serviceId, csrfToken: sessionKey });
+        if (!isCurrentSession(sessionKey)) return;
+        setOAuthOperationFeedback({
+          kind: 'success',
+          message: `${action === 'authorize' ? 'Authorization' : 'Authorization restart'} started. Opening the provider.`,
+        });
+        windowRef.location?.assign(result.redirectUrl);
+      } catch (error) {
+        if (!isCurrentSession(sessionKey)) return;
+        if (!handleUnauthenticated(error)) {
+          setOAuthOperationFeedback({ kind: 'error', message: failureMessage(error) });
+        }
+      } finally {
+        if (oauthOperationRequestRef.current === requestId) {
+          oauthOperationBusyRef.current = false;
+          if (isCurrentSession(sessionKey)) setOAuthBusy(null);
+        }
+      }
+    },
+    [api, handleUnauthenticated, isCurrentSession, windowRef],
+  );
+
   const logout = useCallback(async () => {
     const csrfToken = stateRef.current.session?.csrfToken;
     try {
@@ -390,9 +441,10 @@ export function useAdminConsoleSession({
       }
     } finally {
       clearPoll();
+      resetOAuthOperation();
       dispatch({ type: 'logoutSucceeded' });
     }
-  }, [api, clearPoll, dispatch]);
+  }, [api, clearPoll, dispatch, resetOAuthOperation]);
 
   const copyText = useCallback(async (_label: string, value: string) => {
     if (!navigator.clipboard?.writeText) {
@@ -418,11 +470,17 @@ export function useAdminConsoleSession({
     login,
     logout,
     refresh: () => refreshConsole('Manual refresh failed: '),
-    navigation: { route, section, navigate },
+    navigation: { route, navigate },
     configuredServers: {
       edit: configuredServerEdit,
       mutate: mutateServer,
       copy: copyText,
+    },
+    oauth: {
+      busy: oauthBusy,
+      callbackFeedback: oauthCallbackFeedback,
+      operationFeedback: oauthOperationFeedback,
+      operate: operateOAuth,
     },
     presets: {
       items: presets,
@@ -437,19 +495,38 @@ export function useAdminConsoleSession({
   };
 }
 
-function adminSection(hash: string): 'inventory' | 'oauth' | 'audit' | null {
-  const section = hash.replace(/^#/, '');
-  return section === 'inventory' || section === 'oauth' || section === 'audit' ? section : null;
-}
-
 function presetActionLabel(action: 'create' | 'update' | 'duplicate'): string {
   if (action === 'create') return 'Create';
   if (action === 'duplicate') return 'Duplicate';
   return 'Update';
 }
 
-function adminRoute(pathname: string): 'overview' | 'presets' | 'about' {
+function adminRoute(pathname: string): AdminConsoleRoute {
+  if (pathname === '/admin/servers' || pathname.startsWith('/admin/servers/')) return 'servers';
+  if (pathname === '/admin/oauth' || pathname.startsWith('/admin/oauth/')) return 'oauth';
+  if (pathname === '/admin/audit' || pathname.startsWith('/admin/audit/')) return 'audit';
   if (pathname.startsWith('/admin/presets')) return 'presets';
   if (pathname.startsWith('/admin/about')) return 'about';
-  return 'overview';
+  return 'dashboard';
+}
+
+function adminRoutePath(route: AdminConsoleRoute): string {
+  return route === 'dashboard' ? '/admin' : `/admin/${route}`;
+}
+
+function oauthCallbackOutcome(search: string): OAuthFeedback | null {
+  const query = new URLSearchParams(search);
+  if (query.get('success') === '1') {
+    return { kind: 'success', message: 'OAuth authorization completed.' };
+  }
+  const error = query.get('error');
+  if (!error) return null;
+  const message =
+    {
+      access_denied: 'OAuth authorization was denied.',
+      missing_code: 'The OAuth provider callback did not include an authorization code.',
+      callback_failed: 'The runtime could not complete the OAuth provider callback.',
+      runtime_unavailable: 'The OAuth runtime became unavailable during the callback.',
+    }[error] ?? 'OAuth authorization did not complete.';
+  return { kind: 'error', message };
 }

--- a/web/admin/src/session/AdminConsoleSession.tsx
+++ b/web/admin/src/session/AdminConsoleSession.tsx
@@ -21,6 +21,13 @@ import type {
   OAuthFeedback,
 } from './AdminConsoleSessionModel';
 
+const OAUTH_CALLBACK_MESSAGES: Readonly<Record<string, string>> = {
+  access_denied: 'OAuth authorization was denied.',
+  missing_code: 'The OAuth provider callback did not include an authorization code.',
+  callback_failed: 'The runtime could not complete the OAuth provider callback.',
+  runtime_unavailable: 'The OAuth runtime became unavailable during the callback.',
+};
+
 function failureMessage(error: unknown): string {
   if (error instanceof AdminApiError) return error.failure.message;
   throw error;
@@ -82,9 +89,11 @@ export function useAdminConsoleSession({
   const [loginBusy, setLoginBusy] = useState(false);
   const [route, setRoute] = useState(() => adminRoute(windowRef.location?.pathname ?? '/admin'));
   const [oauthBusy, setOAuthBusy] = useState<{ serviceId: string; action: OAuthAdminAction } | null>(null);
-  const [oauthCallbackFeedback] = useState<OAuthFeedback | null>(() =>
-    oauthCallbackOutcome(windowRef.location?.search ?? ''),
-  );
+  const [oauthCallbackFeedback] = useState<OAuthFeedback | null>(() => {
+    const feedback = oauthCallbackOutcome(windowRef.location?.search ?? '');
+    if (feedback) windowRef.history?.replaceState(null, '', '/admin/oauth');
+    return feedback;
+  });
   const [oauthOperationFeedback, setOAuthOperationFeedback] = useState<OAuthFeedback | null>(null);
   const [presets, setPresets] = useState<AdminPresetListItem[]>([]);
   const [presetTargets, setPresetTargets] = useState<AdminPresetTarget[]>([]);
@@ -521,12 +530,8 @@ function oauthCallbackOutcome(search: string): OAuthFeedback | null {
   }
   const error = query.get('error');
   if (!error) return null;
-  const message =
-    {
-      access_denied: 'OAuth authorization was denied.',
-      missing_code: 'The OAuth provider callback did not include an authorization code.',
-      callback_failed: 'The runtime could not complete the OAuth provider callback.',
-      runtime_unavailable: 'The OAuth runtime became unavailable during the callback.',
-    }[error] ?? 'OAuth authorization did not complete.';
+  const message = Object.hasOwn(OAUTH_CALLBACK_MESSAGES, error)
+    ? OAUTH_CALLBACK_MESSAGES[error]
+    : 'OAuth authorization did not complete.';
   return { kind: 'error', message };
 }

--- a/web/admin/src/session/AdminConsoleSessionModel.ts
+++ b/web/admin/src/session/AdminConsoleSessionModel.ts
@@ -2,6 +2,13 @@ import type { AdminPresetDraft, AdminPresetListItem, AdminPresetPreview, AdminPr
 import type { ConfiguredServerEditModel } from '../configuredServerEdit/useConfiguredServerEdit';
 import type { AdminConsoleState } from '../state/adminConsoleState';
 
+export type AdminConsoleRoute = 'dashboard' | 'servers' | 'oauth' | 'audit' | 'presets' | 'about';
+export type OAuthAdminAction = 'authorize' | 'restart';
+export interface OAuthFeedback {
+  kind: 'success' | 'error';
+  message: string;
+}
+
 export interface AdminConsoleSessionModel {
   state: AdminConsoleState;
   loginBusy: boolean;
@@ -9,17 +16,19 @@ export interface AdminConsoleSessionModel {
   logout(): void | Promise<void>;
   refresh(): void | Promise<void>;
   navigation: {
-    route: 'overview' | 'presets' | 'about';
-    section: 'inventory' | 'oauth' | 'audit' | null;
-    navigate(
-      route: 'overview' | 'presets' | 'about',
-      section?: 'inventory' | 'oauth' | 'audit' | null,
-    ): void | Promise<void>;
+    route: AdminConsoleRoute;
+    navigate(route: AdminConsoleRoute): void | Promise<void>;
   };
   configuredServers: {
     edit: ConfiguredServerEditModel;
     mutate(serverId: string, action: 'enable' | 'disable'): void | Promise<void>;
     copy(label: string, value: string): void | Promise<void>;
+  };
+  oauth: {
+    busy: { serviceId: string; action: OAuthAdminAction } | null;
+    callbackFeedback: OAuthFeedback | null;
+    operationFeedback: OAuthFeedback | null;
+    operate(serviceId: string, action: OAuthAdminAction): void | Promise<void>;
   };
   presets: {
     items: AdminPresetListItem[];
@@ -37,7 +46,7 @@ export interface AdminConsoleSessionModel {
   };
 }
 
-export type RuntimeOperationsModel = Pick<AdminConsoleSessionModel, 'state' | 'logout' | 'refresh'> & {
+export type OperatorWorkspaceModel = Pick<AdminConsoleSessionModel, 'state' | 'logout' | 'refresh'> & {
   configuredServers: AdminConsoleSessionModel['configuredServers'];
 };
 

--- a/web/admin/src/styles.css
+++ b/web/admin/src/styles.css
@@ -146,6 +146,7 @@ input {
   background: transparent;
   color: #aeb8b4;
   cursor: pointer;
+  text-decoration: none;
   text-align: left;
 }
 
@@ -252,6 +253,64 @@ input {
 .operations-panel {
   padding: 16px;
   box-shadow: 0 1px 0 rgba(23, 32, 29, 0.03);
+}
+
+.dashboard-runtime-panel {
+  margin-top: 16px;
+}
+
+.summary-link {
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease;
+}
+
+.summary-link:hover {
+  border-color: var(--admin-teal);
+  transform: translateY(-1px);
+}
+
+.summary-link:focus-visible {
+  outline: 2px solid var(--admin-teal);
+  outline-offset: 3px;
+}
+
+.oauth-service-row {
+  min-width: 0;
+  padding: 16px;
+  border-color: var(--admin-line);
+  border-radius: 8px;
+  background: var(--admin-panel);
+}
+
+.oauth-service-main {
+  min-width: 0;
+}
+
+.oauth-service-identity {
+  margin-top: 10px;
+  color: var(--admin-muted);
+  font-size: 12px;
+}
+
+.oauth-service-identity summary {
+  width: fit-content;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.oauth-service-id {
+  display: block;
+  max-width: min(520px, 60vw);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.oauth-service-action {
+  flex: none;
 }
 
 .login-panel {


### PR DESCRIPTION
## Description

Add first-class, route-backed Admin Console workspaces and OAuth operations. The Admin SPA now uses stable /admin routes for dashboard, server inventory, OAuth services, audit trail, presets, and about views. Backend OAuth authorize and restart actions flow through authenticated, CSRF-protected, idempotent Admin Operations endpoints, with sanitized service identities and callback redirects returning operators to /admin/oauth.

The change also splits the runtime workspace into focused views and extends domain, route, UI, session, and browser smoke coverage.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tests pass locally
- [x] Added tests for new functionality
- [x] Manual testing completed through the built Admin SPA browser smoke suite

## Checklist

- [x] Code follows the style guidelines
- [x] Self-review completed
- [x] Documentation not required; behavior is covered by API and browser tests
- [x] No console.log statements left

## Verification

- pnpm lint
- pnpm typecheck
- pnpm build
- CI=true pnpm test:unit (290 files, 4260 tests)
- pnpm test:admin (9 files, 93 tests)
- pnpm test:e2e test/e2e/admin-spa-browser-smoke.e2e.test.ts (5 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “OAuth services” workspace with service status, full-ID copy, and authorize/restart actions.
  * Exposed rate-limited admin endpoints and matching admin API client methods to authorize/restart backend OAuth flows.
  * Refreshed admin console navigation and workspace routing (Dashboard, Server inventory, OAuth services, Audit trail, Presets, About).
* **Bug Fixes**
  * OAuth callback redirects and admin OAuth flows now consistently return to the admin OAuth workspace with stable, non-sensitive error codes.
* **UI Improvements**
  * Updated OAuth service display (compact labels) and added an audit facts panel, with improved responsive dashboard layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->