### PR TITLE
fix(release): package Admin Console in Docker and binaries

### DIFF
--- a/scripts/build-sea.cjs
+++ b/scripts/build-sea.cjs
@@ -2,6 +2,24 @@
 
 const { execSync } = require('child_process');
 const fs = require('fs');
+const path = require('path');
+
+function readAdminConsoleAssets(rootDir, relativeDir = '') {
+  const assets = {};
+
+  for (const entry of fs.readdirSync(path.join(rootDir, relativeDir), { withFileTypes: true })) {
+    const relativePath = path.posix.join(relativeDir, entry.name);
+    if (entry.isDirectory()) {
+      Object.assign(assets, readAdminConsoleAssets(rootDir, relativePath));
+      continue;
+    }
+    if (entry.isFile()) {
+      assets[relativePath] = fs.readFileSync(path.join(rootDir, relativePath)).toString('base64');
+    }
+  }
+
+  return assets;
+}
 
 /**
  * Build Single Executable Application (SEA) components
@@ -10,17 +28,28 @@ function buildSEA() {
   console.log('🔨 Building SEA components...');
 
   try {
-    // 1. Build TypeScript
+    // 1. Build the Admin Console before collecting it for the SEA bundle.
+    console.log('🖥️ Building Admin Console SPA...');
+    execSync('pnpm exec vite build --config web/admin/vite.config.ts', { stdio: 'inherit' });
+
+    const adminConsoleAssetsDir = path.join('build', 'admin');
+    const adminConsoleAssets = readAdminConsoleAssets(adminConsoleAssetsDir);
+    if (!adminConsoleAssets['index.html']) {
+      throw new Error('Admin Console build did not produce build/admin/index.html');
+    }
+    console.log(`✅ Prepared ${Object.keys(adminConsoleAssets).length} Admin Console assets for embedding`);
+
+    // 2. Build TypeScript
     console.log('📦 Building TypeScript...');
     execSync('tsc --project tsconfig.build.json', { stdio: 'inherit' });
 
-    // 2. Set execute permissions on main file
+    // 3. Set execute permissions on main file
     const mainFile = 'build/index.js';
     if (fs.existsSync(mainFile)) {
       fs.chmodSync(mainFile, '755');
     }
 
-    // 3. Bundle with esbuild (optimized)
+    // 4. Bundle with esbuild (optimized)
     console.log('📦 Bundling with esbuild...');
     execSync(
       [
@@ -38,7 +67,7 @@ function buildSEA() {
       { stdio: 'inherit' },
     );
 
-    // 3.5. Prepare tiktoken WASM files for inlining
+    // 4.5. Prepare tiktoken WASM files for inlining
     console.log('📦 Preparing tiktoken WASM files for inlining...');
     const tiktokenPath = require.resolve('tiktoken');
     const tiktokenDir = require('path').dirname(tiktokenPath);
@@ -79,6 +108,9 @@ const __TIKTOKEN_WASM_DATA__ = ${JSON.stringify(wasmData)};
 
 // Inlined version data for SEA compatibility
 const __PACKAGE_VERSION__ = ${JSON.stringify(packageJson.version)};
+
+// Inlined Admin Console assets for SEA compatibility
+globalThis.__1MCP_SEA_ADMIN_CONSOLE_ASSETS__ = ${JSON.stringify(adminConsoleAssets)};
 `;
 
     // Find the shebang line and insert WASM data after it
@@ -113,7 +145,7 @@ const __PACKAGE_VERSION__ = ${JSON.stringify(packageJson.version)};
 
     fs.writeFileSync('build/bundled.cjs', bundledCode);
 
-    // 4. Create SEA preparation blob
+    // 5. Create SEA preparation blob
     console.log('🔧 Creating SEA blob...');
     execSync('node --experimental-sea-config sea-config.json', { stdio: 'inherit' });
 

--- a/scripts/test-binary-unix.sh
+++ b/scripts/test-binary-unix.sh
@@ -68,8 +68,60 @@ else
 fi
 echo "✅ Tiktoken functionality working"
 
-# Test 4: System installation simulation
-echo "4️⃣ Testing system installation simulation..."
+# Test 4: Admin Console assets from the standalone binary
+echo "4️⃣ Testing embedded Admin Console assets..."
+ADMIN_SMOKE_DIR=$(mktemp -d)
+ADMIN_SMOKE_PORT=$(node -e 'const server=require("node:net").createServer(); server.listen(0,"127.0.0.1",()=>{console.log(server.address().port);server.close()})')
+ADMIN_SMOKE_URL="http://127.0.0.1:$ADMIN_SMOKE_PORT"
+ADMIN_SMOKE_LOG="$ADMIN_SMOKE_DIR/runtime.log"
+mkdir -p "$ADMIN_SMOKE_DIR/config"
+printf '{"mcpServers":{}}\n' > "$ADMIN_SMOKE_DIR/config/mcp.json"
+"$BINARY_PATH" serve --transport http --host 127.0.0.1 --port "$ADMIN_SMOKE_PORT" --external-url "$ADMIN_SMOKE_URL" --config-dir "$ADMIN_SMOKE_DIR/config" > "$ADMIN_SMOKE_LOG" 2>&1 &
+ADMIN_SMOKE_PID=$!
+cleanup_admin_smoke() {
+  kill "$ADMIN_SMOKE_PID" 2>/dev/null || true
+  wait "$ADMIN_SMOKE_PID" 2>/dev/null || true
+  rm -rf "$ADMIN_SMOKE_DIR"
+}
+trap cleanup_admin_smoke EXIT
+
+for attempt in $(seq 1 50); do
+  if curl -fsS "$ADMIN_SMOKE_URL/health/ready" > /dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$ADMIN_SMOKE_PID" 2>/dev/null; then
+    cat "$ADMIN_SMOKE_LOG"
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if ! curl -fsS "$ADMIN_SMOKE_URL/health/ready" > /dev/null 2>&1; then
+  cat "$ADMIN_SMOKE_LOG"
+  echo "❌ Standalone binary did not become ready"
+  exit 1
+fi
+
+ADMIN_HTML=$(curl -fsS "$ADMIN_SMOKE_URL/admin/")
+ADMIN_JS_ASSET=$(printf '%s' "$ADMIN_HTML" | sed -nE 's|.*src="/admin/(assets/[^"]+\.js)".*|\1|p' | head -n 1)
+ADMIN_CSS_ASSET=$(printf '%s' "$ADMIN_HTML" | sed -nE 's|.*href="/admin/(assets/[^"]+\.css)".*|\1|p' | head -n 1)
+if [[ -z "$ADMIN_JS_ASSET" || -z "$ADMIN_CSS_ASSET" ]]; then
+  echo "❌ Admin Console HTML did not reference JavaScript and CSS assets"
+  exit 1
+fi
+
+curl -fsS "$ADMIN_SMOKE_URL/admin/$ADMIN_JS_ASSET" -o "$ADMIN_SMOKE_DIR/admin-console.js"
+curl -fsS "$ADMIN_SMOKE_URL/admin/$ADMIN_CSS_ASSET" -o "$ADMIN_SMOKE_DIR/admin-console.css"
+if [[ ! -s "$ADMIN_SMOKE_DIR/admin-console.js" || ! -s "$ADMIN_SMOKE_DIR/admin-console.css" ]]; then
+  echo "❌ Embedded Admin Console assets were empty"
+  exit 1
+fi
+trap - EXIT
+cleanup_admin_smoke
+echo "✅ Embedded Admin Console assets working"
+
+# Test 5: System installation simulation
+echo "5️⃣ Testing system installation simulation..."
 mkdir -p test-bin
 cp "$BINARY_PATH" test-bin/
 cd test-bin

--- a/scripts/test-binary-windows.ps1
+++ b/scripts/test-binary-windows.ps1
@@ -73,8 +73,67 @@ try {
         exit 1
     }
 
-    # Test 4: System installation simulation
-    Write-Host "4. Testing system installation simulation..."
+    # Test 4: Admin Console assets from the standalone binary
+    Write-Host "4. Testing embedded Admin Console assets..."
+    $adminSmokeDir = Join-Path ([System.IO.Path]::GetTempPath()) ("1mcp-admin-smoke-" + [guid]::NewGuid())
+    $adminConfigDir = Join-Path $adminSmokeDir "config"
+    $adminStdout = Join-Path $adminSmokeDir "runtime.stdout.log"
+    $adminStderr = Join-Path $adminSmokeDir "runtime.stderr.log"
+    New-Item -ItemType Directory -Force -Path $adminConfigDir | Out-Null
+    '{"mcpServers":{}}' | Out-File -FilePath (Join-Path $adminConfigDir "mcp.json") -Encoding utf8
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $listener.Start()
+    $adminPort = $listener.LocalEndpoint.Port
+    $listener.Stop()
+    $adminBaseUrl = "http://127.0.0.1:$adminPort"
+    $adminProcess = Start-Process -FilePath $AbsoluteBinaryPath -ArgumentList @(
+        "serve", "--transport", "http", "--host", "127.0.0.1", "--port", "$adminPort",
+        "--external-url", "$adminBaseUrl", "--config-dir", "`"$adminConfigDir`""
+    ) -WorkingDirectory $adminSmokeDir -RedirectStandardOutput $adminStdout -RedirectStandardError $adminStderr -PassThru
+
+    try {
+        $ready = $false
+        for ($attempt = 0; $attempt -lt 50; $attempt++) {
+            try {
+                $response = Invoke-WebRequest -Uri "$adminBaseUrl/health/ready" -TimeoutSec 1 -ErrorAction Stop
+                if ($response.StatusCode -eq 200) {
+                    $ready = $true
+                    break
+                }
+            } catch {
+                if ($adminProcess.HasExited) {
+                    throw "Standalone binary exited before becoming ready. $((Get-Content $adminStdout -Raw -ErrorAction SilentlyContinue) + (Get-Content $adminStderr -Raw -ErrorAction SilentlyContinue))"
+                }
+            }
+            Start-Sleep -Milliseconds 100
+        }
+        if (-not $ready) {
+            throw "Standalone binary did not become ready. $((Get-Content $adminStdout -Raw -ErrorAction SilentlyContinue) + (Get-Content $adminStderr -Raw -ErrorAction SilentlyContinue))"
+        }
+
+        $adminHtml = (Invoke-WebRequest -Uri "$adminBaseUrl/admin/" -TimeoutSec 5 -ErrorAction Stop).Content
+        $jsMatch = [regex]::Match($adminHtml, 'src="/admin/(assets/[^"]+\.js)"')
+        $cssMatch = [regex]::Match($adminHtml, 'href="/admin/(assets/[^"]+\.css)"')
+        if (-not $jsMatch.Success -or -not $cssMatch.Success) {
+            throw "Admin Console HTML did not reference JavaScript and CSS assets"
+        }
+        foreach ($asset in @($jsMatch.Groups[1].Value, $cssMatch.Groups[1].Value)) {
+            $assetResponse = Invoke-WebRequest -Uri "$adminBaseUrl/admin/$asset" -TimeoutSec 5 -ErrorAction Stop
+            if ($assetResponse.StatusCode -ne 200 -or [string]::IsNullOrWhiteSpace($assetResponse.Content)) {
+                throw "Embedded Admin Console asset was missing or empty: $asset"
+            }
+        }
+    } finally {
+        if ($adminProcess -and -not $adminProcess.HasExited) {
+            Stop-Process -Id $adminProcess.Id -Force
+            $adminProcess.WaitForExit()
+        }
+        Remove-Item -Recurse -Force $adminSmokeDir -ErrorAction SilentlyContinue
+    }
+    Write-Host "Embedded Admin Console assets working"
+
+    # Test 5: System installation simulation
+    Write-Host "5. Testing system installation simulation..."
     New-Item -ItemType Directory -Force -Path test-bin | Out-Null
     Copy-Item $AbsoluteBinaryPath test-bin\
     $binaryName = Split-Path $AbsoluteBinaryPath -Leaf

--- a/src/constants/mcp.ts
+++ b/src/constants/mcp.ts
@@ -10,6 +10,15 @@ export const MCP_INSTRUCTIONS_TEMPLATE_FILE = 'instructions-template.md';
 export const MCP_SERVER_NAME = '1mcp';
 export const MCP_SERVER_VERSION = '0.35.0-beta.2';
 
+// Compiled with every artifact so Admin Console metadata does not depend on
+// package.json being adjacent to the runtime entrypoint.
+export const MCP_PROJECT_METADATA = {
+  repository: 'https://github.com/1mcp-app/agent',
+  documentation: 'https://docs.1mcp.app',
+  issues: 'https://github.com/1mcp-app/agent/issues',
+  license: 'Apache-2.0',
+} as const;
+
 export const MCP_URI_SEPARATOR = '_1mcp_';
 
 /**

--- a/src/transport/http/routes/adminRoutes.test.ts
+++ b/src/transport/http/routes/adminRoutes.test.ts
@@ -33,6 +33,7 @@ const cliRuntimeIdentity = {
   runtimeScopeId: 'scope_123',
   runtimeVersion: '1.2.3',
 } as const;
+const SEA_ADMIN_CONSOLE_ASSETS_KEY = '__1MCP_SEA_ADMIN_CONSOLE_ASSETS__';
 
 function cookieValue(setCookieHeader: string): string {
   const [nameValue] = setCookieHeader.split(';');
@@ -83,6 +84,7 @@ describe('admin routes', () => {
 
   afterEach(() => {
     fs.rmSync(storageDir, { recursive: true, force: true });
+    delete (globalThis as Record<string, unknown>)[SEA_ADMIN_CONSOLE_ASSETS_KEY];
   });
 
   function mountAdminRoutes(
@@ -360,6 +362,31 @@ describe('admin routes', () => {
     expect(response.headers['cache-control']).toContain('public');
     expect(response.headers['cache-control']).toContain('max-age=31536000');
     expect(response.text).toBe('window.__adminConsoleSmoke = true;');
+  });
+
+  it('serves embedded Admin Console assets when the SEA asset manifest is available', async () => {
+    await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+    (globalThis as Record<string, unknown>)[SEA_ADMIN_CONSOLE_ASSETS_KEY] = {
+      'index.html': Buffer.from(
+        '<!doctype html><script type="module" src="/admin/assets/admin-console.js"></script><link rel="stylesheet" href="/admin/assets/admin-console.css">',
+      ).toString('base64'),
+      'assets/admin-console.js': Buffer.from('window.__embeddedAdminConsole = true;').toString('base64'),
+      'assets/admin-console.css': Buffer.from('.admin-console { display: block; }').toString('base64'),
+    };
+    const app = mountAdminRoutes();
+
+    const indexResponse = await request(app).get('/admin/');
+    const jsResponse = await request(app).get('/admin/assets/admin-console.js');
+    const cssResponse = await request(app).get('/admin/assets/admin-console.css');
+
+    expect(indexResponse.status).toBe(200);
+    expect(indexResponse.text).toContain('/admin/assets/admin-console.js');
+    expect(jsResponse.status).toBe(200);
+    expect(jsResponse.headers['content-type']).toContain('javascript');
+    expect(jsResponse.text).toBe('window.__embeddedAdminConsole = true;');
+    expect(cssResponse.status).toBe(200);
+    expect(cssResponse.headers['content-type']).toContain('text/css');
+    expect(cssResponse.text).toBe('.admin-console { display: block; }');
   });
 
   it('resolves the default admin console asset directory as a decoded filesystem path', () => {

--- a/src/transport/http/routes/adminRoutes.ts
+++ b/src/transport/http/routes/adminRoutes.ts
@@ -62,6 +62,7 @@ const ADMIN_API_PROTOCOL_VERSION = '1';
 const TEMPLATE_INSTANCE_ID_DISPLAY_LENGTH = 12;
 const CLI_CONFIGURED_SERVER_OPERATIONS = ['mcp.enable', 'mcp.disable'] as const;
 const CLI_BACKEND_RESTART_OPERATION = 'mcp.restart' as const;
+const SEA_ADMIN_CONSOLE_ASSETS_KEY = '__1MCP_SEA_ADMIN_CONSOLE_ASSETS__';
 const adminLoginBodySchema = z.object({
   username: z.string().trim().min(1).max(ADMIN_USERNAME_MAX_LENGTH),
   password: z.string().min(1).max(ADMIN_PASSWORD_MAX_LENGTH),
@@ -510,13 +511,31 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
     await handleConfiguredServerMutation(req, res, options, 'disableConfiguredServer');
   });
 
-  router.use(
-    '/assets',
-    express.static(path.join(adminConsoleAssets.rootDir, 'assets'), {
-      immutable: true,
-      maxAge: '1y',
-    }),
-  );
+  if (adminConsoleAssets.kind === 'filesystem') {
+    router.use(
+      '/assets',
+      express.static(path.join(adminConsoleAssets.rootDir, 'assets'), {
+        immutable: true,
+        maxAge: '1y',
+      }),
+    );
+  } else {
+    router.use('/assets', (req, res, next) => {
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        next();
+        return;
+      }
+
+      const asset = adminConsoleAssets.assets.get(`assets/${req.path.replace(/^\//u, '')}`);
+      if (!asset) {
+        next();
+        return;
+      }
+
+      res.set('Cache-Control', 'public, max-age=31536000, immutable');
+      res.status(200).type(path.extname(req.path)).send(asset);
+    });
+  }
 
   router.use('/assets', (_req, res) => {
     res.status(404).type('text/plain').send('Admin Console asset not found');
@@ -528,18 +547,45 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
       return;
     }
 
-    sendAdminConsoleIndex(res, adminConsoleAssets.indexPath);
+    sendAdminConsoleIndex(res, adminConsoleAssets);
   });
 
   return router;
 }
 
-function resolveAdminConsoleAssets(configuredDir?: string): { rootDir: string; indexPath: string } {
+type AdminConsoleAssets =
+  { kind: 'embedded'; assets: Map<string, Buffer> } | { kind: 'filesystem'; rootDir: string; indexPath: string };
+
+function resolveAdminConsoleAssets(configuredDir?: string): AdminConsoleAssets {
+  if (!configuredDir) {
+    const embeddedAssets = readEmbeddedAdminConsoleAssets();
+    if (embeddedAssets) {
+      return { kind: 'embedded', assets: embeddedAssets };
+    }
+  }
+
   const rootDir = configuredDir ?? resolveDefaultAdminConsoleAssetsDir();
   return {
+    kind: 'filesystem',
     rootDir,
     indexPath: path.join(rootDir, 'index.html'),
   };
+}
+
+function readEmbeddedAdminConsoleAssets(): Map<string, Buffer> | undefined {
+  const rawAssets = (globalThis as Record<string, unknown>)[SEA_ADMIN_CONSOLE_ASSETS_KEY];
+  if (!rawAssets || typeof rawAssets !== 'object' || Array.isArray(rawAssets)) {
+    return undefined;
+  }
+
+  const assets = new Map<string, Buffer>();
+  for (const [assetPath, encodedAsset] of Object.entries(rawAssets)) {
+    if (typeof encodedAsset === 'string') {
+      assets.set(assetPath, Buffer.from(encodedAsset, 'base64'));
+    }
+  }
+
+  return assets.has('index.html') ? assets : undefined;
 }
 
 export function resolveDefaultAdminConsoleAssetsDir(): string {
@@ -552,13 +598,18 @@ function isAdminApiPath(pathname: string): boolean {
   );
 }
 
-function sendAdminConsoleIndex(res: Response, indexPath: string): void {
-  if (!fs.existsSync(indexPath)) {
+function sendAdminConsoleIndex(res: Response, adminConsoleAssets: AdminConsoleAssets): void {
+  if (adminConsoleAssets.kind === 'embedded') {
+    res.status(200).type('html').send(adminConsoleAssets.assets.get('index.html'));
+    return;
+  }
+
+  if (!fs.existsSync(adminConsoleAssets.indexPath)) {
     res.status(503).type('text/plain').send('Admin Console assets are not available. Run the package build first.');
     return;
   }
 
-  res.status(200).sendFile(indexPath, { dotfiles: 'allow' });
+  res.status(200).sendFile(adminConsoleAssets.indexPath, { dotfiles: 'allow' });
 }
 
 function unauthenticatedAdminApiResponse(options: AdminRoutesOptions): {

--- a/src/transport/http/routes/adminRoutes.ts
+++ b/src/transport/http/routes/adminRoutes.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { BackendOAuthDashboardResult } from '@src/auth/oauthAuthorizationFlow.js';
+import { MCP_PROJECT_METADATA } from '@src/constants.js';
 import { RuntimeIdentity } from '@src/core/runtime/runtimeIdentityService.js';
 import { parseTemplateConnectionKey } from '@src/core/server/templateIdentity.js';
 import type {
@@ -41,7 +42,6 @@ import { sanitizeErrorMessage } from '@src/utils/validation/sanitization.js';
 
 import express, { Request, Response, Router } from 'express';
 import rateLimit from 'express-rate-limit';
-import { createRequire } from 'node:module';
 import { z } from 'zod';
 
 const FAILED_LOGIN_LIMIT = 5;
@@ -60,15 +60,6 @@ const CLI_ADMIN_RESPONSE_TOO_LARGE_MESSAGE =
 const CLI_SESSION_OPERATIONS = ['admin.login', 'admin.status', 'admin.logout'] as const;
 const ADMIN_API_PROTOCOL_VERSION = '1';
 const TEMPLATE_INSTANCE_ID_DISPLAY_LENGTH = 12;
-const packageMetadata = createRequire(import.meta.url)('../../../../package.json') as {
-  name: string;
-  version: string;
-  homepage?: string;
-  documentation?: string;
-  bugs?: { url?: string };
-  license?: string;
-  repository?: { url?: string };
-};
 const CLI_CONFIGURED_SERVER_OPERATIONS = ['mcp.enable', 'mcp.disable'] as const;
 const CLI_BACKEND_RESTART_OPERATION = 'mcp.restart' as const;
 const adminLoginBodySchema = z.object({
@@ -1382,16 +1373,9 @@ function buildAboutMetadata(runtime: RuntimeIdentity, ui: { buildVersion?: strin
       timestamp: process.env.ADMIN_UI_BUILD_TIMESTAMP || undefined,
     },
     project: {
-      repository: normalizeRepositoryUrl(packageMetadata.repository?.url) ?? packageMetadata.homepage,
-      documentation: packageMetadata.documentation,
-      issues: packageMetadata.bugs?.url,
-      license: packageMetadata.license,
+      ...MCP_PROJECT_METADATA,
     },
   };
-}
-
-function normalizeRepositoryUrl(value?: string): string | undefined {
-  return value?.replace(/^git\+/u, '').replace(/\.git$/u, '');
 }
 
 function buildAdminOperationContext(

--- a/test/e2e/admin-spa-package.e2e.test.ts
+++ b/test/e2e/admin-spa-package.e2e.test.ts
@@ -1,13 +1,13 @@
 import { execFileSync, spawn } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 const ADMIN_BUILD_DIR = path.join(process.cwd(), 'build', 'admin');
 const PACK_DESTINATION = path.join(process.cwd(), '.tmp-test', 'admin-spa-package');
-const DOCKER_LAYOUT_DESTINATION = path.join(PACK_DESTINATION, 'docker-layout');
 const TYPECHECK_PROBE = path.join(process.cwd(), 'web', 'admin', 'src', '__node-type-probe.ts');
 const LEGACY_ADMIN_CONSOLE_HTML_BUILD = path.join(
   process.cwd(),
@@ -18,15 +18,35 @@ const LEGACY_ADMIN_CONSOLE_HTML_BUILD = path.join(
   'adminConsoleHtml.js',
 );
 
-function run(command: string, args: string[]): string {
+function run(command: string, args: string[], cwd = process.cwd()): string {
   return execFileSync(command, args, {
-    cwd: process.cwd(),
+    cwd,
     encoding: 'utf8',
     env: {
       ...process.env,
       NODE_ENV: 'test',
     },
   });
+}
+
+function createIsolatedDockerLayout(): { rootDir: string; configDir: string } {
+  const rootDir = mkdtempSync(path.join(tmpdir(), '1mcp-admin-docker-layout-'));
+  const configDir = path.join(rootDir, 'config');
+
+  try {
+    cpSync(path.join(process.cwd(), 'build'), rootDir, { recursive: true });
+    for (const file of ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml']) {
+      cpSync(path.join(process.cwd(), file), path.join(rootDir, file));
+    }
+    run('pnpm', ['install', '--frozen-lockfile', '--prefer-offline', '--prod'], rootDir);
+
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(path.join(configDir, 'mcp.json'), JSON.stringify({ mcpServers: {} }));
+    return { rootDir, configDir };
+  } catch (error) {
+    rmSync(rootDir, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 function runExpectFailure(command: string, args: string[]): string {
@@ -139,38 +159,24 @@ describe('admin SPA package build', () => {
     expect(tarballListing).not.toContain('package/build/transport/http/routes/adminConsoleHtml.js');
   }, 120000);
 
-  it('starts from the flattened production Docker layout and serves Admin Console assets', async () => {
-    rmSync(PACK_DESTINATION, { recursive: true, force: true });
-    mkdirSync(PACK_DESTINATION, { recursive: true });
-    cpSync(path.join(process.cwd(), 'build'), DOCKER_LAYOUT_DESTINATION, { recursive: true });
-    cpSync(path.join(process.cwd(), 'package.json'), path.join(DOCKER_LAYOUT_DESTINATION, 'package.json'));
-
-    const configDir = path.join(DOCKER_LAYOUT_DESTINATION, 'config');
-    mkdirSync(configDir, { recursive: true });
-    writeFileSync(path.join(configDir, 'mcp.json'), JSON.stringify({ mcpServers: {} }));
-
+  it('starts the flattened production Docker layout through its default command and serves Admin Console assets', async () => {
+    const { rootDir, configDir } = createIsolatedDockerLayout();
     const port = await getFreePort();
     let output = '';
-    const runtime = spawn(
-      process.execPath,
-      [
-        'index.js',
-        'serve',
-        '--transport',
-        'http',
-        '--host',
-        '127.0.0.1',
-        '--port',
-        String(port),
-        '--config-dir',
-        configDir,
-      ],
-      {
-        cwd: DOCKER_LAYOUT_DESTINATION,
-        env: { ...process.env, NODE_ENV: 'test', ONE_MCP_LOG_LEVEL: 'error' },
-        stdio: ['ignore', 'pipe', 'pipe'],
+    const runtime = spawn(process.execPath, ['index.js'], {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        ONE_MCP_LOG_LEVEL: 'error',
+        ONE_MCP_TRANSPORT: 'http',
+        ONE_MCP_HOST: '127.0.0.1',
+        ONE_MCP_PORT: String(port),
+        ONE_MCP_EXTERNAL_URL: `http://127.0.0.1:${port}`,
+        ONE_MCP_CONFIG_DIR: configDir,
       },
-    );
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     runtime.stdout?.on('data', (data: Buffer) => {
       output += data.toString();
     });
@@ -191,6 +197,7 @@ describe('admin SPA package build', () => {
       expect((await fetch(`${baseUrl}/admin/assets/${cssAsset}`)).status).toBe(200);
     } finally {
       await stopProcess(runtime);
+      rmSync(rootDir, { recursive: true, force: true });
     }
-  }, 15000);
+  }, 120000);
 });

--- a/test/e2e/admin-spa-package.e2e.test.ts
+++ b/test/e2e/admin-spa-package.e2e.test.ts
@@ -1,11 +1,13 @@
-import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 const ADMIN_BUILD_DIR = path.join(process.cwd(), 'build', 'admin');
 const PACK_DESTINATION = path.join(process.cwd(), '.tmp-test', 'admin-spa-package');
+const DOCKER_LAYOUT_DESTINATION = path.join(PACK_DESTINATION, 'docker-layout');
 const TYPECHECK_PROBE = path.join(process.cwd(), 'web', 'admin', 'src', '__node-type-probe.ts');
 const LEGACY_ADMIN_CONSOLE_HTML_BUILD = path.join(
   process.cwd(),
@@ -40,6 +42,46 @@ function runExpectFailure(command: string, args: string[]): string {
 function findBuiltAsset(extension: string): string {
   const assetsDir = path.join(ADMIN_BUILD_DIR, 'assets');
   return readdirSync(assetsDir).find((name) => name.endsWith(extension)) ?? '';
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Could not allocate a local port')));
+        return;
+      }
+      server.close(() => resolve(address.port));
+    });
+    server.on('error', reject);
+  });
+}
+
+async function waitForServer(url: string, output: () => string): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
+      if (response.ok) return;
+    } catch {
+      // The runtime may still be initializing.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Flattened Docker layout did not start: ${output()}`);
+}
+
+async function stopProcess(process: ReturnType<typeof spawn>): Promise<void> {
+  if (process.exitCode !== null || process.signalCode !== null) return;
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, 5_000);
+    process.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    process.kill('SIGTERM');
+  });
 }
 
 describe('admin SPA package build', () => {
@@ -96,4 +138,59 @@ describe('admin SPA package build', () => {
     expect(tarballListing).not.toContain('package/build/.tmp/');
     expect(tarballListing).not.toContain('package/build/transport/http/routes/adminConsoleHtml.js');
   }, 120000);
+
+  it('starts from the flattened production Docker layout and serves Admin Console assets', async () => {
+    rmSync(PACK_DESTINATION, { recursive: true, force: true });
+    mkdirSync(PACK_DESTINATION, { recursive: true });
+    cpSync(path.join(process.cwd(), 'build'), DOCKER_LAYOUT_DESTINATION, { recursive: true });
+    cpSync(path.join(process.cwd(), 'package.json'), path.join(DOCKER_LAYOUT_DESTINATION, 'package.json'));
+
+    const configDir = path.join(DOCKER_LAYOUT_DESTINATION, 'config');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(path.join(configDir, 'mcp.json'), JSON.stringify({ mcpServers: {} }));
+
+    const port = await getFreePort();
+    let output = '';
+    const runtime = spawn(
+      process.execPath,
+      [
+        'index.js',
+        'serve',
+        '--transport',
+        'http',
+        '--host',
+        '127.0.0.1',
+        '--port',
+        String(port),
+        '--config-dir',
+        configDir,
+      ],
+      {
+        cwd: DOCKER_LAYOUT_DESTINATION,
+        env: { ...process.env, NODE_ENV: 'test', ONE_MCP_LOG_LEVEL: 'error' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    runtime.stdout?.on('data', (data: Buffer) => {
+      output += data.toString();
+    });
+    runtime.stderr?.on('data', (data: Buffer) => {
+      output += data.toString();
+    });
+
+    try {
+      const baseUrl = `http://127.0.0.1:${port}`;
+      await waitForServer(`${baseUrl}/health/ready`, () => output);
+
+      const adminHtml = await (await fetch(`${baseUrl}/admin`)).text();
+      const jsAsset = findBuiltAsset('.js');
+      const cssAsset = findBuiltAsset('.css');
+      expect(adminHtml).toContain(`/admin/assets/${jsAsset}`);
+      expect(adminHtml).toContain(`/admin/assets/${cssAsset}`);
+      expect((await fetch(`${baseUrl}/admin/assets/${jsAsset}`)).status).toBe(200);
+      expect((await fetch(`${baseUrl}/admin/assets/${cssAsset}`)).status).toBe(200);
+    } finally {
+      await stopProcess(runtime);
+    }
+  }, 15000);
 });


### PR DESCRIPTION
## Summary

- remove package.json location assumptions from Admin Console runtime metadata so the flattened Docker layout starts normally
- embed the built Admin Console HTML, JavaScript, and CSS in SEA binaries while preserving filesystem assets for npm and Docker
- add release smoke coverage for the Docker-style production layout and Unix/Windows binary Admin assets

## Verification

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test:admin (94 passed)
- pnpm test:unit --maxWorkers=1 (4,376 passed)
- pnpm test:e2e test/e2e/admin-spa-package.e2e.test.ts (3 passed)
- Node 24 pnpm sea:build and pnpm sea:binary:macos
- ./scripts/test-binary-unix.sh ./1mcp darwin-arm64
- Docker basic image normal CMD: health ready, Admin HTML 200, referenced JS 200/non-empty, referenced CSS 200/non-empty

## Test note

The normal parallel full-unit command was run twice and exposed existing shared-state instability: each run failed on a different HTTP assertion, while both affected files passed in isolation. The deterministic single-worker full suite passed all 4,376 tests. The focused release, Admin, npm-layout, Docker, and binary checks all passed.

The default extended Docker target also reached the completed application build stage, then failed on an external TLS EOF while downloading uv. The Node-only basic release image built and passed the runtime smoke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone builds now include the Admin Console and its JavaScript and CSS assets.
  * The Admin Console is available directly from the standalone binary without requiring separate asset files.
  * About information now includes project repository, documentation, issue tracker, and license links.

* **Bug Fixes**
  * Improved Admin Console asset delivery across packaged and filesystem-based deployments.
  * Added validation to ensure the Admin Console loads correctly in standalone and packaged environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->