### PR TITLE
fix(client): reconnect backends automatically after they lose their session

### DIFF
--- a/src/core/client/clientManager.test.ts
+++ b/src/core/client/clientManager.test.ts
@@ -1,4 +1,5 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
@@ -385,7 +386,7 @@ describe('ClientManager (Integration)', () => {
         _url: new URL('https://example.com/sse'),
         close: vi.fn().mockResolvedValue(undefined),
       } as unknown as AuthProviderTransport;
-      Object.setPrototypeOf(originalTransport, StreamableHTTPClientTransport.prototype);
+      Object.setPrototypeOf(originalTransport, SSEClientTransport.prototype);
 
       (mockClient.connect as unknown as MockInstance).mockResolvedValue(undefined);
       (mockClient.getServerVersion as unknown as MockInstance).mockResolvedValue({
@@ -393,6 +394,7 @@ describe('ClientManager (Integration)', () => {
         version: '1.0.0',
       });
 
+      // Not mocked — exercises the real SSEClientTransport recreation path.
       const recreateForSessionLoss = vi.spyOn((clientManager as any).transportRecreator, 'recreateForSessionLoss');
 
       await clientManager.createSingleClient('sse-session-loss-client', originalTransport);
@@ -400,8 +402,13 @@ describe('ClientManager (Integration)', () => {
       registeredClient.onerror?.(new Error("Error POSTing to endpoint (HTTP 404): Could not find session ID 'abc'"));
 
       await vi.waitFor(() => {
-        expect(recreateForSessionLoss).toHaveBeenCalledWith(originalTransport, 'sse-session-loss-client');
+        expect(clientManager.getClient('sse-session-loss-client').status).toBe(ClientStatus.Connected);
       });
+
+      expect(recreateForSessionLoss).toHaveBeenCalledWith(originalTransport, 'sse-session-loss-client');
+      const recreatedTransport = clientManager.getTransport('sse-session-loss-client');
+      expect(recreatedTransport).not.toBe(originalTransport);
+      expect(recreatedTransport).toBeInstanceOf(SSEClientTransport);
     });
 
     it('ignores unrelated client errors', async () => {
@@ -428,6 +435,35 @@ describe('ClientManager (Integration)', () => {
       await Promise.resolve();
       expect(recreateForSessionLoss).not.toHaveBeenCalled();
       expect(clientManager.getTransport('unrelated-error-client')).toBe(originalTransport);
+    });
+
+    it('does not let a recreation failure escape onerror for a non-HTTP/SSE transport', async () => {
+      vi.useRealTimers();
+
+      // A stdio-style transport: TransportRecreator only supports HTTP/SSE, so
+      // recreateForSessionLoss throws for this one — that throw must be caught,
+      // not propagated out of the onerror callback.
+      const stdioTransport = {
+        name: 'stdio',
+        start: vi.fn(),
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as AuthProviderTransport;
+
+      (mockClient.connect as unknown as MockInstance).mockResolvedValue(undefined);
+      (mockClient.getServerVersion as unknown as MockInstance).mockResolvedValue({
+        name: 'test-server',
+        version: '1.0.0',
+      });
+
+      await clientManager.createSingleClient('stdio-client', stdioTransport);
+      const registeredClient = clientManager.getClient('stdio-client').client;
+
+      expect(() => registeredClient.onerror?.(new Error('Session not found'))).not.toThrow();
+
+      await Promise.resolve();
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Cannot recover stdio-client'));
+      expect(clientManager.getTransport('stdio-client')).toBe(stdioTransport);
     });
   });
 

--- a/src/core/client/clientManager.test.ts
+++ b/src/core/client/clientManager.test.ts
@@ -465,6 +465,110 @@ describe('ClientManager (Integration)', () => {
       expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Cannot recover stdio-client'));
       expect(clientManager.getTransport('stdio-client')).toBe(stdioTransport);
     });
+
+    it('deduplicates recovery when the same dead client reports session loss more than once', async () => {
+      vi.useRealTimers();
+
+      const originalTransport = {
+        _url: new URL('https://example.com/mcp'),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AuthProviderTransport;
+      Object.setPrototypeOf(originalTransport, StreamableHTTPClientTransport.prototype);
+
+      const freshTransport = {
+        _url: new URL('https://example.com/mcp'),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AuthProviderTransport;
+      Object.setPrototypeOf(freshTransport, StreamableHTTPClientTransport.prototype);
+
+      (mockClient.connect as unknown as MockInstance).mockResolvedValue(undefined);
+      (mockClient.getServerVersion as unknown as MockInstance).mockResolvedValue({
+        name: 'test-server',
+        version: '1.0.0',
+      });
+
+      const recreateForSessionLoss = vi
+        .spyOn((clientManager as any).transportRecreator, 'recreateForSessionLoss')
+        .mockReturnValue(freshTransport);
+
+      await clientManager.createSingleClient('dup-session-loss-client', originalTransport);
+      const registeredClient = clientManager.getClient('dup-session-loss-client').client;
+
+      // Hold the recovery connection attempt open so a second onerror firing
+      // for the same dead client lands while the first recovery is in flight.
+      let resolveRecoveryConnect: () => void = () => {};
+      (mockClient.connect as unknown as MockInstance).mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveRecoveryConnect = resolve;
+        }),
+      );
+
+      registeredClient.onerror?.(new Error('Session not found'));
+      registeredClient.onerror?.(new Error('Session not found'));
+
+      resolveRecoveryConnect();
+
+      await vi.waitFor(() => {
+        expect(clientManager.getClient('dup-session-loss-client').status).toBe(ClientStatus.Connected);
+      });
+
+      expect(recreateForSessionLoss).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes the superseded client and transport once session-loss recovery settles', async () => {
+      vi.useRealTimers();
+
+      const originalTransport = {
+        _url: new URL('https://example.com/mcp'),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AuthProviderTransport;
+      Object.setPrototypeOf(originalTransport, StreamableHTTPClientTransport.prototype);
+
+      const freshTransport = {
+        _url: new URL('https://example.com/mcp'),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AuthProviderTransport;
+      Object.setPrototypeOf(freshTransport, StreamableHTTPClientTransport.prototype);
+
+      const erroredClient: Partial<Client> = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        getServerVersion: vi.fn().mockResolvedValue({ name: 'test-server', version: '1.0.0' }),
+        close: vi.fn().mockResolvedValue(undefined),
+        getInstructions: vi.fn().mockReturnValue('test instructions'),
+      };
+      const recoveredClient: Partial<Client> = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        getServerVersion: vi.fn().mockResolvedValue({ name: 'test-server', version: '1.0.0' }),
+        close: vi.fn().mockResolvedValue(undefined),
+        getInstructions: vi.fn().mockReturnValue('test instructions'),
+      };
+      (Client as unknown as MockInstance)
+        .mockImplementationOnce(function () {
+          return erroredClient;
+        })
+        .mockImplementationOnce(function () {
+          return recoveredClient;
+        });
+
+      vi.spyOn((clientManager as any).transportRecreator, 'recreateForSessionLoss').mockReturnValue(freshTransport);
+
+      await clientManager.createSingleClient('cleanup-client', originalTransport);
+      expect(clientManager.getClient('cleanup-client').client).toBe(erroredClient);
+
+      const registeredClient = clientManager.getClient('cleanup-client').client;
+      registeredClient.onerror?.(new Error('Session not found'));
+
+      await vi.waitFor(() => {
+        expect(clientManager.getClient('cleanup-client').client).toBe(recoveredClient);
+      });
+
+      await vi.waitFor(() => {
+        expect(erroredClient.close).toHaveBeenCalled();
+      });
+
+      expect(originalTransport.close).not.toHaveBeenCalled();
+      expect(recoveredClient.close).not.toHaveBeenCalled();
+    });
   });
 
   describe('getClient and getClients', () => {

--- a/src/core/client/clientManager.test.ts
+++ b/src/core/client/clientManager.test.ts
@@ -332,6 +332,105 @@ describe('ClientManager (Integration)', () => {
     });
   });
 
+  describe('session loss recovery', () => {
+    it('reconnects with a fresh (session-less) transport when the backend reports a lost session', async () => {
+      vi.useRealTimers();
+
+      const originalTransport = {
+        _url: new URL('https://example.com/mcp'),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AuthProviderTransport;
+      Object.setPrototypeOf(originalTransport, StreamableHTTPClientTransport.prototype);
+
+      const freshTransport = {
+        _url: new URL('https://example.com/mcp'),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AuthProviderTransport;
+      Object.setPrototypeOf(freshTransport, StreamableHTTPClientTransport.prototype);
+
+      (mockClient.connect as unknown as MockInstance).mockResolvedValue(undefined);
+      (mockClient.getServerVersion as unknown as MockInstance).mockResolvedValue({
+        name: 'test-server',
+        version: '1.0.0',
+      });
+
+      const recreateForSessionLoss = vi
+        .spyOn((clientManager as any).transportRecreator, 'recreateForSessionLoss')
+        .mockReturnValue(freshTransport);
+
+      await clientManager.createSingleClient('session-loss-client', originalTransport);
+      expect(clientManager.getTransport('session-loss-client')).toBe(originalTransport);
+
+      const registeredClient = clientManager.getClient('session-loss-client').client;
+      registeredClient.onerror?.(
+        new Error(
+          'Streamable HTTP error: Error POSTing to endpoint: ' +
+            '{"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}',
+        ),
+      );
+
+      // onerror kicks off recovery fire-and-forget — wait for it to settle
+      await vi.waitFor(() => {
+        expect(clientManager.getTransport('session-loss-client')).toBe(freshTransport);
+      });
+
+      expect(recreateForSessionLoss).toHaveBeenCalledWith(originalTransport, 'session-loss-client');
+      expect(clientManager.getClient('session-loss-client').status).toBe(ClientStatus.Connected);
+    });
+
+    it('also recovers the "Could not find session ID" wording used by SSE-transport backends', async () => {
+      vi.useRealTimers();
+
+      const originalTransport = {
+        _url: new URL('https://example.com/sse'),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AuthProviderTransport;
+      Object.setPrototypeOf(originalTransport, StreamableHTTPClientTransport.prototype);
+
+      (mockClient.connect as unknown as MockInstance).mockResolvedValue(undefined);
+      (mockClient.getServerVersion as unknown as MockInstance).mockResolvedValue({
+        name: 'test-server',
+        version: '1.0.0',
+      });
+
+      const recreateForSessionLoss = vi.spyOn((clientManager as any).transportRecreator, 'recreateForSessionLoss');
+
+      await clientManager.createSingleClient('sse-session-loss-client', originalTransport);
+      const registeredClient = clientManager.getClient('sse-session-loss-client').client;
+      registeredClient.onerror?.(new Error("Error POSTing to endpoint (HTTP 404): Could not find session ID 'abc'"));
+
+      await vi.waitFor(() => {
+        expect(recreateForSessionLoss).toHaveBeenCalledWith(originalTransport, 'sse-session-loss-client');
+      });
+    });
+
+    it('ignores unrelated client errors', async () => {
+      vi.useRealTimers();
+
+      const originalTransport = {
+        _url: new URL('https://example.com/mcp'),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AuthProviderTransport;
+      Object.setPrototypeOf(originalTransport, StreamableHTTPClientTransport.prototype);
+
+      (mockClient.connect as unknown as MockInstance).mockResolvedValue(undefined);
+      (mockClient.getServerVersion as unknown as MockInstance).mockResolvedValue({
+        name: 'test-server',
+        version: '1.0.0',
+      });
+
+      const recreateForSessionLoss = vi.spyOn((clientManager as any).transportRecreator, 'recreateForSessionLoss');
+
+      await clientManager.createSingleClient('unrelated-error-client', originalTransport);
+      const registeredClient = clientManager.getClient('unrelated-error-client').client;
+      registeredClient.onerror?.(new Error('ECONNRESET'));
+
+      await Promise.resolve();
+      expect(recreateForSessionLoss).not.toHaveBeenCalled();
+      expect(clientManager.getTransport('unrelated-error-client')).toBe(originalTransport);
+    });
+  });
+
   describe('getClient and getClients', () => {
     beforeEach(async () => {
       (mockClient.connect as unknown as MockInstance).mockResolvedValue(undefined);

--- a/src/core/client/clientManager.ts
+++ b/src/core/client/clientManager.ts
@@ -37,8 +37,11 @@ export const enum ClientManagerEvent {
 // when a Streamable HTTP / SSE session ID they issued no longer exists on
 // their side (e.g. the backend process restarted and its in-memory session
 // store was wiped): the MCP spec's own "Session not found" wording, and the
-// free-form "Could not find session ID '...'" text some server SDKs use.
-const SESSION_LOST_PATTERN = /session (?:id )?not found|could not find session/i;
+// free-form "Could not find session ID '...'" text some server SDKs use. The
+// second alternative spells out "session id" (rather than a bare "session")
+// so we don't also match unrelated "could not find session <noun>" wording
+// that isn't the specific session-loss shape this recovery path handles.
+const SESSION_LOST_PATTERN = /session (?:id )?not found|could not find session id/i;
 
 function isSessionLostError(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -55,6 +58,11 @@ export class ClientManager extends EventEmitter {
   private transports: Record<string, AuthProviderTransport> = {};
   private connectionSemaphore: Map<string, Promise<void>> = new Map();
   private bulkConnectionOperations = new Set<Promise<unknown>>();
+  // Backends currently running a session-loss recovery (see recoverFromSessionLoss).
+  // Guards against the same dead client's onerror firing more than once — e.g.
+  // several in-flight requests all failing around the same time — from each
+  // kicking off its own redundant recreateForSessionLoss + createSingleClient.
+  private sessionLossRecoveries = new Set<string>();
   private instructionAggregator?: InstructionAggregator;
   private clientFactory: ClientFactory;
   private connectionHandler: ConnectionHandler;
@@ -200,6 +208,15 @@ export class ClientManager extends EventEmitter {
       return;
     }
 
+    // A recovery for this exact dead client is already in flight — e.g. several
+    // requests in flight against the same lost session can each independently
+    // fire onerror around the same time. Let the one already running finish
+    // rather than building a second, redundant replacement transport.
+    if (this.sessionLossRecoveries.has(name)) {
+      return;
+    }
+    this.sessionLossRecoveries.add(name);
+
     logger.warn(`Session for ${name} was lost (backend likely restarted) — reconnecting with a fresh session`);
 
     const staleTransport = this.transports[name] ?? clientInfo.transport;
@@ -212,14 +229,24 @@ export class ClientManager extends EventEmitter {
       logger.error(
         `Cannot recover ${name} from session loss: ${error instanceof Error ? error.message : String(error)}`,
       );
+      this.sessionLossRecoveries.delete(name);
       return;
     }
 
-    void this.createSingleClient(name, freshTransport).catch((error) => {
-      logger.error(
-        `Failed to recover ${name} after session loss: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
+    void this.createSingleClient(name, freshTransport)
+      .catch((error) => {
+        logger.error(
+          `Failed to recover ${name} after session loss: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      })
+      .finally(() => {
+        this.sessionLossRecoveries.delete(name);
+        // Whether recovery succeeded or failed, this dead client/transport is no
+        // longer on record for `name` (createSingleClient always replaces it,
+        // even with an error-status placeholder) — close it so its underlying
+        // connection and any pending SSE reconnection timers don't linger.
+        void this.disposeConnectedClient({ client: erroredClient, transport: staleTransport });
+      });
   }
 
   /**

--- a/src/core/client/clientManager.ts
+++ b/src/core/client/clientManager.ts
@@ -33,6 +33,20 @@ export const enum ClientManagerEvent {
   BackendSupervisionStateChanged = 'backend-supervision-state-changed',
 }
 
+// Matches the two message shapes downstream servers are observed to send back
+// when a Streamable HTTP / SSE session ID they issued no longer exists on
+// their side (e.g. the backend process restarted and its in-memory session
+// store was wiped): the MCP spec's own "Session not found" wording, and the
+// free-form "Could not find session ID '...'" text some server SDKs use.
+const SESSION_LOST_PATTERN = /session (?:id )?not found|could not find session/i;
+
+function isSessionLostError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return SESSION_LOST_PATTERN.test(error.message);
+}
+
 type StdioSupervisionMetadata = NonNullable<AuthProviderTransport['stdioSupervision']>;
 
 export class ClientManager extends EventEmitter {
@@ -159,7 +173,43 @@ export class ClientManager extends EventEmitter {
 
     client.onerror = (error) => {
       logger.error(`Client ${name} error: ${error}`);
+
+      if (isSessionLostError(error)) {
+        this.recoverFromSessionLoss(name, client);
+      }
     };
+  }
+
+  /**
+   * Reconnects a backend whose Streamable HTTP / SSE session was invalidated
+   * server-side (typically because the backend process restarted and lost its
+   * in-memory session store). Without this, the client keeps reusing the dead
+   * session ID on every subsequent request and the backend never recovers
+   * until the whole 1MCP process is restarted.
+   */
+  private recoverFromSessionLoss(name: string, erroredClient: Client): void {
+    if (this.isShuttingDown) {
+      return;
+    }
+
+    // The client that errored may already have been superseded by a newer
+    // connection attempt (e.g. a concurrent recovery, or the server coming
+    // back mid-retry) — only recover if it's still the one on record.
+    const clientInfo = this.outboundConns.get(name);
+    if (!clientInfo || clientInfo.client !== erroredClient) {
+      return;
+    }
+
+    logger.warn(`Session for ${name} was lost (backend likely restarted) — reconnecting with a fresh session`);
+
+    const staleTransport = this.transports[name] ?? clientInfo.transport;
+    const freshTransport = this.transportRecreator.recreateForSessionLoss(staleTransport, name);
+
+    void this.createSingleClient(name, freshTransport).catch((error) => {
+      logger.error(
+        `Failed to recover ${name} after session loss: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
   }
 
   /**

--- a/src/core/client/clientManager.ts
+++ b/src/core/client/clientManager.ts
@@ -203,7 +203,17 @@ export class ClientManager extends EventEmitter {
     logger.warn(`Session for ${name} was lost (backend likely restarted) — reconnecting with a fresh session`);
 
     const staleTransport = this.transports[name] ?? clientInfo.transport;
-    const freshTransport = this.transportRecreator.recreateForSessionLoss(staleTransport, name);
+    let freshTransport: AuthProviderTransport;
+    try {
+      freshTransport = this.transportRecreator.recreateForSessionLoss(staleTransport, name);
+    } catch (error) {
+      // recreateForSessionLoss only supports HTTP/SSE transports; a session-loss-shaped
+      // error message from some other transport kind must not escape client.onerror.
+      logger.error(
+        `Cannot recover ${name} from session loss: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return;
+    }
 
     void this.createSingleClient(name, freshTransport).catch((error) => {
       logger.error(

--- a/src/core/client/recreateHttpTransportOptions.ts
+++ b/src/core/client/recreateHttpTransportOptions.ts
@@ -1,0 +1,13 @@
+export interface RecreateHttpTransportOptions {
+  /**
+   * Whether to carry the existing `sessionId` over to the new transport.
+   *
+   * Defaults to `true`, which is correct for OAuth retries (the session itself
+   * is still valid; only auth needs refreshing). Callers recovering from a
+   * server-invalidated session (e.g. the backend restarted and lost its
+   * in-memory session store) must pass `false` so the new transport performs
+   * a full `initialize` handshake and is issued a fresh session ID, instead of
+   * immediately failing again with the same stale one.
+   */
+  preserveSessionId?: boolean;
+}

--- a/src/core/client/transportRecreator.test.ts
+++ b/src/core/client/transportRecreator.test.ts
@@ -60,6 +60,35 @@ describe('TransportRecreator', () => {
         expect((newTransport as any)._sessionId).toBe('existing-session');
       });
 
+      it('should drop the session ID when preserveSessionId is false', () => {
+        const originalTransport = {
+          _url: new URL('https://example.com/mcp'),
+          _sessionId: 'stale-session',
+          oauthProvider: { token: 'test-token' },
+        } as unknown as AuthProviderTransport;
+        Object.setPrototypeOf(originalTransport, StreamableHTTPClientTransport.prototype);
+
+        const newTransport = transportRecreator.recreateHttpTransport(originalTransport, 'test-server', {
+          preserveSessionId: false,
+        });
+
+        expect((newTransport as any)._sessionId).toBeUndefined();
+      });
+
+      it('recreateForSessionLoss should drop the session ID', () => {
+        const originalTransport = {
+          _url: new URL('https://example.com/mcp'),
+          _sessionId: 'stale-session',
+          oauthProvider: { token: 'test-token' },
+        } as unknown as AuthProviderTransport;
+        Object.setPrototypeOf(originalTransport, StreamableHTTPClientTransport.prototype);
+
+        const newTransport = transportRecreator.recreateForSessionLoss(originalTransport, 'test-server');
+
+        expect(newTransport).not.toBe(originalTransport);
+        expect((newTransport as any)._sessionId).toBeUndefined();
+      });
+
       it('should preserve oauthProvider configuration', () => {
         const oauthProvider = {
           token: 'oauth-token-123',

--- a/src/core/client/transportRecreator.ts
+++ b/src/core/client/transportRecreator.ts
@@ -3,21 +3,8 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 
 import { AuthProviderTransport } from '@src/core/types/index.js';
 
+import type { RecreateHttpTransportOptions } from './recreateHttpTransportOptions.js';
 import type { TransportRecreationState } from './transportRecreationState.js';
-
-export interface RecreateHttpTransportOptions {
-  /**
-   * Whether to carry the existing `sessionId` over to the new transport.
-   *
-   * Defaults to `true`, which is correct for OAuth retries (the session itself
-   * is still valid; only auth needs refreshing). Callers recovering from a
-   * server-invalidated session (e.g. the backend restarted and lost its
-   * in-memory session store) must pass `false` so the new transport performs
-   * a full `initialize` handshake and is issued a fresh session ID, instead of
-   * immediately failing again with the same stale one.
-   */
-  preserveSessionId?: boolean;
-}
 
 export class TransportRecreator {
   public recreateForRetry(transport: AuthProviderTransport, serverName?: string): AuthProviderTransport {

--- a/src/core/client/transportRecreator.ts
+++ b/src/core/client/transportRecreator.ts
@@ -5,6 +5,20 @@ import { AuthProviderTransport } from '@src/core/types/index.js';
 
 import type { TransportRecreationState } from './transportRecreationState.js';
 
+export interface RecreateHttpTransportOptions {
+  /**
+   * Whether to carry the existing `sessionId` over to the new transport.
+   *
+   * Defaults to `true`, which is correct for OAuth retries (the session itself
+   * is still valid; only auth needs refreshing). Callers recovering from a
+   * server-invalidated session (e.g. the backend restarted and lost its
+   * in-memory session store) must pass `false` so the new transport performs
+   * a full `initialize` handshake and is issued a fresh session ID, instead of
+   * immediately failing again with the same stale one.
+   */
+  preserveSessionId?: boolean;
+}
+
 export class TransportRecreator {
   public recreateForRetry(transport: AuthProviderTransport, serverName?: string): AuthProviderTransport {
     if (this.isHttpTransport(transport)) {
@@ -14,12 +28,26 @@ export class TransportRecreator {
     return transport;
   }
 
-  public recreateHttpTransport(transport: AuthProviderTransport, serverName?: string): AuthProviderTransport {
+  /**
+   * Recreates a transport whose backend session was lost (server restarted or
+   * otherwise invalidated the session ID). Unlike {@link recreateForRetry},
+   * this never carries the old session ID forward.
+   */
+  public recreateForSessionLoss(transport: AuthProviderTransport, serverName?: string): AuthProviderTransport {
+    return this.recreateHttpTransport(transport, serverName, { preserveSessionId: false });
+  }
+
+  public recreateHttpTransport(
+    transport: AuthProviderTransport,
+    serverName?: string,
+    options?: RecreateHttpTransportOptions,
+  ): AuthProviderTransport {
     if (!this.isHttpTransport(transport)) {
       const name = serverName ? `Transport for ${serverName}` : 'Transport';
       throw new Error(`${name} does not support OAuth (requires HTTP or SSE transport)`);
     }
 
+    const preserveSessionId = options?.preserveSessionId ?? true;
     const state = transport as unknown as TransportRecreationState;
     const authTransport = transport as AuthProviderTransport;
     const oauthProvider = authTransport.oauthProvider;
@@ -31,7 +59,7 @@ export class TransportRecreator {
             requestInit: state._requestInit,
             fetch: state._fetch,
             reconnectionOptions: state._reconnectionOptions,
-            sessionId: state._sessionId,
+            sessionId: preserveSessionId ? state._sessionId : undefined,
           }) as AuthProviderTransport)
         : (new SSEClientTransport(state._url, {
             authProvider: oauthProvider,


### PR DESCRIPTION
## Problem

When a downstream MCP server restarts, its in-memory Streamable HTTP / SSE session store resets, invalidating any session ID 1MCP was holding for it. `ClientManager`'s `client.onerror` handler only logs the error:

```ts
client.onerror = (error) => {
  logger.error(`Client ${name} error: ${error}`);
};
```

It never recovers. Every subsequent request to that backend — `tools/list` during capability aggregation *and* `tools/call` — keeps failing with the server's "Session not found" response until the whole 1MCP process is restarted by hand. In practice this means a single backend restart silently breaks that backend for every client of the proxy until someone notices and bounces 1MCP.

Reproduced this against a real deployment (1MCP fronting several backends, one Streamable HTTP, one SSE): restarting a backend container reliably produced repeating `Client <name> error: ... "Session not found"` (Streamable HTTP) / `... Could not find session ID '...'` (SSE) log lines, with the backend's tools absent from `tools/list` and its tool calls failing, indefinitely, until 1MCP itself was restarted.

## Fix

`onerror` now recognizes this error class (`isSessionLostError`, matching both message shapes above) and reconnects the backend through a freshly recreated transport with the stale `sessionId` dropped, so the new transport performs a full `initialize` handshake and is issued a new session instead of replaying the dead one.

`TransportRecreator` already had `recreateHttpTransport`, used for OAuth-retry recreation, which always carries the old `sessionId` forward (correct there — the session itself is still valid, only auth needs refreshing). This PR adds an opt-in `{ preserveSessionId: false }` option plus a `recreateForSessionLoss` convenience wrapper for the session-loss case, without changing the existing OAuth-retry behavior/callers.

The existing `client.client !== erroredClient` guard pattern (already used in `onclose`) prevents a stale/superseded client instance from triggering a duplicate recovery, and `createSingleClient`'s existing per-name semaphore dedupes any concurrent recovery attempts.

## Testing

- New unit tests in `transportRecreator.test.ts` covering `preserveSessionId: false` and `recreateForSessionLoss`.
- New unit tests in `clientManager.test.ts` covering: recovery on the Streamable HTTP "Session not found" message, recovery on the SSE "Could not find session ID" message, and a negative case ensuring unrelated `onerror` errors don't trigger recovery.
- `pnpm test:unit` (via `vitest run`) — full suite passes except 4 pre-existing failures unrelated to this change (verified identical on `main` without this diff): two `release-notes-range.test.ts` failures from `git tag` needing a configured commit identity in this sandbox, and two `commonFormatters.test.ts` date-formatting failures that are timezone-dependent.
- `tsc --noEmit` and `eslint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic recovery when Streamable HTTP/SSE sessions are lost or invalidated.
  * Reconnects with a fresh session after “session not found” errors.
  * Keeps the client connected during recovery and prevents duplicate reconnection attempts.
  * Safely handles recovery failures without disrupting the original connection.
  * Ensures recovered connections don’t reuse invalid session identifiers while preserving valid identifiers when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->