### PR TITLE
fix(transport): isolate managed stderr ingestion

### DIFF
--- a/src/transport/managedStdioStderr.test.ts
+++ b/src/transport/managedStdioStderr.test.ts
@@ -10,13 +10,14 @@ describe('ManagedStdioStderr', () => {
     vi.useRealTimers();
   });
 
-  it('deduplicates contiguous lines and emits a repeat summary', () => {
+  it('deduplicates contiguous lines and emits a repeat summary', async () => {
     const emit = vi.fn();
-    const stderr = new ManagedStdioStderr('noisy-server', { emit });
+    const stderr = new ManagedStdioStderr('noisy-server', { emit, maxBytesPerTurn: 8 });
     const stream = new PassThrough();
 
     stderr.attach(stream);
     stream.write('same line\nsame line\nsame line\nnext line\n');
+    await stderr.close();
 
     expect(emit).toHaveBeenNthCalledWith(
       1,
@@ -33,15 +34,118 @@ describe('ManagedStdioStderr', () => {
       ManagedStdioStderrEvent.Line,
       expect.objectContaining({ serverName: 'noisy-server', line: 'next line' }),
     );
+  });
 
-    stderr.close();
+  it('yields to scheduled application work while draining a large stderr burst', async () => {
+    const emittedLines: string[] = [];
+    const stderr = new ManagedStdioStderr('noisy-server', {
+      emit: (event, metadata) => {
+        if (event === ManagedStdioStderrEvent.Line && metadata.line) {
+          emittedLines.push(metadata.line);
+        }
+      },
+      maxBytesPerTurn: 16,
+      maxLinesPerWindow: 10_000,
+    });
+    const stream = new PassThrough();
+    const burst = Array.from({ length: 100 }, (_, index) => `line-${index}`).join('\n') + '\n';
+
+    stderr.attach(stream);
+    stream.write(burst);
+
+    expect(emittedLines).toEqual([]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(emittedLines.length).toBeGreaterThan(0);
+    expect(emittedLines.length).toBeLessThan(100);
+
+    await stderr.close();
+  });
+
+  it('continues draining when an injected per-turn byte budget is zero', async () => {
+    const emit = vi.fn();
+    const stderr = new ManagedStdioStderr('noisy-server', { emit, maxBytesPerTurn: 0 });
+    const stream = new PassThrough();
+
+    stderr.attach(stream);
+    stream.write('still drains\n');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(emit).toHaveBeenCalledWith(ManagedStdioStderrEvent.Line, expect.objectContaining({ line: 'still drains' }));
+    await stderr.close();
+  });
+
+  it('backpressures only the noisy stderr stream and resumes it after draining', async () => {
+    const noisy = new ManagedStdioStderr('noisy-server', {
+      emit: vi.fn(),
+      maxBytesPerTurn: 4,
+      maxBufferedBytes: 8,
+      maxLinesPerWindow: 10_000,
+    });
+    const healthyEmit = vi.fn();
+    const healthy = new ManagedStdioStderr('healthy-server', { emit: healthyEmit });
+    const noisyStream = new PassThrough();
+    const healthyStream = new PassThrough();
+
+    noisy.attach(noisyStream);
+    healthy.attach(healthyStream);
+    const noisyPause = vi.spyOn(noisyStream, 'pause');
+    const noisyResume = vi.spyOn(noisyStream, 'resume');
+    const healthyPause = vi.spyOn(healthyStream, 'pause');
+
+    noisyStream.write('noise\n'.repeat(100));
+    healthyStream.write('healthy\n');
+
+    expect(noisyPause).toHaveBeenCalledOnce();
+    expect(healthyPause).not.toHaveBeenCalled();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(healthyEmit).toHaveBeenCalledWith(
+      ManagedStdioStderrEvent.Line,
+      expect.objectContaining({ serverName: 'healthy-server', line: 'healthy' }),
+    );
+    for (let turn = 0; turn < 200 && noisyResume.mock.calls.length === 0; turn++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(noisyResume).toHaveBeenCalledOnce();
+
+    await noisy.close();
+    await healthy.close();
+  });
+
+  it('drains queued work and releases a paused stream on repeated close', async () => {
+    const emit = vi.fn();
+    const stderr = new ManagedStdioStderr('closing-server', {
+      emit,
+      maxBytesPerTurn: 1,
+      maxBufferedBytes: 1,
+    });
+    const stream = new PassThrough();
+
+    stderr.attach(stream);
+    const resume = vi.spyOn(stream, 'resume');
+    stream.write('queued stderr\n');
+    const firstClose = stderr.close();
+    const repeatedClose = stderr.close();
+    expect(repeatedClose).toBe(firstClose);
+    await firstClose;
+
+    expect(stream.listenerCount('data')).toBe(0);
+    expect(stream.listenerCount('end')).toBe(0);
+    expect(stream.listenerCount('close')).toBe(0);
+    expect(resume).toHaveBeenCalledOnce();
+    expect(emit).toHaveBeenCalledWith(
+      ManagedStdioStderrEvent.Line,
+      expect.objectContaining({ serverName: 'closing-server', line: 'queued stderr' }),
+    );
+    const emittedOnClose = emit.mock.calls.length;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(emit).toHaveBeenCalledTimes(emittedOnClose);
   });
 
   it('rate limits unique lines and emits a suppression summary', async () => {
-    vi.useFakeTimers();
     const emit = vi.fn();
     const stderr = new ManagedStdioStderr('noisy-server', {
       emit,
+      maxBytesPerTurn: 4,
       maxLinesPerWindow: 2,
       windowMs: 100,
     });
@@ -50,35 +154,34 @@ describe('ManagedStdioStderr', () => {
     stderr.attach(stream);
     stream.write('one\ntwo\nthree\n');
 
-    expect(emit).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(100);
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(3));
     expect(emit).toHaveBeenLastCalledWith(
       ManagedStdioStderrEvent.Suppressed,
       expect.objectContaining({ serverName: 'noisy-server', suppressedCount: 1 }),
     );
 
-    stderr.close();
+    await stderr.close();
   });
 
-  it('caps an individual line without buffering the discarded remainder', () => {
+  it('caps an individual line without buffering the discarded remainder', async () => {
     const emit = vi.fn();
-    const stderr = new ManagedStdioStderr('noisy-server', { emit, maxLineBytes: 8 });
+    const stderr = new ManagedStdioStderr('noisy-server', { emit, maxLineBytes: 8, maxBytesPerTurn: 4 });
     const stream = new PassThrough();
 
     stderr.attach(stream);
     stream.write('abcdefghijklmnop\n');
+    await stderr.close();
 
     expect(emit).toHaveBeenCalledWith(
       ManagedStdioStderrEvent.Line,
       expect.objectContaining({ serverName: 'noisy-server', line: 'abcdefgh', truncated: true }),
     );
-
-    stderr.close();
   });
 
-  it('keeps deduplication state across replacement streams', () => {
+  it('keeps deduplication state across replacement streams', async () => {
     const emit = vi.fn();
-    const stderr = new ManagedStdioStderr('restartable-server', { emit });
+    const stderr = new ManagedStdioStderr('restartable-server', { emit, maxBytesPerTurn: 8 });
     const firstStream = new PassThrough();
     const secondStream = new PassThrough();
 
@@ -86,7 +189,7 @@ describe('ManagedStdioStderr', () => {
     firstStream.write('restart failure\nrestart failure\n');
     stderr.attach(secondStream);
     secondStream.write('restart failure\n');
-    stderr.close();
+    await stderr.close();
 
     expect(emit).toHaveBeenCalledWith(
       ManagedStdioStderrEvent.Repeated,

--- a/src/transport/managedStdioStderr.ts
+++ b/src/transport/managedStdioStderr.ts
@@ -9,6 +9,20 @@ const DEFAULT_MAX_LINE_BYTES = 8 * 1024;
 const DEFAULT_MAX_LINES_PER_WINDOW = 20;
 const DEFAULT_WINDOW_MS = 10_000;
 const DEFAULT_REPEAT_SUMMARY_INTERVAL_MS = 5_000;
+const DEFAULT_MAX_BYTES_PER_TURN = 16 * 1024;
+const DEFAULT_MAX_BUFFERED_BYTES = 64 * 1024;
+
+interface QueuedChunk {
+  readonly kind: 'chunk';
+  readonly buffer: Buffer;
+  offset: number;
+}
+
+interface QueueMarker {
+  readonly kind: 'line-boundary' | 'stream-end';
+}
+
+type QueueEntry = QueuedChunk | QueueMarker;
 
 /**
  * Drains one backend's stderr without allowing it to grow parent logs without bound.
@@ -19,7 +33,18 @@ export class ManagedStdioStderr {
   private readonly maxLinesPerWindow: number;
   private readonly windowMs: number;
   private readonly repeatSummaryIntervalMs: number;
+  private readonly maxBytesPerTurn: number;
+  private readonly maxBufferedBytes: number;
   private stream: Stream | null = null;
+  private pausedStream: Stream | null = null;
+  private streamEnded = false;
+  private queue: QueueEntry[] = [];
+  private queuedBytes = 0;
+  private drainImmediate: ReturnType<typeof setImmediate> | null = null;
+  private closing = false;
+  private closed = false;
+  private closePromise: Promise<void> | null = null;
+  private resolveClose: (() => void) | null = null;
   private lineBuffer = Buffer.alloc(0);
   private lineTruncated = false;
   private lastLine: string | undefined;
@@ -31,12 +56,27 @@ export class ManagedStdioStderr {
   private windowTimer: ReturnType<typeof setTimeout> | null = null;
 
   private readonly handleData = (chunk: unknown): void => {
-    this.consumeChunk(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    if (this.closing || this.closed) {
+      return;
+    }
+
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    if (buffer.length > 0) {
+      this.queue.push({ kind: 'chunk', buffer, offset: 0 });
+      this.queuedBytes += buffer.length;
+      this.applyBackpressure();
+      this.scheduleDrain();
+    }
   };
 
   private readonly handleStreamEnd = (): void => {
-    this.flushPendingLine();
-    this.flushRepeatSummary();
+    if (this.closed || this.streamEnded) {
+      return;
+    }
+
+    this.streamEnded = true;
+    this.queue.push({ kind: 'stream-end' });
+    this.scheduleDrain();
   };
 
   constructor(
@@ -52,28 +92,133 @@ export class ManagedStdioStderr {
     this.maxLinesPerWindow = options.maxLinesPerWindow ?? DEFAULT_MAX_LINES_PER_WINDOW;
     this.windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
     this.repeatSummaryIntervalMs = options.repeatSummaryIntervalMs ?? DEFAULT_REPEAT_SUMMARY_INTERVAL_MS;
+    this.maxBytesPerTurn =
+      options.maxBytesPerTurn !== undefined && options.maxBytesPerTurn > 0
+        ? options.maxBytesPerTurn
+        : DEFAULT_MAX_BYTES_PER_TURN;
+    this.maxBufferedBytes =
+      options.maxBufferedBytes !== undefined && options.maxBufferedBytes > 0
+        ? options.maxBufferedBytes
+        : DEFAULT_MAX_BUFFERED_BYTES;
   }
 
   public attach(stream: Stream | null | undefined): void {
-    if (stream === this.stream) {
+    if (this.closing || this.closed || stream === this.stream) {
       return;
     }
 
+    const shouldFinishPreviousLine = this.stream !== null && !this.streamEnded;
     this.detachStream();
-    this.flushPendingLine();
+    if (shouldFinishPreviousLine) {
+      this.queue.push({ kind: 'line-boundary' });
+    }
     this.stream = stream ?? null;
+    this.streamEnded = false;
     this.stream?.on('data', this.handleData);
     this.stream?.on('end', this.handleStreamEnd);
     this.stream?.on('close', this.handleStreamEnd);
+    this.applyBackpressure();
+    if (this.queue.length > 0) {
+      this.scheduleDrain();
+    }
   }
 
-  public close(): void {
+  public close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.closing = true;
     this.detachStream();
+    this.closePromise = new Promise<void>((resolve) => {
+      this.resolveClose = resolve;
+    });
+
+    if (this.queue.length > 0) {
+      this.scheduleDrain();
+    } else {
+      this.completeClose();
+    }
+
+    return this.closePromise;
+  }
+
+  private completeClose(): void {
+    this.closed = true;
     this.flushPendingLine();
     this.flushRepeatSummary();
     this.flushSuppressionSummary();
     this.clearTimer('repeat');
     this.clearTimer('window');
+    this.resolveClose?.();
+    this.resolveClose = null;
+  }
+
+  private scheduleDrain(): void {
+    if (this.closed || this.drainImmediate || this.queue.length === 0) {
+      return;
+    }
+
+    this.drainImmediate = setImmediate(() => {
+      this.drainImmediate = null;
+      this.drainTurn();
+    });
+  }
+
+  private drainTurn(): void {
+    let remainingBudget = this.maxBytesPerTurn;
+
+    while (remainingBudget > 0 && this.queue.length > 0) {
+      const entry = this.queue[0];
+      if (entry.kind !== 'chunk') {
+        this.queue.shift();
+        this.flushPendingLine();
+        if (entry.kind === 'stream-end') {
+          this.flushRepeatSummary();
+        }
+        remainingBudget--;
+        continue;
+      }
+
+      const available = entry.buffer.length - entry.offset;
+      const consumed = Math.min(available, remainingBudget);
+      this.consumeChunk(entry.buffer.subarray(entry.offset, entry.offset + consumed));
+      entry.offset += consumed;
+      this.queuedBytes -= consumed;
+      remainingBudget -= consumed;
+      if (entry.offset === entry.buffer.length) {
+        this.queue.shift();
+      }
+    }
+
+    this.releaseBackpressure();
+    if (this.queue.length > 0) {
+      this.scheduleDrain();
+    } else if (this.closing) {
+      this.completeClose();
+    }
+  }
+
+  private applyBackpressure(): void {
+    if (this.queuedBytes < this.maxBufferedBytes || this.pausedStream === this.stream) {
+      return;
+    }
+
+    const pausable = this.stream as (Stream & { pause?: () => unknown }) | null;
+    if (pausable?.pause) {
+      pausable.pause();
+      this.pausedStream = this.stream;
+    }
+  }
+
+  private releaseBackpressure(): void {
+    if (!this.pausedStream || this.queuedBytes >= this.maxBufferedBytes) {
+      return;
+    }
+
+    const resumable = this.pausedStream as Stream & { resume?: () => unknown };
+    this.pausedStream = null;
+    resumable.resume?.();
   }
 
   private consumeChunk(chunk: Buffer): void {
@@ -209,6 +354,11 @@ export class ManagedStdioStderr {
     this.stream?.off('data', this.handleData);
     this.stream?.off('end', this.handleStreamEnd);
     this.stream?.off('close', this.handleStreamEnd);
+    if (this.pausedStream && this.pausedStream === this.stream) {
+      const resumable = this.pausedStream as Stream & { resume?: () => unknown };
+      this.pausedStream = null;
+      resumable.resume?.();
+    }
     this.stream = null;
   }
 

--- a/src/transport/managedStdioStderrOptions.ts
+++ b/src/transport/managedStdioStderrOptions.ts
@@ -7,4 +7,6 @@ export interface ManagedStdioStderrOptions {
   readonly maxLinesPerWindow?: number;
   readonly windowMs?: number;
   readonly repeatSummaryIntervalMs?: number;
+  readonly maxBytesPerTurn?: number;
+  readonly maxBufferedBytes?: number;
 }

--- a/src/transport/restartableStdioTransport.ts
+++ b/src/transport/restartableStdioTransport.ts
@@ -225,7 +225,7 @@ export class RestartableStdioTransport implements Transport {
       this._currentTransport = null;
     }
 
-    this.managedStderr?.close();
+    await this.managedStderr?.close();
 
     debugIf('RestartableStdioTransport closed');
   }

--- a/src/transport/transportFactory.ts
+++ b/src/transport/transportFactory.ts
@@ -255,7 +255,7 @@ function createStdioTransport(name: string, validatedTransport: ValidatedTranspo
       try {
         await closeTransport();
       } finally {
-        managedStderr.close();
+        await managedStderr.close();
       }
     };
   }

--- a/test/e2e/stdio/managed-stderr-fairness.test.ts
+++ b/test/e2e/stdio/managed-stderr-fairness.test.ts
@@ -1,0 +1,68 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { join } from 'node:path';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+import { ManagedStdioStderr } from '@src/transport/managedStdioStderr.js';
+
+import { expect, it } from 'vitest';
+
+async function within<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Operation exceeded ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+it('keeps a healthy MCP request responsive while another child floods managed stderr', async () => {
+  const noisyProcess = spawn(
+    process.execPath,
+    [
+      '-e',
+      "const chunk = 'stderr flood\\n'.repeat(16384); const flood = () => { if (!process.stderr.write(chunk)) process.stderr.once('drain', flood); else setImmediate(flood); }; flood();",
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] },
+  );
+  const noisyExited = once(noisyProcess, 'exit');
+  const noisyStarted = once(noisyProcess.stderr, 'data');
+  const noisyStderr = new ManagedStdioStderr('noisy-server', {
+    emit: () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5),
+    maxBytesPerTurn: 64,
+    maxBufferedBytes: 1024,
+    maxLinesPerWindow: 200,
+  });
+  const healthyTransport = new StdioClientTransport({
+    command: process.execPath,
+    args: [join(process.cwd(), 'test/e2e/fixtures/echo-server.js')],
+  });
+  const healthyClient = new Client({ name: 'stderr-fairness-test', version: '1.0.0' });
+
+  noisyStderr.attach(noisyProcess.stderr);
+
+  try {
+    await within(noisyStarted, 1_000);
+    await within(healthyClient.connect(healthyTransport), 2_000);
+    const result = await within(
+      healthyClient.callTool({ name: 'echo', arguments: { message: 'still responsive' } }),
+      500,
+    );
+
+    expect(result.content).toContainEqual(
+      expect.objectContaining({ text: expect.stringContaining('still responsive') }),
+    );
+  } finally {
+    noisyProcess.kill();
+    await Promise.all([noisyStderr.close(), healthyTransport.close(), within(noisyExited, 1_000)]);
+  }
+});


### PR DESCRIPTION
## Summary

- process managed backend stderr with a bounded per-turn byte budget
- apply pause/resume backpressure only to the noisy backend and preserve queued diagnostics during async close/replacement
- add deterministic unit coverage and a real-process MCP responsiveness regression in the sequential E2E suite

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (303 unit files / 4,409 tests; 9 Admin Console files / 94 tests)
- `pnpm test:e2e test/e2e/stdio/managed-stderr-fairness.test.ts test/e2e/stdio/backend-stdio-supervision.test.ts` (2 files / 4 tests)

Closes #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved handling of high-volume standard error output with bounded buffering and fair, asynchronous processing.
  * Prevented noisy subprocess output from blocking other connections or requests.
  * Preserved complete lines and pending output when streams are replaced, detached, or closed.
  * Ensured transport shutdown waits for buffered diagnostic output to finish processing.
  * Added configurable limits for per-turn processing and maximum buffered output.
* **Bug Fixes**
  * Improved stream cleanup and prevented duplicate processing after closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->