### PR TITLE
fix(release): write Windows smoke configs without BOM

### DIFF
--- a/scripts/test-binary-windows.ps1
+++ b/scripts/test-binary-windows.ps1
@@ -10,6 +10,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 
 Write-Host "Testing $Platform binary at $BinaryPath..."
 
@@ -42,7 +43,7 @@ try {
     Write-Host "3. Testing tiktoken functionality..."
     $configContent = '{"mcpServers": {"test-server": {"command": "echo", "args": ["test"]}}}'
     $configPath = Join-Path $PWD "test-config.json"
-    $configContent | Out-File -FilePath $configPath -Encoding utf8
+    [System.IO.File]::WriteAllText($configPath, $configContent, $Utf8NoBom)
 
     # Try a simpler approach - just run the command and check if it completes without crashing
     try {
@@ -77,10 +78,11 @@ try {
     Write-Host "4. Testing embedded Admin Console assets..."
     $adminSmokeDir = Join-Path ([System.IO.Path]::GetTempPath()) ("1mcp-admin-smoke-" + [guid]::NewGuid())
     $adminConfigDir = Join-Path $adminSmokeDir "config"
+    $adminConfigPath = Join-Path $adminConfigDir "mcp.json"
     $adminStdout = Join-Path $adminSmokeDir "runtime.stdout.log"
     $adminStderr = Join-Path $adminSmokeDir "runtime.stderr.log"
     New-Item -ItemType Directory -Force -Path $adminConfigDir | Out-Null
-    '{"mcpServers":{}}' | Out-File -FilePath (Join-Path $adminConfigDir "mcp.json") -Encoding utf8
+    [System.IO.File]::WriteAllText($adminConfigPath, '{"mcpServers":{}}', $Utf8NoBom)
     $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
     $listener.Start()
     $adminPort = $listener.LocalEndpoint.Port

--- a/src/release/windows-binary-smoke-test.test.ts
+++ b/src/release/windows-binary-smoke-test.test.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+function readWindowsBinarySmokeTest(): string {
+  return fs.readFileSync(path.join(process.cwd(), 'scripts', 'test-binary-windows.ps1'), 'utf8');
+}
+
+describe('Windows binary smoke test', () => {
+  it('writes JSON fixtures as UTF-8 without a byte-order mark', () => {
+    const script = readWindowsBinarySmokeTest();
+
+    expect(script).toContain('[System.Text.UTF8Encoding]::new($false)');
+    expect(script.match(/\[System\.IO\.File\]::WriteAllText/g)).toHaveLength(2);
+    expect(script).not.toMatch(/Out-File[^\r\n]+-Encoding utf8/);
+  });
+});


### PR DESCRIPTION
Fixes the Windows release binary smoke test from Actions run 30755204788. Windows PowerShell 5.1 wrote a UTF-8 BOM into temporary JSON fixtures via Out-File, causing the standalone binary to reject mcp.json before the Admin Console asset check. Use explicit BOM-free UTF-8 for both fixtures and add a focused regression test. Local validation: lint, typecheck, build, 22 release tests, and all 4,460 unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows binary smoke-test configuration writing to consistently use UTF-8 without a byte-order mark.
  * Prevented encoding-related issues when generating MCP and Admin Console configuration files.

* **Tests**
  * Added automated coverage to verify the expected UTF-8 output behavior and configuration-writing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->