### PR TITLE
feat(admin): add custom configured server creation

### DIFF
--- a/docs/en/guide/essentials/server-management.md
+++ b/docs/en/guide/essentials/server-management.md
@@ -152,6 +152,18 @@ npx -y @1mcp/agent mcp add remote-api --type=http --url="https://mcp.example.com
 
 Server-Sent Events is a deprecated transport type. It is recommended to use the HTTP transport instead.
 
+## Configure a Custom Server in the Admin Console
+
+Use **Server inventory → Configure Custom Server** when you need to add one static server without editing the runtime configuration file. The form supports local STDIO, remote HTTP, and legacy SSE targets. Registry discovery and Template Server definitions are separate workflows.
+
+1. Choose the transport and complete its structured fields. STDIO requires a command; HTTP and SSE require a URL.
+2. Add tags and choose whether the target starts enabled.
+3. For credentials, prefer **Environment Secret Reference**. The configuration stores the environment variable name or substitution expression instead of the secret material. Inline secret replacement is an advanced fallback.
+4. Select **Preview server**. Preview validates the target, reports name conflicts, redacts secret material, and runs a bounded connectivity check when applicable. Preview does not write configuration.
+5. Review the diff and runtime facts, then explicitly confirm **Create server**.
+
+Creation never replaces an existing static or Template Server target. If another writer creates the same name after preview, the confirmation is rejected and you must preview again. After a successful write, the Admin Console refreshes the inventory and opens the created target so you can verify its effective configuration and reload status.
+
 ## Server Configuration Details
 
 Each server you define in 1MCP has a set of common configuration options:

--- a/docs/en/guide/essentials/server-management.md
+++ b/docs/en/guide/essentials/server-management.md
@@ -169,8 +169,8 @@ Creation never replaces an existing static or Template Server target. If another
 Each server you define in 1MCP has a set of common configuration options:
 
 - **Name**: A unique, human-readable name for the server (e.g., `my-git-server`).
-- **Transport**: The transport type (`stdio` or `http`).
-- **Command/URL**: The command to execute for `stdio` transports, or the URL for `http` transports.
+- **Transport**: The transport type (`stdio`, `http`, or deprecated `sse`).
+- **Command/URL**: The command to execute for `stdio` transports, or the URL for `http` and deprecated `sse` transports.
 - **Arguments**: An array of command-line arguments for `stdio` servers.
 - **Environment**: Key-value pairs of environment variables for `stdio` servers.
 - **Tags**: A list of tags for organizing and filtering servers.

--- a/docs/zh/guide/essentials/server-management.md
+++ b/docs/zh/guide/essentials/server-management.md
@@ -157,8 +157,8 @@ Server-Sent Events 是已弃用的传输类型。建议改用 HTTP 传输。
 Each server you define in 1MCP has a set of common configuration options:
 
 - **Name**: A unique, human-readable name for the server (e.g., `my-git-server`).
-- **Transport**: The transport type (`stdio` or `http`).
-- **Command/URL**: The command to execute for `stdio` transports, or the URL for `http` transports.
+- **Transport**: The transport type (`stdio`, `http`, or deprecated `sse`).
+- **Command/URL**: The command to execute for `stdio` transports, or the URL for `http` and deprecated `sse` transports.
 - **Arguments**: An array of command-line arguments for `stdio` servers.
 - **Environment**: Key-value pairs of environment variables for `stdio` servers.
 - **Tags**: A list of tags for organizing and filtering servers.

--- a/docs/zh/guide/essentials/server-management.md
+++ b/docs/zh/guide/essentials/server-management.md
@@ -140,6 +140,18 @@ npx -y @1mcp/agent mcp add remote-api --type=http --url="https://mcp.example.com
 
 Server-Sent Events 是已弃用的传输类型。建议改用 HTTP 传输。
 
+## 在 Admin Console 中配置自定义服务器
+
+需要添加一个静态服务器、但不希望手动编辑运行时配置文件时，请打开 **Server inventory → Configure Custom Server**。该表单支持本地 STDIO、远程 HTTP 和旧版 SSE 目标。Registry 发现与 Template Server 定义属于独立工作流。
+
+1. 选择传输类型并填写对应的结构化字段。STDIO 必须提供命令；HTTP 和 SSE 必须提供 URL。
+2. 添加标签，并选择目标创建后是否立即启用。
+3. 凭据优先使用 **Environment Secret Reference**。配置中只保存环境变量名或替换表达式，不保存密钥内容。内联密钥仅作为高级备用方式。
+4. 选择 **Preview server**。预览会验证目标、报告名称冲突、隐藏密钥内容，并在适用时执行有界连接检查。预览不会写入配置。
+5. 检查差异与运行时信息，然后明确确认 **Create server**。
+
+创建流程绝不会替换已有的静态目标或 Template Server 目标。如果预览后有其他写入者占用了同一名称，确认操作会被拒绝，必须重新预览。写入成功后，Admin Console 会刷新服务器清单并打开新目标，以便核对其生效配置和重载状态。
+
 ## Server Configuration Details
 
 Each server you define in 1MCP has a set of common configuration options:

--- a/src/domains/admin/adminConfiguredServerService.test.ts
+++ b/src/domains/admin/adminConfiguredServerService.test.ts
@@ -3916,6 +3916,492 @@ describe('AdminConfiguredServerService', () => {
     expect(JSON.stringify(service.getRecentAuditFacts())).not.toContain('secret-value');
   });
 
+  it('publishes a normalized create contract for stdio, HTTP, and SSE only', async () => {
+    const result = await createService().getConfiguredServerCreateContract({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        schemaVersion: 1,
+        capabilities: {
+          create: { supported: true },
+          forceReplacement: { supported: false },
+          rawJson: { supported: false },
+        },
+      },
+    });
+    expect(result.ok && result.result.fieldGroups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fields: expect.arrayContaining([
+            expect.objectContaining({ fieldPath: ['transport', 'type'], options: ['stdio', 'http', 'sse'] }),
+          ]),
+        }),
+      ]),
+    );
+    if (!result.ok) return;
+    expect(
+      result.result.fieldGroups
+        .flatMap((group) => group.fields)
+        .filter((field) => field.fieldPath[0] === 'transport')
+        .map((field) => field.fieldPath[1]),
+    ).toEqual([
+      'type',
+      'timeout',
+      'connectionTimeout',
+      'requestTimeout',
+      'url',
+      'headers',
+      'command',
+      'args',
+      'cwd',
+      'env',
+      'restartOnExit',
+      'maxRestarts',
+      'restartDelay',
+    ]);
+  });
+
+  it('previews a direct create with an opaque secret-bound fingerprint and no inline secret exposure', async () => {
+    const service = createService();
+    const draft = {
+      name: 'custom',
+      enabled: true,
+      tags: ['local'],
+      transport: { type: 'stdio', command: 'node', args: ['server.js'] },
+      secrets: [
+        {
+          fieldPath: ['env', 'API_TOKEN'],
+          action: 'replace',
+          replacement: { kind: 'inlineSecret', value: 'super-secret-value' },
+        },
+      ],
+    };
+
+    const result = await service.previewConfiguredServerCreate({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+      draft,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        targetName: 'custom',
+        previewFingerprint: expect.stringMatching(/^preview_[a-f0-9]{64}$/u),
+        validation: { status: 'valid', errors: [] },
+        configChange: {
+          status: 'changed',
+          operation: 'create_static',
+          changed: true,
+          backup: { created: false },
+          reload: { status: 'skipped' },
+        },
+        connectivityCheck: { status: 'skipped', reason: 'local_stdio_transport' },
+        expectedReload: {
+          policy: 'observe_after_write',
+          possibleStatuses: ['observed', 'runtime_not_running', 'reload_disabled', 'failed'],
+        },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('super-secret-value');
+    if (!result.ok) return;
+
+    const applied = await service.applyConfiguredServerCreate({
+      context: context({
+        idempotencyKey: 'create-secret',
+        requestFingerprint: 'create-secret:fingerprint',
+        confirmationFacts: {
+          previewConfirmed: result.result.previewFingerprint,
+          targetNameConfirmed: 'custom',
+          connectionCriticalConfirmed: true,
+          secretChangeConfirmed: true,
+        },
+      }),
+      draft,
+      previewFingerprint: result.result.previewFingerprint,
+    });
+    expect(applied.ok).toBe(true);
+    expect(JSON.stringify(service.getRecentAuditFacts())).not.toContain('super-secret-value');
+  });
+
+  it('binds the semantic connectivity result into the create preview fingerprint', async () => {
+    const checkConnectivity = vi
+      .fn<ConfiguredServerConnectivityChecker>()
+      .mockResolvedValueOnce({
+        status: 'passed',
+        mode: 'bounded_dry_run',
+        checkedAt: '2026-08-05T00:00:00.000Z',
+      })
+      .mockResolvedValueOnce({
+        status: 'passed',
+        mode: 'bounded_dry_run',
+        checkedAt: '2026-08-05T00:00:01.000Z',
+      })
+      .mockResolvedValueOnce({ status: 'failed', mode: 'bounded_dry_run', message: 'Connection refused' });
+    const service = createService({ checkConnectivity });
+    const draft = { name: 'remote', enabled: true, transport: { type: 'http', url: 'https://mcp.example' } };
+
+    const first = await service.previewConfiguredServerCreate({ context: context(), draft });
+    const second = await service.previewConfiguredServerCreate({ context: context(), draft });
+    const failed = await service.previewConfiguredServerCreate({ context: context(), draft });
+
+    expect(first.ok && second.ok && first.result.previewFingerprint).toBe(
+      second.ok ? second.result.previewFingerprint : '',
+    );
+    expect(first.ok && failed.ok && first.result.previewFingerprint).not.toBe(
+      failed.ok ? failed.result.previewFingerprint : '',
+    );
+  });
+
+  it.each(['http', 'sse'] as const)(
+    'previews and creates an enabled %s target after connectivity passes',
+    async (type) => {
+      const checkConnectivity = vi.fn<ConfiguredServerConnectivityChecker>().mockResolvedValue({
+        status: 'passed',
+        mode: 'bounded_dry_run',
+        checkedAt: '2026-08-05T00:00:00.000Z',
+      });
+      const service = createService({ checkConnectivity });
+      const draft = {
+        name: `remote-${type}`,
+        enabled: true,
+        transport: { type, url: `https://${type}.example/mcp`, connectionTimeout: 2_000, requestTimeout: 5_000 },
+      };
+      const preview = await service.previewConfiguredServerCreate({ context: context(), draft });
+      expect(preview).toMatchObject({
+        ok: true,
+        result: {
+          validation: { status: 'valid' },
+          connectivityCheck: { status: 'passed' },
+          configChange: { changed: true },
+        },
+      });
+      if (!preview.ok) return;
+
+      const applied = await service.applyConfiguredServerCreate({
+        context: context({
+          idempotencyKey: `create-${type}`,
+          requestFingerprint: `create-${type}:fingerprint`,
+          confirmationFacts: {
+            previewConfirmed: preview.result.previewFingerprint,
+            targetNameConfirmed: draft.name,
+            connectionCriticalConfirmed: true,
+          },
+        }),
+        draft,
+        previewFingerprint: preview.result.previewFingerprint,
+      });
+
+      expect(applied.ok).toBe(true);
+      expect(readConfig().mcpServers[draft.name]).toMatchObject({
+        type,
+        url: draft.transport.url,
+        connectionTimeout: 2_000,
+        requestTimeout: 5_000,
+      });
+    },
+  );
+
+  it('requires an explicit override to create after a failed remote connectivity preview', async () => {
+    const checkConnectivity = vi.fn<ConfiguredServerConnectivityChecker>().mockResolvedValue({
+      status: 'failed',
+      mode: 'bounded_dry_run',
+      message: 'Connection refused',
+    });
+    const service = createService({ checkConnectivity });
+    const draft = { name: 'remote-failed', enabled: true, transport: { type: 'http', url: 'https://bad.example/mcp' } };
+    const preview = await service.previewConfiguredServerCreate({ context: context(), draft });
+    expect(preview).toMatchObject({ ok: true, result: { connectivityCheck: { status: 'failed' } } });
+    if (!preview.ok) return;
+
+    await expect(
+      service.applyConfiguredServerCreate({
+        context: context({
+          idempotencyKey: 'create-failed-without-override',
+          requestFingerprint: 'create-failed-without-override:fingerprint',
+          confirmationFacts: {
+            previewConfirmed: preview.result.previewFingerprint,
+            targetNameConfirmed: draft.name,
+            connectionCriticalConfirmed: true,
+          },
+        }),
+        draft,
+        previewFingerprint: preview.result.previewFingerprint,
+      }),
+    ).rejects.toMatchObject({ code: 'configured_server_connectivity_blocked' });
+
+    const applied = await service.applyConfiguredServerCreate({
+      context: context({
+        idempotencyKey: 'create-failed-with-override',
+        requestFingerprint: 'create-failed-with-override:fingerprint',
+        confirmationFacts: {
+          previewConfirmed: preview.result.previewFingerprint,
+          targetNameConfirmed: draft.name,
+          connectionCriticalConfirmed: true,
+          connectivityFailureOverrideConfirmed: true,
+        },
+      }),
+      draft,
+      previewFingerprint: preview.result.previewFingerprint,
+    });
+    expect(applied.ok).toBe(true);
+  });
+
+  it('returns non-secret validation facts for malformed create secrets', async () => {
+    const result = await createService().previewConfiguredServerCreate({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+      draft: {
+        name: 'custom',
+        transport: { type: 'stdio', command: 'node' },
+        secrets: [
+          {
+            fieldPath: ['unsupported', 'API_TOKEN'],
+            action: 'replace',
+            replacement: { kind: 'inlineSecret', value: '' },
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        validation: {
+          status: 'invalid',
+          errors: expect.arrayContaining([
+            expect.objectContaining({ code: 'unsupported_secret_field' }),
+            expect.objectContaining({ code: 'empty_inline_secret' }),
+          ]),
+        },
+      },
+    });
+  });
+
+  it('rejects secret fields that do not apply to the selected create transport', async () => {
+    const result = await createService().previewConfiguredServerCreate({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+      draft: {
+        name: 'custom',
+        transport: { type: 'stdio', command: 'node' },
+        secrets: [
+          {
+            fieldPath: ['headers', 'Authorization'],
+            action: 'replace',
+            replacement: { kind: 'environmentReference', value: 'API_TOKEN' },
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        validation: {
+          status: 'invalid',
+          errors: expect.arrayContaining([expect.objectContaining({ code: 'unsupported_secret_field' })]),
+        },
+        configChange: { changed: false },
+      },
+    });
+  });
+
+  it.each([
+    ['mcpServers', 'mcpServers'],
+    ['mcpTemplates', 'mcpTemplates'],
+  ] as const)('identifies an existing %s target in the create preview', async (collection, source) => {
+    writeConfig({ [collection]: { occupied: { type: 'stdio', command: 'external' } } });
+
+    const result = await createService().previewConfiguredServerCreate({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+      draft: { name: 'occupied', enabled: true, transport: { type: 'stdio', command: 'node' } },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        configChange: {
+          status: collection === 'mcpServers' ? 'destination_conflict' : 'template_conflict',
+          target: { name: 'occupied', source },
+          changed: false,
+        },
+      },
+    });
+  });
+
+  it.each(['mcpServers', 'mcpTemplates'] as const)(
+    'atomically rejects a post-preview create conflict in %s without replacing the occupant',
+    async (collection) => {
+      writeConfig({ mcpServers: {}, mcpTemplates: {} });
+      const service = createService();
+      const draft = { name: 'occupied', enabled: true, transport: { type: 'stdio', command: 'node' } };
+      const preview = await service.previewConfiguredServerCreate({
+        context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+        draft,
+      });
+      expect(preview.ok).toBe(true);
+      if (!preview.ok) return;
+      writeConfig({ [collection]: { occupied: { type: 'stdio', command: 'external' } } });
+
+      await expect(
+        service.applyConfiguredServerCreate({
+          context: context({
+            idempotencyKey: `create-${collection}`,
+            requestFingerprint: `create-${collection}:fingerprint`,
+            confirmationFacts: {
+              previewConfirmed: preview.result.previewFingerprint,
+              targetNameConfirmed: 'occupied',
+              connectionCriticalConfirmed: true,
+            },
+          }),
+          draft,
+          previewFingerprint: preview.result.previewFingerprint,
+        }),
+      ).rejects.toMatchObject({ code: 'configured_server_stale_preview' });
+      expect(readConfig()).toEqual({ [collection]: { occupied: { type: 'stdio', command: 'external' } } });
+      expect(reload).not.toHaveBeenCalled();
+      expect(fs.readdirSync(tempDir).filter((name) => name.includes('.backup.'))).toEqual([]);
+    },
+  );
+
+  it('replays a completed create before re-reading config and leaves a later external occupant untouched', async () => {
+    writeConfig({ mcpServers: {} });
+    const service = createService();
+    const draft = { name: 'custom', enabled: true, transport: { type: 'stdio', command: 'node' } };
+    const preview = await service.previewConfiguredServerCreate({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+      draft,
+    });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    const applyInput = {
+      context: context({
+        idempotencyKey: 'create-custom',
+        requestFingerprint: 'create-custom:fingerprint',
+        confirmationFacts: {
+          previewConfirmed: preview.result.previewFingerprint,
+          targetNameConfirmed: 'custom',
+          connectionCriticalConfirmed: true,
+        },
+      }),
+      draft,
+      previewFingerprint: preview.result.previewFingerprint,
+    };
+
+    const first = await service.applyConfiguredServerCreate(applyInput);
+    writeConfig({ mcpServers: { custom: { type: 'stdio', command: 'external' } } });
+    const replay = await service.applyConfiguredServerCreate(applyInput);
+
+    expect(first).toMatchObject({ ok: true, replayed: false, result: { targetName: 'custom' } });
+    expect(replay).toMatchObject({ ok: true, replayed: true, result: { targetName: 'custom' } });
+    expect(readConfig().mcpServers.custom).toEqual({ type: 'stdio', command: 'external' });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a create preview after any config document revision changes', async () => {
+    writeConfig({ mcpServers: {}, unrelated: { revision: 1 } });
+    const service = createService();
+    const draft = { name: 'custom', enabled: true, transport: { type: 'stdio', command: 'node' } };
+    const preview = await service.previewConfiguredServerCreate({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+      draft,
+    });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    writeConfig({ mcpServers: {}, unrelated: { revision: 2 } });
+
+    await expect(
+      service.applyConfiguredServerCreate({
+        context: context({
+          confirmationFacts: {
+            previewConfirmed: preview.result.previewFingerprint,
+            targetNameConfirmed: 'custom',
+            connectionCriticalConfirmed: true,
+          },
+        }),
+        draft,
+        previewFingerprint: preview.result.previewFingerprint,
+      }),
+    ).rejects.toMatchObject({ code: 'configured_server_stale_preview' });
+    expect(readConfig().mcpServers).toEqual({});
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('completes and replays a create whose write succeeded but reload observation failed', async () => {
+    writeConfig({ mcpServers: {} });
+    reload.mockImplementationOnce(() => {
+      throw new Error('reload sentinel should be reported');
+    });
+    const service = createService();
+    const draft = { name: 'custom', enabled: true, transport: { type: 'stdio', command: 'node' } };
+    const preview = await service.previewConfiguredServerCreate({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+      draft,
+    });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+    const applyInput = {
+      context: context({
+        idempotencyKey: 'reload-create',
+        requestFingerprint: 'reload-create:fingerprint',
+        confirmationFacts: {
+          previewConfirmed: preview.result.previewFingerprint,
+          targetNameConfirmed: 'custom',
+          connectionCriticalConfirmed: true,
+        },
+      }),
+      draft,
+      previewFingerprint: preview.result.previewFingerprint,
+    };
+
+    const first = await service.applyConfiguredServerCreate(applyInput);
+    const replay = await service.applyConfiguredServerCreate(applyInput);
+
+    expect(first).toMatchObject({
+      ok: true,
+      replayed: false,
+      result: {
+        configChange: { status: 'changed', reload: { status: 'failed', error: 'reload sentinel should be reported' } },
+      },
+    });
+    expect(replay).toMatchObject({ ok: true, replayed: true, result: first.ok ? first.result : undefined });
+    expect(readConfig().mcpServers.custom).toEqual({ type: 'stdio', command: 'node', disabled: false });
+  });
+
+  it('keeps create preview available but rejects apply when the runtime-scope writer lock is unavailable', async () => {
+    writeConfig({ mcpServers: {} });
+    const service = createService({ mutationAvailability: { available: false, reason: 'writer_lock_unavailable' } });
+    const draft = { name: 'custom', enabled: true, transport: { type: 'stdio', command: 'node' } };
+    const preview = await service.previewConfiguredServerCreate({
+      context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),
+      draft,
+    });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+
+    const result = await service.applyConfiguredServerCreate({
+      context: context({
+        confirmationFacts: {
+          previewConfirmed: preview.result.previewFingerprint,
+          targetNameConfirmed: 'custom',
+          connectionCriticalConfirmed: true,
+        },
+      }),
+      draft,
+      previewFingerprint: preview.result.previewFingerprint,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'runtime_scope_locked',
+      code: 'runtime_scope_locked',
+      retryable: true,
+      reason: 'writer_lock_unavailable',
+    });
+    expect(readConfig().mcpServers).toEqual({});
+  });
+
   function createService(
     options: {
       readConfigDocument?: () => { serverDefaults?: Record<string, any>; mcpServers?: Record<string, any> } | null;

--- a/src/domains/admin/adminConfiguredServerService.test.ts
+++ b/src/domains/admin/adminConfiguredServerService.test.ts
@@ -4149,6 +4149,34 @@ describe('AdminConfiguredServerService', () => {
     expect(applied.ok).toBe(true);
   });
 
+  it('creates an enabled remote target when the connectivity checker is unavailable', async () => {
+    const service = createService();
+    const draft = { name: 'remote-unchecked', enabled: true, transport: { type: 'http', url: 'https://mcp.example' } };
+    const preview = await service.previewConfiguredServerCreate({ context: context(), draft });
+    expect(preview).toMatchObject({
+      ok: true,
+      result: { connectivityCheck: { status: 'skipped', reason: 'checker_unavailable' } },
+    });
+    if (!preview.ok) return;
+
+    const applied = await service.applyConfiguredServerCreate({
+      context: context({
+        idempotencyKey: 'create-remote-unchecked',
+        requestFingerprint: 'create-remote-unchecked:fingerprint',
+        confirmationFacts: {
+          previewConfirmed: preview.result.previewFingerprint,
+          targetNameConfirmed: draft.name,
+          connectionCriticalConfirmed: true,
+        },
+      }),
+      draft,
+      previewFingerprint: preview.result.previewFingerprint,
+    });
+
+    expect(applied.ok).toBe(true);
+    expect(readConfig().mcpServers[draft.name]).toMatchObject({ type: 'http', url: 'https://mcp.example' });
+  });
+
   it('returns non-secret validation facts for malformed create secrets', async () => {
     const result = await createService().previewConfiguredServerCreate({
       context: context({ idempotencyKey: undefined, requestFingerprint: undefined }),

--- a/src/domains/admin/adminConfiguredServerService.ts
+++ b/src/domains/admin/adminConfiguredServerService.ts
@@ -883,6 +883,9 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
           !wouldUseLocalStdioTransport(prepared.config) &&
           preview.connectivityCheck.status !== 'passed' &&
           !(
+            preview.connectivityCheck.status === 'skipped' && preview.connectivityCheck.reason === 'checker_unavailable'
+          ) &&
+          !(
             preview.connectivityCheck.status === 'failed' &&
             input.context.confirmationFacts?.connectivityFailureOverrideConfirmed === true
           )

--- a/src/domains/admin/adminConfiguredServerService.ts
+++ b/src/domains/admin/adminConfiguredServerService.ts
@@ -10,11 +10,17 @@ import {
 import {
   type ConfigChangeResult,
   type ConfigChangeService,
+  fingerprintConfiguredServerConfigDocument,
   fingerprintConfiguredServerDefaults,
   fingerprintConfiguredServerSecretValue,
   fingerprintConfiguredServerTarget,
   isConfiguredServerTargetDisabled,
 } from '@src/domains/config-change/configChange.js';
+import {
+  createServerInstallationWorkflow,
+  type DirectInstallationSource,
+  type ServerInstallationWorkflowResult,
+} from '@src/domains/installation/serverInstallationWorkflow.js';
 
 import { z } from 'zod';
 
@@ -45,6 +51,433 @@ interface AdminConfiguredServerServiceOptions {
   checkConnectivity?: ConfiguredServerConnectivityChecker;
 }
 
+interface PreparedConfiguredServerCreate {
+  draft: ConfiguredServerCreateDraft;
+  source: DirectInstallationSource;
+  targetName: string;
+  enabled: boolean;
+  workflow: ServerInstallationWorkflowResult;
+  config?: MCPServerParams;
+  validation: ConfiguredServerPreviewValidation;
+}
+
+const configuredServerCreateSecretSchema = z
+  .object({
+    fieldPath: z.array(z.string()).min(2),
+    action: z.literal('replace'),
+    replacement: z.object({
+      kind: z.enum(['environmentReference', 'inlineSecret']),
+      value: z.string(),
+    }),
+  })
+  .strict();
+
+const configuredServerCreateDraftSchema = z
+  .object({
+    name: z.string(),
+    enabled: z.boolean().optional(),
+    tags: z.array(z.string()).optional(),
+    transport: z
+      .object({
+        type: z.enum(['stdio', 'http', 'sse']),
+        command: z.string().optional(),
+        url: z.string().optional(),
+        args: z.array(z.string()).optional(),
+        cwd: z.string().optional(),
+        env: z.record(z.string(), z.string()).optional(),
+        headers: z.record(z.string(), z.string()).optional(),
+        timeout: z.number().optional(),
+        connectionTimeout: z.number().optional(),
+        requestTimeout: z.number().optional(),
+        restartOnExit: z.boolean().optional(),
+        maxRestarts: z.number().optional(),
+        restartDelay: z.number().optional(),
+      })
+      .strict(),
+    secrets: z.array(configuredServerCreateSecretSchema).optional(),
+  })
+  .strict();
+
+const CONFIGURED_SERVER_CREATE_TRANSPORT_FIELD_KEYS = new Set([
+  'type',
+  'timeout',
+  'connectionTimeout',
+  'requestTimeout',
+  'url',
+  'headers',
+  'command',
+  'args',
+  'cwd',
+  'env',
+  'restartOnExit',
+  'maxRestarts',
+  'restartDelay',
+]);
+
+function normalizeConfiguredServerCreateDraft(value: unknown): {
+  draft: ConfiguredServerCreateDraft;
+  source: DirectInstallationSource;
+  validation: ConfiguredServerPreviewValidation;
+} {
+  const parsed = configuredServerCreateDraftSchema.safeParse(value);
+  if (!parsed.success) {
+    const record =
+      value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+    const transport =
+      record.transport && typeof record.transport === 'object' && !Array.isArray(record.transport)
+        ? (record.transport as Record<string, unknown>)
+        : {};
+    const transportType = transport.type === 'http' || transport.type === 'sse' ? transport.type : 'stdio';
+    return {
+      draft: {},
+      source: {
+        type: 'direct',
+        localName: typeof record.name === 'string' ? record.name : '',
+        transport: transportType,
+      },
+      validation: {
+        status: 'invalid',
+        errors: parsed.error.issues.map((issue) => ({
+          fieldPath: issue.path.map(String),
+          code: 'invalid_create_field',
+          message: issue.message,
+        })),
+      },
+    };
+  }
+
+  const { transport } = parsed.data;
+  const draft: ConfiguredServerCreateDraft = {
+    name: parsed.data.name,
+    enabled: parsed.data.enabled,
+    tags: parsed.data.tags,
+    transport: { ...transport },
+    secrets: parsed.data.secrets,
+  };
+  const secretContainer = transport.type === 'stdio' ? 'env' : 'headers';
+  const secretValues = configuredServerCreateSecretValues(draft, secretContainer);
+  const source: DirectInstallationSource = {
+    type: 'direct',
+    localName: parsed.data.name,
+    transport: transport.type,
+    enabled: parsed.data.enabled,
+    tags: parsed.data.tags,
+    command: transport.command,
+    url: transport.url,
+    args: transport.args,
+    cwd: transport.cwd,
+    env: mergeConfiguredServerCreateRecord(transport.env, secretContainer === 'env' ? secretValues : undefined),
+    headers: mergeConfiguredServerCreateRecord(
+      transport.headers,
+      secretContainer === 'headers' ? secretValues : undefined,
+    ),
+    timeout: transport.timeout,
+    connectionTimeout: transport.connectionTimeout,
+    requestTimeout: transport.requestTimeout,
+    autoRestart: transport.restartOnExit,
+    maxRestarts: transport.maxRestarts,
+    restartDelay: transport.restartDelay,
+  };
+  return { draft, source, validation: { status: 'valid', errors: [] } };
+}
+
+function configuredServerCreateSecretValues(
+  draft: ConfiguredServerCreateDraft,
+  container: 'env' | 'headers',
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const secret of draft.secrets ?? []) {
+    if (secret.fieldPath.length !== 2 || secret.fieldPath[0] !== container || !isValidFieldPath(secret.fieldPath)) {
+      continue;
+    }
+    if (!secret.replacement) continue;
+    values[secret.fieldPath[1]] = replacementValue(secret.replacement);
+  }
+  return values;
+}
+
+function mergeConfiguredServerCreateRecord(
+  base: Record<string, string> | undefined,
+  additions: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  const merged = { ...base, ...additions };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function createWorkflowValidation(
+  workflow: ServerInstallationWorkflowResult,
+  config: MCPServerParams | undefined,
+): ConfiguredServerPreviewValidation {
+  const errors: ConfiguredServerPreviewValidationError[] = [];
+  for (const [field, messages] of Object.entries(workflow.fieldErrors ?? {})) {
+    for (const message of messages) {
+      errors.push({
+        fieldPath: field === 'localName' ? ['name'] : ['transport', field],
+        code: 'invalid_create_field',
+        message,
+      });
+    }
+  }
+  if (workflow.status === 'exists' || workflow.status === 'template_conflict') {
+    errors.push({
+      fieldPath: ['name'],
+      code: workflow.status === 'template_conflict' ? 'template_name_conflict' : 'configured_server_name_conflict',
+      message: 'A configured server or Template Server definition already uses this name.',
+    });
+  }
+  if (config) {
+    const parsed = previewTransportConfigSchema.safeParse(config);
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) {
+        errors.push({
+          fieldPath: ['transport', ...issue.path.map(String)],
+          code: 'invalid_transport_config',
+          message: issue.message,
+        });
+      }
+    }
+  }
+  return { status: errors.length === 0 ? 'valid' : 'invalid', errors };
+}
+
+function validateConfiguredServerCreateSecrets(draft: ConfiguredServerCreateDraft): ConfiguredServerPreviewValidation {
+  const errors: ConfiguredServerPreviewValidationError[] = [];
+  const expectedContainer = draft.transport?.type === 'stdio' ? 'env' : 'headers';
+  for (const [index, secret] of (draft.secrets ?? []).entries()) {
+    const basePath = ['secrets', String(index)];
+    if (
+      !isValidFieldPath(secret.fieldPath) ||
+      secret.fieldPath.length !== 2 ||
+      secret.fieldPath[0] !== expectedContainer
+    ) {
+      errors.push({
+        fieldPath: [...basePath, 'fieldPath'],
+        code: 'unsupported_secret_field',
+        message: `Secret replacement must target ${expectedContainer} for the selected transport.`,
+      });
+    }
+    if (!secret.replacement) {
+      errors.push({
+        fieldPath: [...basePath, 'replacement'],
+        code: 'missing_secret_replacement',
+        message: 'Create secret actions require a replacement.',
+      });
+      continue;
+    }
+    if (secret.replacement.kind === 'environmentReference' && !isEnvironmentReferenceInput(secret.replacement.value)) {
+      errors.push({
+        fieldPath: [...basePath, 'replacement', 'value'],
+        code: 'invalid_environment_reference',
+        message: 'Environment reference must be an environment variable name or substitution expression.',
+      });
+    }
+    if (secret.replacement.kind === 'inlineSecret' && secret.replacement.value.length === 0) {
+      errors.push({
+        fieldPath: [...basePath, 'replacement', 'value'],
+        code: 'empty_inline_secret',
+        message: 'Inline secret replacement cannot be empty.',
+      });
+    }
+  }
+  return { status: errors.length === 0 ? 'valid' : 'invalid', errors };
+}
+
+function createConfiguredServerCreateContract(): ConfiguredServerCreateContract {
+  const transportFields = TRANSPORT_FIELD_DEFINITIONS.filter((definition) =>
+    CONFIGURED_SERVER_CREATE_TRANSPORT_FIELD_KEYS.has(definition.key),
+  ).map((definition) => ({
+    fieldPath: ['transport', definition.key],
+    label: definition.label,
+    control: definition.control,
+    value: definition.defaultValue,
+    options: definition.key === 'type' ? ['stdio', 'http', 'sse'] : definition.options,
+    editable: true,
+    applicableTransportTypes: definition.applicableTransportTypes?.filter((type) => type !== 'streamableHttp'),
+  }));
+  return {
+    schemaVersion: 1,
+    capabilities: {
+      create: { supported: true },
+      forceReplacement: { supported: false },
+      rawJson: { supported: false },
+      preview: { supported: true },
+      apply: { supported: true },
+    },
+    secretPolicy: {
+      allowedActions: ['replace'],
+      environmentReference: {
+        recommended: true,
+        storesSecretMaterial: false,
+        guidance: 'Store an environment variable name or substitution expression instead of secret material.',
+      },
+      inlineReplacement: {
+        emphasis: 'secondary',
+        guidance: 'Inline secret material is stored in the Runtime Scope configuration.',
+      },
+    },
+    fieldGroups: [
+      {
+        id: 'identity',
+        label: 'Identity',
+        fields: [
+          { fieldPath: ['name'], label: 'Server Name', control: 'text', editable: true },
+          { fieldPath: ['enabled'], label: 'Enabled', control: 'switch', value: true, editable: true },
+          { fieldPath: ['tags'], label: 'Tags', control: 'tag-list', value: [], editable: true },
+        ],
+      },
+      { id: 'transport', label: 'Transport', fields: transportFields },
+    ],
+  };
+}
+
+function createConfiguredServerCreateDiff(
+  proposed: ConfiguredServerReadModel,
+  draft: ConfiguredServerCreateDraft,
+): ConfiguredServerPreviewDiffEntry[] {
+  const diff: ConfiguredServerPreviewDiffEntry[] = [
+    { fieldPath: ['name'], oldValue: undefined, newValue: proposed.id, riskFlags: [] },
+    { fieldPath: ['enabled'], oldValue: undefined, newValue: proposed.enabled, riskFlags: ['connection_critical'] },
+    { fieldPath: ['tags'], oldValue: undefined, newValue: proposed.tags, riskFlags: [] },
+  ];
+  for (const [key, value] of Object.entries(proposed.transport)) {
+    diff.push({
+      fieldPath: ['transport', key],
+      oldValue: undefined,
+      newValue: value,
+      riskFlags: previewRiskFlags([key]),
+    });
+  }
+  for (const secret of draft.secrets ?? []) {
+    diff.push({
+      fieldPath: secret.fieldPath,
+      oldValue: undefined,
+      newValue: previewSecretNewValue(secret),
+      secretAction: 'replace',
+      riskFlags: ['connection_critical', 'secret'],
+    });
+  }
+  return diff;
+}
+
+function previewSecretNewValue(secret: ConfiguredServerSecretEditDraft): unknown {
+  const replacement = secret.replacement;
+  if (!replacement) return { present: false, value: '[REDACTED]', secret: true };
+  if (replacement.kind === 'environmentReference') {
+    return {
+      kind: 'environmentReference',
+      value: normalizeEnvironmentReference(replacement.value),
+      storesSecretMaterial: false,
+    };
+  }
+  return { present: true, value: '[REDACTED]', secret: true };
+}
+
+function configuredServerCreatePreviewFingerprint(input: {
+  configFingerprint: string;
+  draft: ConfiguredServerCreateDraft;
+  proposed?: ConfiguredServerReadModel;
+  diff: ConfiguredServerPreviewDiffEntry[];
+  validation: ConfiguredServerPreviewValidation;
+  connectivityCheck: ConfiguredServerConnectivityCheckResult;
+}): string {
+  const redactedDraft = {
+    ...input.draft,
+    secrets: input.draft.secrets?.map((secret) => ({
+      fieldPath: secret.fieldPath,
+      action: secret.action,
+      replacement: secret.replacement ? fingerprintSecretReplacement(secret.replacement) : undefined,
+    })),
+  };
+  return `preview_${createHash('sha256')
+    .update(
+      stableStringify({
+        schemaVersion: 1,
+        configFingerprint: input.configFingerprint,
+        draft: redactedDraft,
+        proposed: input.proposed,
+        diff: input.diff,
+        validation: input.validation,
+        connectivityCheck: connectivityFingerprintFacts(input.connectivityCheck),
+      }),
+    )
+    .digest('hex')}`;
+}
+
+function connectivityFingerprintFacts(
+  connectivityCheck: ConfiguredServerConnectivityCheckResult,
+):
+  | Omit<ConfiguredServerConnectivityCheckPassed, 'checkedAt'>
+  | ConfiguredServerConnectivityCheckFailed
+  | ConfiguredServerConnectivityCheckSkipped {
+  if (connectivityCheck.status !== 'passed') return connectivityCheck;
+  return { status: connectivityCheck.status, mode: connectivityCheck.mode };
+}
+
+function previewCreateConfigChange(
+  targetName: string,
+  workflowStatus: ServerInstallationWorkflowResult['status'],
+  changed: boolean,
+): ConfigChangeResult {
+  const status =
+    workflowStatus === 'template_conflict'
+      ? 'template_conflict'
+      : workflowStatus === 'exists'
+        ? 'destination_conflict'
+        : changed
+          ? 'changed'
+          : 'failed';
+  return {
+    status,
+    operation: 'create_static',
+    configPath: '[redacted]',
+    target: {
+      name: targetName,
+      ...(workflowStatus === 'template_conflict'
+        ? { source: 'mcpTemplates' as const }
+        : workflowStatus === 'exists'
+          ? { source: 'mcpServers' as const }
+          : {}),
+    },
+    changed,
+    backup: { created: false },
+    retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+    reload: { status: 'skipped' },
+    warnings: [],
+  };
+}
+
+function createDraftCandidateName(value: unknown): string {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return '';
+  const name = (value as Record<string, unknown>).name;
+  return typeof name === 'string' ? name : '';
+}
+
+function sanitizeCreateConfirmationFacts(
+  facts: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!facts) return undefined;
+  const allowed = [
+    'previewConfirmed',
+    'targetNameConfirmed',
+    'secretChangeConfirmed',
+    'connectionCriticalConfirmed',
+    'connectivityFailureOverrideConfirmed',
+  ];
+  const sanitized = Object.fromEntries(allowed.filter((key) => key in facts).map((key) => [key, facts[key]]));
+  return Object.keys(sanitized).length ? sanitized : undefined;
+}
+
+function assertSuccessfulConfiguredServerCreate(configChange: ConfigChangeResult): void {
+  if (configChange.status === 'changed') return;
+  if (configChange.status === 'source_conflict') {
+    throw new AdminConfiguredServerApplyError('configured_server_stale_preview');
+  }
+  if (configChange.status === 'destination_conflict' || configChange.status === 'template_conflict') {
+    throw new AdminConfiguredServerApplyError('configured_server_destination_conflict');
+  }
+  throw new AdminConfiguredServerApplyError('configured_server_create_failed');
+}
+
 interface ConfiguredServerMutationInput {
   context: AdminOperationContext;
   targetName: string;
@@ -68,6 +501,22 @@ interface ConfiguredServerApplyInput {
   context: AdminOperationContext;
   targetName: string;
   edit: unknown;
+  previewFingerprint: string;
+}
+
+interface ConfiguredServerCreateContractInput {
+  context: AdminOperationContext;
+}
+
+interface ConfiguredServerCreatePreviewInput {
+  context: AdminOperationContext;
+  draft: unknown;
+  connectivityCheck?: 'auto' | 'manual';
+}
+
+interface ConfiguredServerCreateApplyInput {
+  context: AdminOperationContext;
+  draft: unknown;
   previewFingerprint: string;
 }
 
@@ -221,6 +670,52 @@ export interface ConfiguredServerApplyResult {
   configChange: ConfigChangeResult;
 }
 
+export interface ConfiguredServerCreateContract {
+  schemaVersion: 1;
+  capabilities: {
+    create: { supported: true };
+    forceReplacement: { supported: false };
+    rawJson: { supported: false };
+    preview: { supported: true };
+    apply: { supported: true };
+  };
+  secretPolicy: {
+    allowedActions: ['replace'];
+    environmentReference: { recommended: true; storesSecretMaterial: false; guidance: string };
+    inlineReplacement: { emphasis: 'secondary'; guidance: string };
+  };
+  fieldGroups: ConfiguredServerEditFieldGroup[];
+}
+
+export interface ConfiguredServerCreateDraft {
+  name?: string;
+  enabled?: boolean;
+  tags?: string[];
+  transport?: Record<string, unknown>;
+  secrets?: ConfiguredServerSecretEditDraft[];
+}
+
+export interface ConfiguredServerCreatePreviewResult {
+  targetName: string;
+  previewFingerprint: string;
+  validation: ConfiguredServerPreviewValidation;
+  diff: ConfiguredServerPreviewDiffEntry[];
+  configChange: ConfigChangeResult;
+  connectivityCheck: ConfiguredServerConnectivityCheckResult;
+  expectedReload: ConfiguredServerExpectedReload;
+}
+
+export interface ConfiguredServerExpectedReload {
+  policy: 'observe_after_write';
+  possibleStatuses: readonly ['observed', 'runtime_not_running', 'reload_disabled', 'failed'];
+}
+
+export interface ConfiguredServerCreateApplyResult {
+  targetName: string;
+  previewFingerprint: string;
+  configChange: ConfigChangeResult;
+}
+
 export type ConfiguredServerEditFieldControl =
   'text' | 'number' | 'switch' | 'tag-list' | 'select' | 'string-list' | 'secret' | 'record' | 'readonly';
 
@@ -288,9 +783,19 @@ export interface ConfiguredServerDetailResult {
 export interface ConfiguredServerConfigDocument {
   serverDefaults?: GlobalTransportConfig;
   mcpServers?: Record<string, MCPServerParams>;
+  mcpTemplates?: Record<string, MCPServerParams>;
 }
 
 export interface AdminConfiguredServerOperations {
+  getConfiguredServerCreateContract(
+    input: ConfiguredServerCreateContractInput,
+  ): Promise<AdminOperationResult<ConfiguredServerCreateContract>>;
+  previewConfiguredServerCreate(
+    input: ConfiguredServerCreatePreviewInput,
+  ): Promise<AdminOperationResult<ConfiguredServerCreatePreviewResult>>;
+  applyConfiguredServerCreate(
+    input: ConfiguredServerCreateApplyInput,
+  ): Promise<AdminOperationResult<ConfiguredServerCreateApplyResult>>;
   listConfiguredServers(input: {
     context: AdminOperationContext;
   }): Promise<AdminOperationResult<{ servers: ConfiguredServerReadModel[] }>>;
@@ -323,6 +828,103 @@ export class AdminConfiguredServerNotFoundError extends Error {
 
 export class AdminConfiguredServerService implements AdminConfiguredServerOperations {
   constructor(private readonly options: AdminConfiguredServerServiceOptions) {}
+
+  async getConfiguredServerCreateContract(
+    input: ConfiguredServerCreateContractInput,
+  ): Promise<AdminOperationResult<ConfiguredServerCreateContract>> {
+    return this.options.operationService.executeReadOnly({
+      context: input.context,
+      operationName: 'getConfiguredServerCreateContract',
+      run: async () => createConfiguredServerCreateContract(),
+    });
+  }
+
+  async previewConfiguredServerCreate(
+    input: ConfiguredServerCreatePreviewInput,
+  ): Promise<AdminOperationResult<ConfiguredServerCreatePreviewResult>> {
+    return this.options.operationService.executeDryRun({
+      context: input.context,
+      operationName: 'previewConfiguredServerCreate',
+      run: async () => this.previewConfiguredServerCreateResult(input),
+    });
+  }
+
+  async applyConfiguredServerCreate(
+    input: ConfiguredServerCreateApplyInput,
+  ): Promise<AdminOperationResult<ConfiguredServerCreateApplyResult>> {
+    const candidateName = createDraftCandidateName(input.draft);
+    const context = {
+      ...input.context,
+      target: { type: 'configured_server', id: candidateName },
+      confirmationFacts: sanitizeCreateConfirmationFacts(input.context.confirmationFacts),
+    };
+    return this.options.operationService.executeMutation({
+      context,
+      operationName: 'applyConfiguredServerCreate',
+      prepare: async () => {
+        const document = this.options.readConfigDocument() ?? {};
+        const preview = await this.previewConfiguredServerCreateResult(
+          { ...input, connectivityCheck: 'auto' },
+          true,
+          document,
+        );
+        if (preview.previewFingerprint !== input.previewFingerprint) {
+          throw new AdminConfiguredServerApplyError('configured_server_stale_preview');
+        }
+        if (preview.validation.status !== 'valid' || !preview.configChange.changed) {
+          throw new AdminConfiguredServerApplyError('configured_server_create_invalid');
+        }
+        const prepared = await this.resolveConfiguredServerCreate(input.draft, document);
+        if (!prepared.config) {
+          throw new AdminConfiguredServerApplyError('configured_server_create_invalid');
+        }
+        if (
+          prepared.enabled &&
+          !wouldUseLocalStdioTransport(prepared.config) &&
+          preview.connectivityCheck.status !== 'passed' &&
+          !(
+            preview.connectivityCheck.status === 'failed' &&
+            input.context.confirmationFacts?.connectivityFailureOverrideConfirmed === true
+          )
+        ) {
+          throw new AdminConfiguredServerApplyError('configured_server_connectivity_blocked');
+        }
+        const secretChange = prepared.draft.secrets?.length;
+        const configFingerprint = fingerprintConfiguredServerConfigDocument(document);
+        return {
+          confirmationRequirements: [
+            { code: 'previewConfirmed', expected: input.previewFingerprint },
+            { code: 'targetNameConfirmed', expected: prepared.targetName },
+            { code: 'connectionCriticalConfirmed', expected: true },
+            ...(secretChange ? [{ code: 'secretChangeConfirmed', expected: true }] : []),
+            ...(preview.connectivityCheck.status === 'failed'
+              ? [{ code: 'connectivityFailureOverrideConfirmed', expected: true }]
+              : []),
+          ],
+          run: async () => {
+            let configChange: ConfigChangeResult;
+            try {
+              configChange = await this.options.configChangeService.createStaticConfiguredServerTarget({
+                targetName: prepared.targetName,
+                serverConfig: prepared.config!,
+                operation: 'install',
+                backup: 'skip',
+                expectedConfigFingerprint: configFingerprint,
+              });
+            } catch {
+              throw new AdminConfiguredServerApplyError('configured_server_create_failed');
+            }
+            assertSuccessfulConfiguredServerCreate(configChange);
+            return {
+              targetName: prepared.targetName,
+              previewFingerprint: preview.previewFingerprint,
+              configChange,
+            };
+          },
+        };
+      },
+    });
+  }
 
   async listConfiguredServers(input: {
     context: AdminOperationContext;
@@ -672,6 +1274,83 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
       targetName: input.targetName,
       serverConfig: input.serverConfig,
     });
+  }
+
+  private async previewConfiguredServerCreateResult(
+    input: ConfiguredServerCreatePreviewInput,
+    forceConnectivity = false,
+    document: ConfiguredServerConfigDocument = this.options.readConfigDocument() ?? {},
+  ): Promise<ConfiguredServerCreatePreviewResult> {
+    const prepared = await this.resolveConfiguredServerCreate(input.draft, document);
+    const proposedReadModel = prepared.config
+      ? createConfiguredServerReadModel(
+          prepared.targetName,
+          mergeGlobalAndServerConfig(document.serverDefaults, prepared.config),
+        )
+      : undefined;
+    const validation = prepared.validation;
+    const diff = proposedReadModel ? createConfiguredServerCreateDiff(proposedReadModel, prepared.draft) : [];
+    const changed = validation.status === 'valid' && prepared.workflow.status === 'preview';
+    const connectivityCheck = prepared.config
+      ? await this.previewConnectivityCheck({
+          targetName: prepared.targetName,
+          serverConfig: prepared.config,
+          enabled: prepared.enabled,
+          validationStatus: validation.status,
+          connectionCriticalChanged: true,
+          force: forceConnectivity || input.connectivityCheck === 'manual',
+          endpointChangedWithPreservedSecrets: false,
+        })
+      : ({ status: 'skipped', reason: 'validation_failed' } as const);
+    const preview = {
+      targetName: prepared.targetName,
+      previewFingerprint: configuredServerCreatePreviewFingerprint({
+        configFingerprint: fingerprintConfiguredServerConfigDocument(document),
+        draft: prepared.draft,
+        proposed: proposedReadModel,
+        diff,
+        validation,
+        connectivityCheck,
+      }),
+      validation,
+      diff,
+      configChange: previewCreateConfigChange(prepared.targetName, prepared.workflow.status, changed),
+      connectivityCheck,
+      expectedReload: {
+        policy: 'observe_after_write' as const,
+        possibleStatuses: ['observed', 'runtime_not_running', 'reload_disabled', 'failed'] as const,
+      },
+    };
+    return preview;
+  }
+
+  private async resolveConfiguredServerCreate(
+    draftValue: unknown,
+    document: ConfiguredServerConfigDocument = this.options.readConfigDocument() ?? {},
+  ): Promise<PreparedConfiguredServerCreate> {
+    const normalized = normalizeConfiguredServerCreateDraft(draftValue);
+    const workflow = createServerInstallationWorkflow({
+      findConfiguredTarget: (targetName) => {
+        if (document.mcpTemplates?.[targetName]) return { name: targetName, source: 'mcpTemplates' };
+        if (document.mcpServers?.[targetName]) return { name: targetName, source: 'mcpServers' };
+        return null;
+      },
+    });
+    const workflowResult = await workflow.run({ mode: 'preview', source: normalized.source });
+    const config = workflowResult.config;
+    const validation = mergeValidation(
+      mergeValidation(normalized.validation, validateConfiguredServerCreateSecrets(normalized.draft)),
+      createWorkflowValidation(workflowResult, config),
+    );
+    return {
+      draft: normalized.draft,
+      source: normalized.source,
+      targetName: normalized.source.localName,
+      enabled: normalized.source.enabled !== false,
+      workflow: workflowResult,
+      config,
+      validation,
+    };
   }
 }
 

--- a/src/domains/config-change/configChange.test.ts
+++ b/src/domains/config-change/configChange.test.ts
@@ -7,7 +7,11 @@ import ConfigContext from '@src/config/configContext.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createConfigChangeService, fingerprintConfiguredServerTarget } from './configChange.js';
+import {
+  createConfigChangeService,
+  fingerprintConfiguredServerConfigDocument,
+  fingerprintConfiguredServerTarget,
+} from './configChange.js';
 
 const mockAgentConfig = {
   get: vi.fn().mockImplementation((key: string) => {
@@ -261,6 +265,105 @@ describe('Config Change', () => {
         },
       },
     });
+  });
+
+  it('creates a static configured target only when the name is absent', async () => {
+    await writeConfig({
+      mcpServers: { existing: { type: 'stdio', command: 'node' } },
+      mcpTemplates: { templated: { type: 'stdio', command: 'template' } },
+    });
+    const service = createConfigChangeService({ reloadConfig: reload });
+
+    const result = await service.createStaticConfiguredServerTarget({
+      targetName: 'custom',
+      serverConfig: { type: 'http', url: 'https://example.com/mcp' },
+      operation: 'install',
+    });
+
+    expect(result).toMatchObject({
+      status: 'changed',
+      operation: 'create_static',
+      target: { name: 'custom', source: 'mcpServers' },
+      changed: true,
+      backup: { created: false },
+      reload: { status: 'observed' },
+    });
+    expect(await readConfig()).toMatchObject({
+      mcpServers: {
+        existing: { type: 'stdio', command: 'node' },
+        custom: { type: 'http', url: 'https://example.com/mcp' },
+      },
+    });
+  });
+
+  it.each([
+    ['mcpServers', 'destination_conflict'],
+    ['mcpTemplates', 'template_conflict'],
+  ] as const)('atomically rejects create-only conflicts in %s', async (collection, status) => {
+    await writeConfig({
+      [collection]: { occupied: { type: 'stdio', command: 'original' } },
+    });
+    const service = createConfigChangeService({ reloadConfig: reload });
+
+    const result = await service.createStaticConfiguredServerTarget({
+      targetName: 'occupied',
+      serverConfig: { type: 'stdio', command: 'replacement' },
+      operation: 'install',
+    });
+
+    expect(result).toMatchObject({
+      status,
+      operation: 'create_static',
+      changed: false,
+      backup: { created: false },
+      reload: { status: 'skipped' },
+    });
+    expect(await readConfig()).toEqual({
+      [collection]: { occupied: { type: 'stdio', command: 'original' } },
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('rejects a create when the locked config revision differs from preview', async () => {
+    const previewed = { mcpServers: {}, unrelated: { revision: 1 } };
+    await writeConfig({ mcpServers: {}, unrelated: { revision: 2 } });
+    const service = createConfigChangeService({ reloadConfig: reload });
+
+    const result = await service.createStaticConfiguredServerTarget({
+      targetName: 'custom',
+      serverConfig: { type: 'stdio', command: 'node' },
+      expectedConfigFingerprint: fingerprintConfiguredServerConfigDocument(previewed),
+    });
+
+    expect(result).toMatchObject({
+      status: 'source_conflict',
+      operation: 'create_static',
+      changed: false,
+      backup: { created: false },
+      reload: { status: 'skipped' },
+    });
+    expect(await readConfig()).toEqual({ mcpServers: {}, unrelated: { revision: 2 } });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent create-only writers so exactly one can claim a name', async () => {
+    await writeConfig({ mcpServers: {} });
+    const service = createConfigChangeService({ reloadConfig: reload });
+
+    const results = await Promise.all([
+      service.createStaticConfiguredServerTarget({
+        targetName: 'custom',
+        serverConfig: { type: 'stdio', command: 'first' },
+      }),
+      service.createStaticConfiguredServerTarget({
+        targetName: 'custom',
+        serverConfig: { type: 'stdio', command: 'second' },
+      }),
+    ]);
+
+    expect(results.map((result) => result.status).sort()).toEqual(['changed', 'destination_conflict']);
+    expect(['first', 'second']).toContain((await readConfig()).mcpServers.custom.command);
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 
   it('creates a backup before replacing a static configured target when requested', async () => {

--- a/src/domains/config-change/configChange.ts
+++ b/src/domains/config-change/configChange.ts
@@ -32,6 +32,7 @@ import type {
   ConfigReloadResult,
   ConfigRetentionCleanupResult,
   ConfiguredServerTargetRef,
+  CreateStaticConfiguredServerTargetInput,
   EditConfiguredServerTargetInput,
   MutableConfigDocument,
   RemoveConfiguredServerTargetInput,
@@ -53,6 +54,7 @@ export type {
   ConfigRetentionCleanupResult,
   ConfiguredServerTargetRef,
   ConfiguredServerTargetSource,
+  CreateStaticConfiguredServerTargetInput,
   EditConfiguredServerTargetInput,
   RemoveConfiguredServerTargetInput,
   SetConfiguredServerTargetEnabledStateInput,
@@ -71,6 +73,16 @@ export function fingerprintConfiguredServerTarget(serverConfig: MCPServerParams)
 
 export function fingerprintConfiguredServerDefaults(serverDefaults: unknown): string {
   return `configured_server_defaults_${keyedConfiguredServerFingerprint('defaults', stableStringify(serverDefaults ?? {}))}`;
+}
+
+export function fingerprintConfiguredServerConfigDocument(config: unknown): string {
+  const record =
+    config && typeof config === 'object' && !Array.isArray(config) ? (config as Record<string, unknown>) : {};
+  const normalized = {
+    ...record,
+    mcpServers: record.mcpServers && typeof record.mcpServers === 'object' ? record.mcpServers : {},
+  };
+  return `configured_server_config_${keyedConfiguredServerFingerprint('config-document', stableStringify(normalized))}`;
 }
 
 export function fingerprintConfiguredServerSecretValue(value: string): string {
@@ -238,6 +250,93 @@ class DefaultConfigChangeService implements ConfigChangeService {
       ...resultWithoutReload,
       reload: this.reloadConfig(configPath),
     };
+  }
+
+  async createStaticConfiguredServerTarget(
+    input: CreateStaticConfiguredServerTargetInput,
+  ): Promise<ConfigChangeResult> {
+    const configPath = this.resolveConfigPath();
+    let releaseLock: ReleaseConfigLock;
+
+    try {
+      releaseLock = await acquireConfigLock(configPath, this.ports.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS);
+    } catch (error) {
+      if (error instanceof ConfigLockTimeoutError) {
+        return {
+          status: 'failed',
+          operation: 'create_static',
+          configPath,
+          target: { name: input.targetName },
+          changed: false,
+          backup: { created: false },
+          retentionCleanup: retentionSkipped(),
+          reload: { status: 'skipped' },
+          warnings: [],
+          error: error.message,
+        };
+      }
+      throw error;
+    }
+
+    let resultWithoutReload: ConfigChangeResult;
+    try {
+      const config = this.loadConfigForSet(configPath);
+      if (
+        input.expectedConfigFingerprint !== undefined &&
+        fingerprintConfiguredServerConfigDocument(config) !== input.expectedConfigFingerprint
+      ) {
+        return {
+          status: 'source_conflict',
+          operation: 'create_static',
+          configPath,
+          target: { name: input.targetName },
+          changed: false,
+          backup: { created: false },
+          retentionCleanup: retentionSkipped(),
+          reload: { status: 'skipped' },
+          warnings: [],
+          error: 'Configured server state changed after preview',
+        };
+      }
+      const target = resolveConfiguredServerTarget(config, input.targetName);
+      if (target.source) {
+        const templateConflict = target.source === 'mcpTemplates';
+        return {
+          status: templateConflict ? 'template_conflict' : 'destination_conflict',
+          operation: 'create_static',
+          configPath,
+          target,
+          changed: false,
+          backup: { created: false },
+          retentionCleanup: retentionSkipped(),
+          reload: { status: 'skipped' },
+          warnings: [],
+          error: `Configured server target '${input.targetName}' already exists`,
+        };
+      }
+
+      const backup = this.createBackupIfNeeded(configPath, input.backup ?? 'skip');
+      config.mcpServers = normalizeServerRecord(config.mcpServers);
+      config.mcpServers[input.targetName] = input.serverConfig;
+      this.validateConfig(configPath, config);
+      this.writeConfig(configPath, config);
+      const retentionCleanup = this.cleanupBackups(configPath, backup);
+      resultWithoutReload = {
+        status: 'changed',
+        operation: 'create_static',
+        configPath,
+        target: { name: input.targetName, source: 'mcpServers' },
+        changed: true,
+        backup,
+        retentionCleanup,
+        reload: { status: 'skipped' },
+        warnings: retentionCleanup.warnings,
+      };
+    } finally {
+      releaseLock();
+    }
+
+    return { ...resultWithoutReload, reload: this.reloadConfig(configPath) };
   }
 
   async setConfiguredServerTargetEnabledState(

--- a/src/domains/config-change/types.ts
+++ b/src/domains/config-change/types.ts
@@ -1,7 +1,7 @@
 import type { MCPServerParams } from '@src/core/types/index.js';
 
 export type ConfiguredServerTargetSource = 'mcpServers' | 'mcpTemplates';
-export type ConfigChangeOperation = 'remove' | 'set_static' | 'edit' | 'enable' | 'disable';
+export type ConfigChangeOperation = 'remove' | 'set_static' | 'create_static' | 'edit' | 'enable' | 'disable';
 export type ConfigChangeReason = 'install' | 'uninstall' | 'remove' | 'config_change' | 'enable' | 'disable';
 export type ConfigChangeStatus =
   'changed' | 'unchanged' | 'not_found' | 'template_conflict' | 'source_conflict' | 'destination_conflict' | 'failed';
@@ -56,6 +56,10 @@ export interface SetStaticConfiguredServerTargetInput {
   backup?: ConfigBackupPolicy;
 }
 
+export interface CreateStaticConfiguredServerTargetInput extends SetStaticConfiguredServerTargetInput {
+  expectedConfigFingerprint?: string;
+}
+
 export interface SetConfiguredServerTargetEnabledStateInput {
   targetName: string;
   enabled: boolean;
@@ -80,6 +84,7 @@ export interface ConfigChangePorts {
 export interface ConfigChangeService {
   removeConfiguredServerTarget(input: RemoveConfiguredServerTargetInput): Promise<ConfigChangeResult>;
   setStaticConfiguredServerTarget(input: SetStaticConfiguredServerTargetInput): Promise<ConfigChangeResult>;
+  createStaticConfiguredServerTarget(input: CreateStaticConfiguredServerTargetInput): Promise<ConfigChangeResult>;
   previewConfiguredServerTargetEnabledState(
     input: SetConfiguredServerTargetEnabledStateInput,
   ): Promise<ConfigChangeResult>;

--- a/src/domains/installation/serverInstallationSourceResolution.ts
+++ b/src/domains/installation/serverInstallationSourceResolution.ts
@@ -145,6 +145,8 @@ function createDirectServerConfig(source: DirectInstallationSource): MCPServerPa
   const common = {
     tags: source.tags,
     timeout: source.timeout,
+    connectionTimeout: source.connectionTimeout,
+    requestTimeout: source.requestTimeout,
     disabled: source.enabled === undefined ? undefined : !source.enabled,
   };
 

--- a/src/domains/installation/serverInstallationTypes.ts
+++ b/src/domains/installation/serverInstallationTypes.ts
@@ -40,6 +40,8 @@ export interface DirectInstallationSource {
   headers?: Record<string, string>;
   tags?: string[];
   timeout?: number;
+  connectionTimeout?: number;
+  requestTimeout?: number;
   enabled?: boolean;
   cwd?: string;
   autoRestart?: boolean;
@@ -96,6 +98,12 @@ export interface ServerInstallationWorkflowPorts {
   getRegistryServer?: (registryId: string, version?: string) => Promise<RegistryServer | null>;
   findConfiguredTarget?: (targetName: string) => ConfiguredServerTargetRef | null;
   applyConfigChange?: (input: {
+    targetName: string;
+    serverConfig: MCPServerParams;
+    operation: 'install';
+    backup: ConfigBackupPolicy;
+  }) => Promise<ConfigChangeResult>;
+  createConfigChange?: (input: {
     targetName: string;
     serverConfig: MCPServerParams;
     operation: 'install';

--- a/src/domains/installation/serverInstallationWorkflow.test.ts
+++ b/src/domains/installation/serverInstallationWorkflow.test.ts
@@ -22,6 +22,8 @@ describe('Server Installation Workflow', () => {
         args: ['server.js'],
         env: { NODE_ENV: 'test' },
         tags: ['local'],
+        connectionTimeout: 2_000,
+        requestTimeout: 5_000,
       },
     });
 
@@ -35,6 +37,8 @@ describe('Server Installation Workflow', () => {
         args: ['server.js'],
         env: { NODE_ENV: 'test' },
         tags: ['local'],
+        connectionTimeout: 2_000,
+        requestTimeout: 5_000,
       },
     });
     expect(result.configChange).toBeUndefined();
@@ -178,6 +182,67 @@ describe('Server Installation Workflow', () => {
       operation: 'install',
       backup: 'required',
     });
+  });
+
+  it('uses create-only Config Change for a non-force direct apply', async () => {
+    const createConfigChange = vi.fn().mockResolvedValue({
+      status: 'changed',
+      operation: 'create_static',
+      configPath: '/tmp/mcp.json',
+      target: { name: 'custom', source: 'mcpServers' },
+      changed: true,
+      backup: { created: false },
+      retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+      reload: { status: 'observed' },
+      warnings: [],
+    });
+    const applyConfigChange = vi.fn();
+    const workflow = createWorkflow({ createConfigChange, applyConfigChange });
+
+    const result = await workflow.run({
+      mode: 'apply',
+      source: {
+        type: 'direct',
+        localName: 'custom',
+        transport: 'http',
+        url: 'https://example.com/mcp',
+      },
+    });
+
+    expect(result).toMatchObject({ status: 'applied', targetName: 'custom' });
+    expect(createConfigChange).toHaveBeenCalledWith({
+      targetName: 'custom',
+      serverConfig: { type: 'http', url: 'https://example.com/mcp' },
+      operation: 'install',
+      backup: 'skip',
+    });
+    expect(applyConfigChange).not.toHaveBeenCalled();
+  });
+
+  it('reports an atomic create-only race as exists without falling back to replacement', async () => {
+    const applyConfigChange = vi.fn();
+    const workflow = createWorkflow({
+      applyConfigChange,
+      createConfigChange: vi.fn().mockResolvedValue({
+        status: 'destination_conflict',
+        operation: 'create_static',
+        configPath: '/tmp/mcp.json',
+        target: { name: 'custom', source: 'mcpServers' },
+        changed: false,
+        backup: { created: false },
+        retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+        reload: { status: 'skipped' },
+        warnings: [],
+      }),
+    });
+
+    const result = await workflow.run({
+      mode: 'apply',
+      source: { type: 'direct', localName: 'custom', transport: 'stdio', command: 'node' },
+    });
+
+    expect(result).toMatchObject({ status: 'exists', targetName: 'custom' });
+    expect(applyConfigChange).not.toHaveBeenCalled();
   });
 
   it('uses registry endpoint priority and result-only metadata', async () => {

--- a/src/domains/installation/serverInstallationWorkflow.ts
+++ b/src/domains/installation/serverInstallationWorkflow.ts
@@ -91,12 +91,15 @@ class DefaultServerInstallationWorkflow implements ServerInstallationWorkflow {
     }
 
     const backup = input.backup ?? (conflict?.source === 'mcpServers' ? 'required' : 'skip');
-    const configChange = await this.applyConfigChange({
+    const configChangeInput = {
       targetName: resolved.targetName,
       serverConfig: resolved.config,
-      operation: 'install',
+      operation: 'install' as const,
       backup,
-    });
+    };
+    const configChange = input.force
+      ? await this.applyConfigChange(configChangeInput)
+      : await this.createConfigChange(configChangeInput);
 
     if (configChange.status === 'changed') {
       return {
@@ -109,7 +112,12 @@ class DefaultServerInstallationWorkflow implements ServerInstallationWorkflow {
 
     return {
       ...resultFromResolved(input.mode, resolved),
-      status: configChange.status === 'template_conflict' ? 'template_conflict' : 'failed',
+      status:
+        configChange.status === 'template_conflict'
+          ? 'template_conflict'
+          : configChange.status === 'destination_conflict'
+            ? 'exists'
+            : 'failed',
       configChange,
       warnings: [...resolved.warnings, ...configChange.warnings],
       error: configChange.error ?? `Config Change returned ${configChange.status}`,
@@ -190,6 +198,19 @@ class DefaultServerInstallationWorkflow implements ServerInstallationWorkflow {
     }
 
     return createConfigChangeService().setStaticConfiguredServerTarget(input);
+  }
+
+  private createConfigChange(input: {
+    targetName: string;
+    serverConfig: MCPServerParams;
+    operation: 'install';
+    backup: ConfigBackupPolicy;
+  }): Promise<ConfigChangeResult> {
+    if (this.ports.createConfigChange) {
+      return this.ports.createConfigChange(input);
+    }
+
+    return createConfigChangeService().createStaticConfiguredServerTarget(input);
   }
 }
 

--- a/src/transport/http/routes/adminRoutes.test.ts
+++ b/src/transport/http/routes/adminRoutes.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { BackendOAuthDashboardResult, OAuthAuthorizationFlow } from '@src/auth/oauthAuthorizationFlow.js';
 import type { AdminBackendRestartOperations } from '@src/domains/admin/adminBackendRestartService.js';
 import {
+  AdminConfiguredServerApplyError,
   AdminConfiguredServerNotFoundError,
   type AdminConfiguredServerOperations,
   AdminConfiguredServerService,
@@ -47,6 +48,15 @@ describe('admin routes', () => {
   let oauthFlow: OAuthAuthorizationFlow;
   let storageDir: string;
   let configuredServerService: {
+    getConfiguredServerCreateContract: ReturnType<
+      typeof vi.fn<AdminConfiguredServerOperations['getConfiguredServerCreateContract']>
+    >;
+    previewConfiguredServerCreate: ReturnType<
+      typeof vi.fn<AdminConfiguredServerOperations['previewConfiguredServerCreate']>
+    >;
+    applyConfiguredServerCreate: ReturnType<
+      typeof vi.fn<AdminConfiguredServerOperations['applyConfiguredServerCreate']>
+    >;
     listConfiguredServers: ReturnType<typeof vi.fn<AdminConfiguredServerOperations['listConfiguredServers']>>;
     getConfiguredServerDetail: ReturnType<typeof vi.fn<AdminConfiguredServerOperations['getConfiguredServerDetail']>>;
     previewConfiguredServerEdit: ReturnType<
@@ -71,6 +81,9 @@ describe('admin routes', () => {
     });
     oauthFlow = createOAuthFlow();
     configuredServerService = {
+      getConfiguredServerCreateContract: vi.fn<AdminConfiguredServerOperations['getConfiguredServerCreateContract']>(),
+      previewConfiguredServerCreate: vi.fn<AdminConfiguredServerOperations['previewConfiguredServerCreate']>(),
+      applyConfiguredServerCreate: vi.fn<AdminConfiguredServerOperations['applyConfiguredServerCreate']>(),
       listConfiguredServers: vi.fn<AdminConfiguredServerOperations['listConfiguredServers']>(),
       getConfiguredServerDetail: vi.fn<AdminConfiguredServerOperations['getConfiguredServerDetail']>(),
       previewConfiguredServerEdit: vi.fn<AdminConfiguredServerOperations['previewConfiguredServerEdit']>(),
@@ -2228,7 +2241,7 @@ describe('admin routes', () => {
       ok: false,
       error: 'configured_server_stale_preview',
       code: 'configured_server_stale_preview',
-      message: 'The configured server changed after preview. Preview the edit again.',
+      message: 'The Runtime Scope configuration changed after preview. Preview the server again.',
     });
   });
 
@@ -2736,6 +2749,202 @@ describe('admin routes', () => {
       }),
       targetName: 'filesystem',
     });
+  });
+
+  it('serves configured-server create contract, preview, and confirmed apply through the agreed wire shape', async () => {
+    await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+    configuredServerService.getConfiguredServerCreateContract.mockResolvedValue({
+      ok: true,
+      status: 'completed',
+      operationId: 'op_contract',
+      operationName: 'getConfiguredServerCreateContract',
+      replayed: false,
+      result: {
+        schemaVersion: 1,
+        capabilities: {
+          create: { supported: true },
+          forceReplacement: { supported: false },
+          rawJson: { supported: false },
+          preview: { supported: true },
+          apply: { supported: true },
+        },
+        secretPolicy: {
+          allowedActions: ['replace'],
+          environmentReference: { recommended: true, storesSecretMaterial: false, guidance: 'Use an env reference.' },
+          inlineReplacement: { emphasis: 'secondary', guidance: 'Stored inline.' },
+        },
+        fieldGroups: [],
+      },
+    });
+    configuredServerService.previewConfiguredServerCreate.mockResolvedValue({
+      ok: true,
+      status: 'completed',
+      operationId: 'op_preview_create',
+      operationName: 'previewConfiguredServerCreate',
+      replayed: false,
+      result: {
+        targetName: 'custom',
+        previewFingerprint: 'preview_123',
+        validation: { status: 'valid', errors: [] },
+        diff: [],
+        configChange: {
+          status: 'changed',
+          operation: 'create_static',
+          configPath: '[redacted]',
+          target: { name: 'custom' },
+          changed: true,
+          backup: { created: false },
+          retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+          reload: { status: 'skipped' },
+          warnings: [],
+        },
+        connectivityCheck: { status: 'skipped', reason: 'local_stdio_transport' },
+        expectedReload: {
+          policy: 'observe_after_write',
+          possibleStatuses: ['observed', 'runtime_not_running', 'reload_disabled', 'failed'],
+        },
+      },
+    });
+    configuredServerService.applyConfiguredServerCreate.mockResolvedValue({
+      ok: true,
+      status: 'completed',
+      operationId: 'op_apply_create',
+      operationName: 'applyConfiguredServerCreate',
+      replayed: false,
+      result: {
+        targetName: 'custom',
+        previewFingerprint: 'preview_123',
+        configChange: {
+          status: 'changed',
+          operation: 'create_static',
+          configPath: '/tmp/mcp.json',
+          target: { name: 'custom', source: 'mcpServers' },
+          changed: true,
+          backup: { created: false },
+          retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+          reload: { status: 'failed', error: 'runtime reload was not observed' },
+          warnings: [],
+        },
+      },
+    });
+    const draft = { name: 'custom', enabled: true, transport: { type: 'stdio', command: 'node' } };
+    const app = mountAdminRoutes();
+    const loginResponse = await request(app)
+      .post('/admin/api/session/login')
+      .send({ username: 'operator', password: 'correct horse battery staple' });
+    const cookie = loginResponse.headers['set-cookie']?.[0] as string;
+    const csrfToken = loginResponse.body.csrfToken as string;
+
+    const contract = await request(app).get('/admin/api/configured-servers/create-contract').set('Cookie', cookie);
+    const preview = await request(app)
+      .post('/admin/api/configured-servers/create-preview')
+      .set('Cookie', cookie)
+      .set('X-CSRF-Token', csrfToken)
+      .send({ draft, connectivityCheck: 'auto' });
+    const rejected = await request(app)
+      .post('/admin/api/configured-servers')
+      .set('Cookie', cookie)
+      .set('X-CSRF-Token', csrfToken)
+      .send({ draft, previewFingerprint: 'preview_123', confirmationFacts: {} });
+    const applied = await request(app)
+      .post('/admin/api/configured-servers')
+      .set('Cookie', cookie)
+      .set('X-CSRF-Token', csrfToken)
+      .set('Idempotency-Key', 'create-custom')
+      .send({
+        draft,
+        previewFingerprint: 'preview_123',
+        confirmationFacts: {
+          previewConfirmed: 'preview_123',
+          targetNameConfirmed: 'custom',
+          connectionCriticalConfirmed: true,
+        },
+      });
+
+    expect(contract.status).toBe(200);
+    expect(contract.body).toMatchObject({ ok: true, operationId: 'op_contract', createContract: { schemaVersion: 1 } });
+    expect(preview.status).toBe(200);
+    expect(preview.body).toMatchObject({
+      ok: true,
+      operationId: 'op_preview_create',
+      preview: { targetName: 'custom' },
+    });
+    expect(rejected.status).toBe(400);
+    expect(applied.status).toBe(200);
+    expect(applied.body).toMatchObject({
+      ok: true,
+      operationId: 'op_apply_create',
+      result: { targetName: 'custom', configChange: { reload: { status: 'failed' } } },
+    });
+    expect(configuredServerService.applyConfiguredServerCreate).toHaveBeenCalledWith({
+      context: expect.objectContaining({
+        idempotencyKey: 'create-custom',
+        requestFingerprint: expect.stringMatching(/^configured_server_create_/u),
+        confirmationFacts: expect.objectContaining({ previewConfirmed: 'preview_123' }),
+      }),
+      draft,
+      previewFingerprint: 'preview_123',
+    });
+  });
+
+  it('maps stale or conflicting configured-server create apply to actionable non-secret 409 responses', async () => {
+    await adminService.bootstrapFirstAdmin({ username: 'operator', password: 'correct horse battery staple' });
+    configuredServerService.applyConfiguredServerCreate.mockRejectedValue(
+      new AdminConfiguredServerApplyError('configured_server_stale_preview'),
+    );
+    const app = mountAdminRoutes();
+    const loginResponse = await request(app)
+      .post('/admin/api/session/login')
+      .send({ username: 'operator', password: 'correct horse battery staple' });
+    const cookie = loginResponse.headers['set-cookie']?.[0] as string;
+
+    const response = await request(app)
+      .post('/admin/api/configured-servers')
+      .set('Cookie', cookie)
+      .set('X-CSRF-Token', loginResponse.body.csrfToken as string)
+      .set('Idempotency-Key', 'create-conflict')
+      .send({
+        draft: {
+          name: 'custom',
+          transport: { type: 'stdio', command: 'node' },
+          secrets: [
+            {
+              fieldPath: ['env', 'API_TOKEN'],
+              action: 'replace',
+              replacement: { kind: 'inlineSecret', value: 'secret-sentinel' },
+            },
+          ],
+        },
+        previewFingerprint: 'preview_old',
+        confirmationFacts: { previewConfirmed: 'preview_old' },
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({ ok: false, code: 'configured_server_stale_preview' });
+    expect(JSON.stringify(response.body)).not.toContain('secret-sentinel');
+
+    configuredServerService.applyConfiguredServerCreate.mockResolvedValueOnce({
+      ok: false,
+      status: 'mutation_failed',
+      code: 'mutation_failed',
+      retryable: false,
+      operationName: 'applyConfiguredServerCreate',
+      error: 'configured_server_create_failed',
+    });
+    const persistenceFailure = await request(app)
+      .post('/admin/api/configured-servers')
+      .set('Cookie', cookie)
+      .set('X-CSRF-Token', loginResponse.body.csrfToken as string)
+      .set('Idempotency-Key', 'create-persistence-failure')
+      .send({
+        draft: { name: 'custom', transport: { type: 'stdio', command: 'node' } },
+        previewFingerprint: 'preview_current',
+        confirmationFacts: { previewConfirmed: 'preview_current' },
+      });
+
+    expect(persistenceFailure.status).toBe(409);
+    expect(persistenceFailure.body).toMatchObject({ ok: false, code: 'configured_server_create_failed' });
+    expect(JSON.stringify(persistenceFailure.body)).not.toMatch(/secret|configPath|stack/iu);
   });
 
   it('bootstraps the first admin from environment only when no account exists', async () => {

--- a/src/transport/http/routes/adminRoutes.ts
+++ b/src/transport/http/routes/adminRoutes.ts
@@ -525,6 +525,18 @@ export function createAdminRoutes(options: AdminRoutesOptions): Router | null {
     });
   });
 
+  router.get('/api/configured-servers/create-contract', async (req, res) => {
+    await handleConfiguredServerCreateContract(req, res, options);
+  });
+
+  router.post('/api/configured-servers/create-preview', async (req, res) => {
+    await handleConfiguredServerCreatePreview(req, res, options);
+  });
+
+  router.post('/api/configured-servers', async (req, res) => {
+    await handleConfiguredServerCreateApply(req, res, options);
+  });
+
   router.get('/api/configured-servers/:name', async (req, res) => {
     await handleConfiguredServerDetail(req, res, options);
   });
@@ -983,6 +995,104 @@ async function handleConfiguredServerDetail(req: Request, res: Response, options
   }
 }
 
+async function handleConfiguredServerCreateContract(
+  req: Request,
+  res: Response,
+  options: AdminRoutesOptions,
+): Promise<void> {
+  if (!options.configuredServerService) {
+    res.status(404).json({ error: 'admin_configured_servers_unavailable' });
+    return;
+  }
+  const result = await options.configuredServerService.getConfiguredServerCreateContract({
+    context: buildAdminOperationContext(req, options, { type: 'configured_server_collection' }),
+  });
+  if (!result.ok) {
+    sendAdminOperationResult(res, result);
+    return;
+  }
+  res.status(200).json({ ok: true, operationId: result.operationId, createContract: result.result });
+}
+
+async function handleConfiguredServerCreatePreview(
+  req: Request,
+  res: Response,
+  options: AdminRoutesOptions,
+): Promise<void> {
+  if (!options.configuredServerService) {
+    res.status(404).json({ error: 'admin_configured_servers_unavailable' });
+    return;
+  }
+  const draft = getBodyValue(req.body, 'draft') ?? {};
+  const result = await options.configuredServerService.previewConfiguredServerCreate({
+    context: buildAdminOperationContext(req, options, {
+      type: 'configured_server',
+      id: configuredServerCreateDraftName(draft),
+    }),
+    draft,
+    connectivityCheck: getBodyString(req.body, 'connectivityCheck') === 'manual' ? 'manual' : 'auto',
+  });
+  if (!result.ok) {
+    sendAdminOperationResult(res, result);
+    return;
+  }
+  res.status(200).json({ ok: true, operationId: result.operationId, preview: result.result });
+}
+
+async function handleConfiguredServerCreateApply(
+  req: Request,
+  res: Response,
+  options: AdminRoutesOptions,
+): Promise<void> {
+  if (!options.configuredServerService) {
+    res.status(404).json({ error: 'admin_configured_servers_unavailable' });
+    return;
+  }
+  if (!req.header('Idempotency-Key')?.trim()) {
+    res.status(400).json({ ok: false, error: 'idempotency_key_required', code: 'idempotency_key_required' });
+    return;
+  }
+  if (isMutationLocked(options)) {
+    sendAdminOperationResult(res, {
+      ok: false,
+      status: 'runtime_scope_locked',
+      code: 'runtime_scope_locked',
+      retryable: true,
+      operationName: 'applyConfiguredServerCreate',
+      reason: 'writer_lock_unavailable',
+    });
+    return;
+  }
+  const draft = getBodyValue(req.body, 'draft') ?? {};
+  try {
+    const result = await options.configuredServerService.applyConfiguredServerCreate({
+      context: buildAdminOperationContext(req, options, {
+        type: 'configured_server',
+        id: configuredServerCreateDraftName(draft),
+      }),
+      draft,
+      previewFingerprint: getBodyString(req.body, 'previewFingerprint'),
+    });
+    if (!result.ok && result.status === 'mutation_failed' && isConfiguredServerApplyErrorCode(result.error)) {
+      sendConfiguredServerApplyError(res, result.error);
+      return;
+    }
+    sendAdminOperationResult(res, result);
+  } catch (error) {
+    if (error instanceof AdminConfiguredServerApplyError) {
+      sendConfiguredServerApplyError(res, error.code);
+      return;
+    }
+    throw error;
+  }
+}
+
+function configuredServerCreateDraftName(draft: unknown): string {
+  if (!draft || typeof draft !== 'object' || Array.isArray(draft)) return '';
+  const name = (draft as Record<string, unknown>).name;
+  return typeof name === 'string' ? name : '';
+}
+
 async function handleConfiguredServerPreview(req: Request, res: Response, options: AdminRoutesOptions): Promise<void> {
   if (!options.configuredServerService) {
     res.status(404).json({ error: 'admin_configured_servers_unavailable' });
@@ -1083,7 +1193,7 @@ function sendConfiguredServerApplyError(res: Response, code: string): void {
 function configuredServerApplyErrorMessage(code: string): string {
   switch (code) {
     case 'configured_server_stale_preview':
-      return 'The configured server changed after preview. Preview the edit again.';
+      return 'The Runtime Scope configuration changed after preview. Preview the server again.';
     case 'configured_server_destination_conflict':
       return 'The requested configured server target name is already in use.';
     case 'configured_server_connectivity_blocked':
@@ -1092,6 +1202,10 @@ function configuredServerApplyErrorMessage(code: string): string {
       return 'The configured server edit is invalid.';
     case 'configured_server_edit_unchanged':
       return 'The configured server edit does not contain any changes.';
+    case 'configured_server_create_invalid':
+      return 'The proposed configured server is invalid. Correct the fields and preview it again.';
+    case 'configured_server_create_failed':
+      return 'The configured server could not be persisted. Inspect the Runtime Scope configuration and retry with a new idempotency key.';
     case 'configured_server_not_found':
       return 'Configured server target was not found.';
     default:
@@ -1703,6 +1817,16 @@ function configuredServerRequestFingerprint(
           ),
         }
       : {}),
+    ...(operationName === 'applyConfiguredServerCreate'
+      ? {
+          previewFingerprint,
+          draftDigest: keyedRequestFingerprint(
+            previewFingerprint,
+            'configured-server-create-draft',
+            stableJsonStringify(getBodyValue(body, 'draft') ?? {}),
+          ),
+        }
+      : {}),
     ...(operationName === 'restartBackend'
       ? {
           restartSelection: {
@@ -1712,6 +1836,9 @@ function configuredServerRequestFingerprint(
         }
       : {}),
   });
+  if (operationName === 'applyConfiguredServerCreate') {
+    return `configured_server_create_${keyedRequestFingerprint(previewFingerprint, 'configured-server-create', normalized)}`;
+  }
   return operationName === 'applyConfiguredServerEdit'
     ? `configured_server_apply_${keyedRequestFingerprint(previewFingerprint, 'configured-server-apply', normalized)}`
     : normalized;
@@ -1818,6 +1945,15 @@ function operationNameForRequest(req: Request): string {
   }
   if (req.path.endsWith('/disable') || req.path.endsWith('/disable-server')) {
     return 'disableConfiguredServer';
+  }
+  if (req.path === '/api/configured-servers/create-preview') {
+    return 'previewConfiguredServerCreate';
+  }
+  if (req.method === 'POST' && req.path === '/api/configured-servers') {
+    return 'applyConfiguredServerCreate';
+  }
+  if (req.method === 'GET' && req.path === '/api/configured-servers/create-contract') {
+    return 'getConfiguredServerCreateContract';
   }
   if (req.path.endsWith('/preview')) {
     return 'previewConfiguredServerEdit';

--- a/test/e2e/admin-spa-browser-smoke.e2e.test.ts
+++ b/test/e2e/admin-spa-browser-smoke.e2e.test.ts
@@ -638,7 +638,17 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
               ],
             }
           : { status: 'valid' as const, errors: [] },
-        diff: exists ? [] : [{ fieldPath: ['name'], oldValue: undefined, newValue: name, riskFlags: [] }],
+        diff: exists
+          ? []
+          : [
+              { fieldPath: ['name'], oldValue: undefined, newValue: name, riskFlags: [] },
+              {
+                fieldPath: ['enabled'],
+                oldValue: undefined,
+                newValue: draft.enabled !== false,
+                riskFlags: ['connection_critical' as const],
+              },
+            ],
         configChange: {
           status: exists ? 'destination_conflict' : 'changed',
           operation: 'create_static',

--- a/test/e2e/admin-spa-browser-smoke.e2e.test.ts
+++ b/test/e2e/admin-spa-browser-smoke.e2e.test.ts
@@ -3,10 +3,11 @@ import { createServer, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import type {
-  AdminConfiguredServerOperations,
-  ConfiguredServerMutationResult,
-  ConfiguredServerReadModel,
+import {
+  AdminConfiguredServerApplyError,
+  type AdminConfiguredServerOperations,
+  type ConfiguredServerMutationResult,
+  type ConfiguredServerReadModel,
 } from '@src/domains/admin/adminConfiguredServerService.js';
 import { AdminIdentityService } from '@src/domains/admin/adminIdentityService.js';
 import type { AdminOperationResult } from '@src/domains/admin/adminOperationService.js';
@@ -240,6 +241,175 @@ describe('admin SPA browser smoke', () => {
     }
   });
 
+  it('configures all custom transport controls and creates a static server from the packaged console', async () => {
+    const page = await newPage({ width: 1280, height: 980 });
+    try {
+      await expectCenteredLoginGate(page);
+      await login(page, { skipNavigation: true });
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers`);
+      await page.getByRole('button', { name: 'Configure Custom Server' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers/new`);
+      expect(await page.getByLabel(/registry id|version|package metadata/i).count()).toBe(0);
+
+      const transport = page.getByLabel('Transport Type');
+      await expectVisible(page.getByLabel('Command'));
+      expect(await page.getByLabel('URL').count()).toBe(0);
+      await transport.selectOption('http');
+      await expectVisible(page.getByLabel('URL'));
+      expect(await page.getByLabel('Command').count()).toBe(0);
+      await transport.selectOption('sse');
+      await expectText(page, 'SSE is deprecated');
+      await expectVisible(page.getByLabel('URL'));
+      await transport.selectOption('stdio');
+
+      await page.getByLabel('Server Name').fill('custom server');
+      await page.getByLabel('Command').fill('node');
+      await page.getByRole('button', { name: 'Add secret' }).click();
+      await page.getByLabel('Environment variable').fill('API_TOKEN');
+      await page.getByLabel('Environment reference for API_TOKEN').fill('CUSTOM_SERVER_TOKEN');
+      expect(page.url()).not.toContain('CUSTOM_SERVER_TOKEN');
+      const browserPersistence = await page.evaluate(() => ({
+        history: JSON.stringify(globalThis.history.state),
+        local: Object.entries(globalThis.localStorage),
+        session: Object.entries(globalThis.sessionStorage),
+      }));
+      expect(JSON.stringify(browserPersistence)).not.toContain('CUSTOM_SERVER_TOKEN');
+
+      await page.getByRole('button', { name: 'Preview server' }).click();
+      await expectText(page, 'Preview only - no config has been written.');
+      await page.getByRole('button', { name: 'Create server' }).click();
+      const dialog = page.getByRole('dialog');
+      await expectVisible(dialog);
+      await expectVisible(dialog.getByText('Create configured server custom server?'));
+      const createResponsePromise = page.waitForResponse(
+        (response) =>
+          response.url().endsWith('/admin/api/configured-servers') && response.request().method() === 'POST',
+      );
+      await dialog.getByRole('button', { name: 'Create server' }).click();
+      const createResponse = await createResponsePromise;
+      expect(createResponse.status(), await createResponse.text()).toBe(200);
+
+      await page.waitForURL(`${baseUrl}/admin/servers/custom%20server`);
+      await expectVisible(page.getByRole('heading', { name: 'custom server', exact: true }));
+      await expectText(page, '3 configured targets');
+      expect(await page.locator('body').innerText()).not.toContain('CUSTOM_SERVER_TOKEN');
+      await expectNoPageOverflow(page);
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  it('keeps a name conflict in preview and never offers replacement', async () => {
+    const page = await newPage({ width: 1280, height: 900 });
+    try {
+      await expectCenteredLoginGate(page);
+      await login(page, { skipNavigation: true });
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.getByRole('button', { name: 'Configure Custom Server' }).click();
+      await page.getByLabel('Server Name').fill('github');
+      await page.getByLabel('Command').fill('node');
+      await page.getByRole('button', { name: 'Preview server' }).click();
+      await expectText(page, 'configured_server_destination_conflict');
+      expect(await page.getByRole('button', { name: /force|replace/i }).count()).toBe(0);
+      expect(await page.getByRole('button', { name: 'Create server' }).isDisabled()).toBe(true);
+      await page.getByRole('button', { name: 'Edit existing server' }).click();
+      await page.getByRole('dialog').getByRole('button', { name: 'Discard draft' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers/github`);
+      await expectVisible(page.getByRole('heading', { name: 'github', exact: true }));
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  it.each(['http', 'sse'] as const)('creates a remote %s target from its transport-specific controls', async (type) => {
+    const page = await newPage({ width: 1280, height: 900 });
+    try {
+      await expectCenteredLoginGate(page);
+      await login(page, { skipNavigation: true });
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.getByRole('button', { name: 'Configure Custom Server' }).click();
+      await page.getByLabel('Transport Type').selectOption(type);
+      await page.getByLabel('Server Name').fill(`remote-${type}`);
+      await page.getByLabel('URL').fill(`https://${type}.example/mcp`);
+      await page.getByRole('button', { name: 'Preview server' }).click();
+      await expectText(page, 'passed');
+      await page.getByRole('button', { name: 'Create server' }).click();
+      await page.getByRole('dialog').getByRole('button', { name: 'Create server' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers/remote-${type}`);
+      await expectVisible(page.getByRole('heading', { name: `remote-${type}`, exact: true }));
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  it('requires an explicit browser confirmation to override failed remote connectivity', async () => {
+    const page = await newPage({ width: 1280, height: 900 });
+    try {
+      await expectCenteredLoginGate(page);
+      await login(page, { skipNavigation: true });
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.getByRole('button', { name: 'Configure Custom Server' }).click();
+      await page.getByLabel('Transport Type').selectOption('http');
+      await page.getByLabel('Server Name').fill('connectivity-failure');
+      await page.getByLabel('URL').fill('https://unreachable.example/mcp');
+      await page.getByRole('button', { name: 'Preview server' }).click();
+      await expectText(page, 'Connection refused');
+      await page.getByRole('button', { name: 'Create server' }).click();
+      const dialog = page.getByRole('dialog');
+      await expectVisible(dialog.getByText('Create connectivity-failure despite failed connectivity?'));
+      await dialog.getByRole('button', { name: 'Create despite failure' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers/connectivity-failure`);
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  it.each([
+    { name: 'apply-failure', message: 'could not be persisted' },
+    { name: 'post-preview-conflict', message: 'already in use' },
+  ])('keeps $name actionable without adding the target', async ({ name, message }) => {
+    const page = await newPage({ width: 1280, height: 900 });
+    try {
+      await expectCenteredLoginGate(page);
+      await login(page, { skipNavigation: true });
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.getByRole('button', { name: 'Configure Custom Server' }).click();
+      await page.getByLabel('Server Name').fill(name);
+      await page.getByLabel('Command').fill('node');
+      await page.getByRole('button', { name: 'Preview server' }).click();
+      await page.getByRole('button', { name: 'Create server' }).click();
+      await page.getByRole('dialog').getByRole('button', { name: 'Create server' }).click();
+      await expectText(page, message);
+      await page.getByRole('button', { name: 'Back' }).click();
+      await page.getByRole('dialog').getByRole('button', { name: 'Discard draft' }).click();
+      await expectText(page, '2 configured targets');
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  it('shows a truthful reload warning after creation before opening detail', async () => {
+    const page = await newPage({ width: 1280, height: 900 });
+    try {
+      await expectCenteredLoginGate(page);
+      await login(page, { skipNavigation: true });
+      await page.getByRole('link', { name: 'Server inventory' }).click();
+      await page.getByRole('button', { name: 'Configure Custom Server' }).click();
+      await page.getByLabel('Server Name').fill('reload-failure');
+      await page.getByLabel('Command').fill('node');
+      await page.getByRole('button', { name: 'Preview server' }).click();
+      await page.getByRole('button', { name: 'Create server' }).click();
+      await page.getByRole('dialog').getByRole('button', { name: 'Create server' }).click();
+      await page.waitForURL(`${baseUrl}/admin/servers/reload-failure`);
+      await expectText(page, 'reload observation timed out');
+      await page.getByRole('button', { name: 'Open server detail' }).click();
+      await expectVisible(page.getByRole('heading', { name: 'reload-failure', exact: true }));
+    } finally {
+      await page.context().close();
+    }
+  });
+
   it.each([
     { width: 390, height: 844, compactInventory: true },
     { width: 800, height: 900, compactInventory: false },
@@ -419,6 +589,117 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
     reset() {
       servers = createConfiguredServerReadModels();
     },
+    async getConfiguredServerCreateContract() {
+      return operationSuccess('getConfiguredServerCreateContract', 'op_create_contract', {
+        schemaVersion: 1,
+        capabilities: {
+          create: { supported: true },
+          forceReplacement: { supported: false },
+          rawJson: { supported: false },
+          preview: { supported: true },
+          apply: { supported: true },
+        },
+        secretPolicy: {
+          allowedActions: ['replace'],
+          environmentReference: {
+            recommended: true,
+            storesSecretMaterial: false,
+            guidance: 'Keep secret material in the runtime environment.',
+          },
+          inlineReplacement: {
+            emphasis: 'secondary',
+            guidance: 'Use inline replacement only when an environment reference is unsuitable.',
+          },
+        },
+        fieldGroups: createFieldGroups(),
+      });
+    },
+    async previewConfiguredServerCreate(input) {
+      const draft = input.draft as {
+        name?: string;
+        enabled?: boolean;
+        tags?: string[];
+        transport?: Record<string, unknown>;
+      };
+      const name = draft.name ?? '';
+      const exists = servers.some((server) => server.id === name);
+      return operationSuccess('previewConfiguredServerCreate', 'op_create_preview', {
+        targetName: name,
+        previewFingerprint: `preview_create_${name}`,
+        validation: exists
+          ? {
+              status: 'invalid' as const,
+              errors: [
+                {
+                  fieldPath: ['name'],
+                  code: 'configured_server_destination_conflict',
+                  message: 'A configured target already uses this name.',
+                },
+              ],
+            }
+          : { status: 'valid' as const, errors: [] },
+        diff: exists ? [] : [{ fieldPath: ['name'], oldValue: undefined, newValue: name, riskFlags: [] }],
+        configChange: {
+          status: exists ? 'destination_conflict' : 'changed',
+          operation: 'create_static',
+          configPath: '[redacted]',
+          target: { name, source: 'mcpServers' },
+          changed: !exists,
+          backup: { created: false },
+          retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+          reload: { status: 'skipped' },
+          warnings: [],
+        },
+        connectivityCheck:
+          draft.transport?.type === 'stdio'
+            ? { status: 'skipped' as const, reason: 'local_stdio_transport' as const }
+            : String(draft.transport?.url).includes('unreachable')
+              ? { status: 'failed' as const, mode: 'bounded_dry_run' as const, message: 'Connection refused' }
+              : { status: 'passed' as const, mode: 'bounded_dry_run' as const },
+        expectedReload: {
+          policy: 'observe_after_write' as const,
+          possibleStatuses: ['observed', 'runtime_not_running', 'reload_disabled', 'failed'] as const,
+        },
+      });
+    },
+    async applyConfiguredServerCreate(input) {
+      const draft = input.draft as {
+        name?: string;
+        enabled?: boolean;
+        tags?: string[];
+        transport?: Record<string, unknown>;
+      };
+      const name = draft.name ?? 'custom';
+      if (name === 'apply-failure') {
+        throw new AdminConfiguredServerApplyError('configured_server_create_failed');
+      }
+      if (name === 'post-preview-conflict') {
+        throw new AdminConfiguredServerApplyError('configured_server_destination_conflict');
+      }
+      const type = String(draft.transport?.type ?? 'stdio');
+      const label = type === 'stdio' ? String(draft.transport?.command ?? '') : String(draft.transport?.url ?? '');
+      servers.push({
+        id: name,
+        source: 'mcpServers',
+        target: { type: 'configured_server', id: name, source: 'mcpServers' },
+        enabled: draft.enabled !== false,
+        tags: draft.tags ?? [],
+        transportSummary: { kind: type, label },
+        mutationAvailability: { available: true, operations: ['enable', 'disable'] },
+        actionState: actionState(name, draft.enabled !== false),
+        transport: { ...(draft.transport ?? {}) },
+        secretInputs: [],
+      });
+      const configChange = configChangeResult(name, true);
+      if (name === 'reload-failure') {
+        configChange.reload = { status: 'failed', error: 'reload observation timed out' };
+      }
+      return operationSuccess('applyConfiguredServerCreate', 'op_create_apply', {
+        targetName: name,
+        previewFingerprint: input.previewFingerprint,
+        configChange,
+      });
+    },
     async listConfiguredServers() {
       return operationSuccess('listConfiguredServers', 'op_list', { servers });
     },
@@ -531,6 +812,74 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
       ];
     },
   };
+}
+
+function createFieldGroups() {
+  return [
+    {
+      id: 'identity',
+      label: 'Identity',
+      fields: [
+        { fieldPath: ['name'], label: 'Server Name', control: 'text' as const, value: '', editable: true },
+        { fieldPath: ['enabled'], label: 'Enabled', control: 'switch' as const, value: true, editable: true },
+        { fieldPath: ['tags'], label: 'Tags', control: 'tag-list' as const, value: [], editable: true },
+      ],
+    },
+    {
+      id: 'transport',
+      label: 'Transport',
+      fields: [
+        {
+          fieldPath: ['transport', 'type'],
+          label: 'Transport Type',
+          control: 'select' as const,
+          value: 'stdio',
+          options: ['stdio', 'http', 'sse'],
+          editable: true,
+        },
+        {
+          fieldPath: ['transport', 'command'],
+          label: 'Command',
+          control: 'text' as const,
+          value: '',
+          editable: true,
+          applicableTransportTypes: ['stdio' as const],
+        },
+        {
+          fieldPath: ['transport', 'args'],
+          label: 'Args',
+          control: 'string-list' as const,
+          value: [],
+          editable: true,
+          applicableTransportTypes: ['stdio' as const],
+        },
+        {
+          fieldPath: ['transport', 'env'],
+          label: 'Environment',
+          control: 'record' as const,
+          value: {},
+          editable: true,
+          applicableTransportTypes: ['stdio' as const],
+        },
+        {
+          fieldPath: ['transport', 'url'],
+          label: 'URL',
+          control: 'text' as const,
+          value: '',
+          editable: true,
+          applicableTransportTypes: ['http' as const, 'sse' as const],
+        },
+        {
+          fieldPath: ['transport', 'headers'],
+          label: 'Headers',
+          control: 'record' as const,
+          value: {},
+          editable: true,
+          applicableTransportTypes: ['http' as const, 'sse' as const],
+        },
+      ],
+    },
+  ];
 }
 
 function createConfiguredServerReadModels(): ConfiguredServerReadModel[] {

--- a/web/admin/src/api/adminApi.test.ts
+++ b/web/admin/src/api/adminApi.test.ts
@@ -130,6 +130,55 @@ describe('admin API client', () => {
     });
   });
 
+  it('loads, previews, and confirms configured-server creation without a force flag', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const api = createAdminApi({
+      fetch: async (input, init) => {
+        calls.push({ input, init });
+        return jsonResponse({ ok: true, createContract: {}, preview: {}, result: {} });
+      },
+    });
+    const draft = {
+      name: 'custom',
+      enabled: true,
+      tags: ['local'],
+      transport: { type: 'stdio' as const, command: 'node', args: ['server.js'] },
+    };
+
+    await api.getConfiguredServerCreateContract();
+    await api.previewConfiguredServerCreate({ draft, connectivityCheck: 'auto', csrfToken: 'csrf_123' });
+    await api.createConfiguredServer({
+      draft,
+      previewFingerprint: 'preview_1',
+      confirmationFacts: { previewConfirmed: 'preview_1' },
+      idempotencyKey: 'create-key',
+      csrfToken: 'csrf_123',
+    });
+
+    expect(calls[0]).toMatchObject({ input: '/admin/api/configured-servers/create-contract' });
+    expect(calls[1]).toMatchObject({
+      input: '/admin/api/configured-servers/create-preview',
+      init: {
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-CSRF-Token': 'csrf_123' }),
+        body: JSON.stringify({ draft, connectivityCheck: 'auto' }),
+      },
+    });
+    expect(calls[2]).toMatchObject({
+      input: '/admin/api/configured-servers',
+      init: {
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-CSRF-Token': 'csrf_123', 'Idempotency-Key': 'create-key' }),
+        body: JSON.stringify({
+          draft,
+          previewFingerprint: 'preview_1',
+          confirmationFacts: { previewConfirmed: 'preview_1' },
+        }),
+      },
+    });
+    expect(calls[2].init?.body).not.toContain('force');
+  });
+
   it('authorizes and restarts full OAuth service ids with CSRF, unique idempotency, and redirect results', async () => {
     const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
     const api = createAdminApi({

--- a/web/admin/src/api/adminApi.ts
+++ b/web/admin/src/api/adminApi.ts
@@ -247,6 +247,39 @@ export interface ConfiguredServerEditContract {
   fieldGroups: ConfiguredServerEditFieldGroup[];
 }
 
+export type ConfiguredServerCreateTransport = 'stdio' | 'http' | 'sse';
+
+export interface ConfiguredServerCreateDraft {
+  name: string;
+  enabled: boolean;
+  tags: string[];
+  transport: Record<string, unknown> & { type: ConfiguredServerCreateTransport };
+  secrets?: Array<{
+    fieldPath: string[];
+    action: 'replace';
+    replacement: ConfiguredServerSecretReplacement;
+  }>;
+}
+
+export interface ConfiguredServerCreateContractResponse {
+  ok: true;
+  operationId: string;
+  createContract: {
+    schemaVersion: 1;
+    capabilities: {
+      create: { supported: true };
+      preview: { supported: true };
+      apply: { supported: boolean };
+    };
+    fieldGroups: ConfiguredServerEditFieldGroup[];
+    secretPolicy: {
+      allowedActions: ['replace'];
+      environmentReference: { recommended: true; storesSecretMaterial: false; guidance: string };
+      inlineReplacement: { emphasis: 'secondary'; guidance: string };
+    };
+  };
+}
+
 export interface ConfiguredServerDetailResponse {
   ok: true;
   operationId: string;
@@ -354,6 +387,28 @@ export interface ConfiguredServerApplyResponse {
   operationId: string;
   result: {
     originalTargetName: string;
+    targetName: string;
+    previewFingerprint: string;
+    configChange: ConfiguredServerPreviewConfigChange;
+  };
+}
+
+export interface ConfiguredServerCreatePreviewResponse {
+  ok: true;
+  operationId: string;
+  preview: Omit<ConfiguredServerPreviewResponse['preview'], 'proposedTargetName'> & {
+    proposedTargetName?: string;
+    expectedReload: {
+      policy: 'observe_after_write';
+      possibleStatuses: readonly ['observed', 'runtime_not_running', 'reload_disabled', 'failed'];
+    };
+  };
+}
+
+export interface ConfiguredServerCreateResponse {
+  ok: true;
+  operationId: string;
+  result: {
     targetName: string;
     previewFingerprint: string;
     configChange: ConfiguredServerPreviewConfigChange;
@@ -662,6 +717,46 @@ export function createAdminApi(options: AdminApiOptions = {}) {
       return response.servers ?? [];
     },
 
+    getConfiguredServerCreateContract(): Promise<ConfiguredServerCreateContractResponse> {
+      return request('/admin/api/configured-servers/create-contract');
+    },
+
+    previewConfiguredServerCreate(input: {
+      draft: ConfiguredServerCreateDraft;
+      csrfToken: string;
+      connectivityCheck?: 'auto' | 'manual';
+    }): Promise<ConfiguredServerCreatePreviewResponse> {
+      return request('/admin/api/configured-servers/create-preview', {
+        method: 'POST',
+        headers: { 'X-CSRF-Token': input.csrfToken },
+        body: JSON.stringify({
+          draft: input.draft,
+          ...(input.connectivityCheck ? { connectivityCheck: input.connectivityCheck } : {}),
+        }),
+      });
+    },
+
+    createConfiguredServer(input: {
+      draft: ConfiguredServerCreateDraft;
+      csrfToken: string;
+      idempotencyKey: string;
+      previewFingerprint: string;
+      confirmationFacts: Record<string, unknown>;
+    }): Promise<ConfiguredServerCreateResponse> {
+      return request('/admin/api/configured-servers', {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': input.csrfToken,
+          'Idempotency-Key': input.idempotencyKey,
+        },
+        body: JSON.stringify({
+          draft: input.draft,
+          previewFingerprint: input.previewFingerprint,
+          confirmationFacts: input.confirmationFacts,
+        }),
+      });
+    },
+
     getConfiguredServerDetail(name: string): Promise<ConfiguredServerDetailResponse> {
       return request(`/admin/api/configured-servers/${encodeURIComponent(name)}`);
     },
@@ -722,6 +817,10 @@ export function createAdminApi(options: AdminApiOptions = {}) {
 
 export function createConfiguredServerApplyIdempotencyKey(name: string): string {
   return `admin-console-server-apply-${encodeIdempotencyKeyPart(name)}-${Date.now()}-${crypto.getRandomValues(new Uint32Array(2)).join('-')}`;
+}
+
+export function createConfiguredServerCreateIdempotencyKey(name: string): string {
+  return `admin-console-server-create-${encodeIdempotencyKeyPart(name)}-${Date.now()}-${crypto.getRandomValues(new Uint32Array(2)).join('-')}`;
 }
 
 function defaultPresetIdempotencyKey(action: string, name: string): string {

--- a/web/admin/src/api/adminApi.ts
+++ b/web/admin/src/api/adminApi.ts
@@ -268,6 +268,8 @@ export interface ConfiguredServerCreateContractResponse {
     schemaVersion: 1;
     capabilities: {
       create: { supported: true };
+      forceReplacement: { supported: false };
+      rawJson: { supported: false };
       preview: { supported: true };
       apply: { supported: boolean };
     };

--- a/web/admin/src/components/AdminConsoleApp.fixtures.tsx
+++ b/web/admin/src/components/AdminConsoleApp.fixtures.tsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react';
 import { useReducer } from 'react';
 
 import type { ConfiguredServerReadModel } from '../api/adminApi';
+import { createConfiguredServerCreateState } from '../configuredServerCreate/configuredServerCreateState';
+import type { ConfiguredServerCreateModel } from '../configuredServerCreate/useConfiguredServerCreate';
 import {
   type ConfiguredServerEditState,
   createConfiguredServerEditState,
@@ -16,6 +18,7 @@ import { createInitialState } from '../state/adminConsoleState';
 import { AdminConsoleApp } from './AdminConsoleApp';
 
 interface ConfiguredServerOverrides {
+  create?: ConfiguredServerCreateModel;
   editor?: ConfiguredServerEditState;
   mutate?: AdminConsoleSessionModel['configuredServers']['mutate'];
   open?: ConfiguredServerEditModel['open'];
@@ -81,6 +84,7 @@ export function fixtureSession(
       navigate: overrides.navigation?.navigate ?? (() => undefined),
     },
     configuredServers: {
+      create: overrides.configuredServers?.create ?? staticConfiguredServerCreateModel(),
       edit,
       mutate: overrides.configuredServers?.mutate ?? (() => undefined),
       copy: overrides.configuredServers?.copy ?? (() => undefined),
@@ -116,6 +120,21 @@ export function fixtureSession(
       save: overrides.presets?.save ?? (() => true),
       delete: overrides.presets?.delete ?? (() => undefined),
     },
+  };
+}
+
+function staticConfiguredServerCreateModel(): ConfiguredServerCreateModel {
+  return {
+    state: createConfiguredServerCreateState(),
+    open: () => undefined,
+    close: async () => true,
+    editExisting: () => undefined,
+    changeField: () => undefined,
+    addSecret: () => undefined,
+    changeSecret: () => undefined,
+    removeSecret: () => undefined,
+    preview: () => undefined,
+    apply: () => undefined,
   };
 }
 

--- a/web/admin/src/components/AdminConsoleApp.test.tsx
+++ b/web/admin/src/components/AdminConsoleApp.test.tsx
@@ -18,12 +18,43 @@ describe('AdminConsoleApp', () => {
         connection: 'active',
         selectedSourceId: 'static:filesystem',
         sources: [
-          { id: 'static:filesystem', canonicalName: 'filesystem', displayName: 'filesystem', kind: 'static', capture: 'managed', lifecycle: 'active' },
-          { id: 'static:manual', canonicalName: 'manual', displayName: 'manual', kind: 'static', capture: 'not-captured', lifecycle: 'active' },
-          { id: 'template:0123456789abcdef', canonicalName: '0123456789abcdef', displayName: 'search (0123456789ab)', kind: 'template', capture: 'managed', lifecycle: 'ended' },
+          {
+            id: 'static:filesystem',
+            canonicalName: 'filesystem',
+            displayName: 'filesystem',
+            kind: 'static',
+            capture: 'managed',
+            lifecycle: 'active',
+          },
+          {
+            id: 'static:manual',
+            canonicalName: 'manual',
+            displayName: 'manual',
+            kind: 'static',
+            capture: 'not-captured',
+            lifecycle: 'active',
+          },
+          {
+            id: 'template:0123456789abcdef',
+            canonicalName: '0123456789abcdef',
+            displayName: 'search (0123456789ab)',
+            kind: 'template',
+            capture: 'managed',
+            lifecycle: 'ended',
+          },
         ],
         entries: [
-          { sequence: 7, timestamp: '2026-08-02T00:00:00.000Z', sourceId: 'static:filesystem', canonicalName: 'filesystem', displayName: 'filesystem', sourceKind: 'static', kind: 'line', content: '<script>window.injected=true</script>', truncated: false },
+          {
+            sequence: 7,
+            timestamp: '2026-08-02T00:00:00.000Z',
+            sourceId: 'static:filesystem',
+            canonicalName: 'filesystem',
+            displayName: 'filesystem',
+            sourceKind: 'static',
+            kind: 'line',
+            content: '<script>window.injected=true</script>',
+            truncated: false,
+          },
         ],
         unread: { 'template:0123456789abcdef': 2 },
         cursors: { 'static:filesystem': 7 },
@@ -48,7 +79,14 @@ describe('AdminConsoleApp', () => {
         connection: 'active',
         selectedSourceId: 'static:filesystem',
         sources: [
-          { id: 'static:filesystem', canonicalName: 'filesystem', displayName: 'filesystem', kind: 'static', capture: 'managed', lifecycle: 'active' },
+          {
+            id: 'static:filesystem',
+            canonicalName: 'filesystem',
+            displayName: 'filesystem',
+            kind: 'static',
+            capture: 'managed',
+            lifecycle: 'active',
+          },
         ],
         selectionError: 'Failed to load retained backend logs. Live entries will continue to appear.',
       },
@@ -131,6 +169,26 @@ describe('AdminConsoleApp', () => {
 
     await user.click(screen.getByRole('button', { name: /copy runtime scope/i }));
     expect(onCopyText).toHaveBeenCalledWith('runtimeScopeId', 'scope_123');
+  });
+
+  it('keeps custom server creation available when the inventory is empty', async () => {
+    const open = vi.fn();
+    const state = { ...consoleState(), configuredServers: [] };
+    const create = {
+      state: { status: 'idle' as const },
+      open,
+      close: async () => true,
+      changeField: vi.fn(),
+      addSecret: vi.fn(),
+      changeSecret: vi.fn(),
+      removeSecret: vi.fn(),
+      preview: vi.fn(),
+      apply: vi.fn(),
+    };
+    renderApp(state, { navigation: { route: 'servers' }, configuredServers: { create } });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Configure Custom Server' }));
+    expect(open).toHaveBeenCalledOnce();
   });
 
   it('renders the full inventory and editor only in the servers workspace', async () => {

--- a/web/admin/src/components/ConfiguredServersPanel.tsx
+++ b/web/admin/src/components/ConfiguredServersPanel.tsx
@@ -1,7 +1,7 @@
 import { Badge, Button, Group, SegmentedControl, Table, Text, TextInput } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 
-import { Pencil, Search, ServerCog } from 'lucide-react';
+import { Pencil, Plus, Search, ServerCog } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import type { ConfiguredServerReadModel } from '../api/adminApi';
@@ -22,10 +22,12 @@ export function ConfiguredServersPanel({
   state,
   onServerAction,
   onOpenServerDetail,
+  onConfigureCustomServer,
 }: {
   state: AdminConsoleState;
   onServerAction?: (serverId: string, action: 'enable' | 'disable') => void | Promise<void>;
   onOpenServerDetail?: (serverId: string) => void | Promise<void>;
+  onConfigureCustomServer?: () => void | Promise<void>;
 }) {
   const [query, setQuery] = useState('');
   const [filter, setFilter] = useState<ServerFilter>('all');
@@ -60,6 +62,9 @@ export function ConfiguredServersPanel({
             { label: 'Disabled', value: 'disabled' },
           ]}
         />
+        <Button leftSection={<Plus size={16} />} onClick={() => void onConfigureCustomServer?.()}>
+          Configure Custom Server
+        </Button>
       </Group>
       {servers.length === 0 ? (
         <EmptyState message="No servers match the current filter." />

--- a/web/admin/src/components/adminConsoleUtils.ts
+++ b/web/admin/src/components/adminConsoleUtils.ts
@@ -1,4 +1,5 @@
 import type {
+  ConfiguredServerCreatePreviewResponse,
   ConfiguredServerPreviewResponse,
   ConfiguredServerReadModel,
   OAuthServiceStatus,
@@ -67,7 +68,9 @@ export function serverActionState(server: ConfiguredServerReadModel, action: 'en
   );
 }
 
-export function connectivityMeta(preview: ConfiguredServerPreviewResponse['preview']): string | undefined {
+export function connectivityMeta(
+  preview: ConfiguredServerPreviewResponse['preview'] | ConfiguredServerCreatePreviewResponse['preview'],
+): string | undefined {
   const check = preview.connectivityCheck;
   if (check.status === 'skipped') {
     return connectivitySkipReason(check.reason);

--- a/web/admin/src/components/configuredServerCreator/ConfiguredServerCreator.test.tsx
+++ b/web/admin/src/components/configuredServerCreator/ConfiguredServerCreator.test.tsx
@@ -1,0 +1,75 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useReducer } from 'react';
+
+import { configuredServerCreateContract } from '../../configuredServerCreate/configuredServerCreate.fixtures';
+import {
+  createConfiguredServerCreateState,
+  reduceConfiguredServerCreateState,
+} from '../../configuredServerCreate/configuredServerCreateState';
+import type { ConfiguredServerCreateModel } from '../../configuredServerCreate/useConfiguredServerCreate';
+import { ConfiguredServerCreator } from './ConfiguredServerCreator';
+
+function CreatorHarness() {
+  const [state, dispatch] = useReducer(
+    reduceConfiguredServerCreateState,
+    createConfiguredServerCreateState(),
+    (initial) =>
+      reduceConfiguredServerCreateState(initial, {
+        type: 'contractLoaded',
+        contract: configuredServerCreateContract(),
+      }),
+  );
+  const model: ConfiguredServerCreateModel = {
+    state,
+    open: () => undefined,
+    close: async () => true,
+    editExisting: () => undefined,
+    changeField: (fieldPath, value) => dispatch({ type: 'fieldChanged', fieldPath, value }),
+    addSecret: (secret) => dispatch({ type: 'secretAdded', secret }),
+    changeSecret: (secret) => dispatch({ type: 'secretChanged', secret }),
+    removeSecret: (id) => dispatch({ type: 'secretRemoved', id }),
+    preview: () => undefined,
+    apply: () => undefined,
+  };
+  return <ConfiguredServerCreator model={model} />;
+}
+
+describe('ConfiguredServerCreator', () => {
+  it('switches structured controls across stdio, HTTP, and legacy SSE', async () => {
+    const user = userEvent.setup();
+    render(
+      <MantineProvider>
+        <CreatorHarness />
+      </MantineProvider>,
+    );
+
+    expect(screen.getByLabelText('Command')).toBeInTheDocument();
+    expect(screen.queryByLabelText('URL')).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Transport Type'), 'http');
+    expect(screen.getByLabelText('URL')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Command')).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Transport Type'), 'sse');
+    expect(screen.getByText(/SSE is deprecated/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('URL')).toBeInTheDocument();
+  });
+
+  it('defaults dynamic secrets to environment references and keeps inline entry secondary', async () => {
+    const user = userEvent.setup();
+    render(
+      <MantineProvider>
+        <CreatorHarness />
+      </MantineProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add secret' }));
+    expect(screen.getByLabelText('Secret source')).toHaveValue('environmentReference');
+    await user.type(screen.getByLabelText('Environment variable'), 'API_TOKEN');
+    expect(screen.getByLabelText(/Environment reference for API_TOKEN/i)).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Secret source'), 'inlineSecret');
+    expect(screen.getByText(/stores secret material in configuration/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Inline secret for API_TOKEN/i)).toHaveAttribute('type', 'password');
+  });
+});

--- a/web/admin/src/components/configuredServerCreator/ConfiguredServerCreator.tsx
+++ b/web/admin/src/components/configuredServerCreator/ConfiguredServerCreator.tsx
@@ -133,7 +133,10 @@ export function ConfiguredServerCreator({ model }: { model: ConfiguredServerCrea
         <DynamicSecrets
           transport={selectedTransport}
           secrets={state.secrets}
-          inlineSupported
+          inlineSupported={
+            Boolean(state.contract.createContract.secretPolicy.inlineReplacement) &&
+            state.contract.createContract.secretPolicy.allowedActions.includes('replace')
+          }
           onAdd={model.addSecret}
           onChange={model.changeSecret}
           onRemove={model.removeSecret}

--- a/web/admin/src/components/configuredServerCreator/ConfiguredServerCreator.tsx
+++ b/web/admin/src/components/configuredServerCreator/ConfiguredServerCreator.tsx
@@ -1,0 +1,326 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Group,
+  NativeSelect,
+  Paper,
+  PasswordInput,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+
+import { Pencil, Plus, ServerCog, ShieldCheck, Trash2 } from 'lucide-react';
+
+import type { ConfiguredServerCreateSecretDraft } from '../../configuredServerCreate/configuredServerCreateState';
+import {
+  configuredServerCreateApplyEligibility,
+  type ConfiguredServerCreateModel,
+} from '../../configuredServerCreate/useConfiguredServerCreate';
+import { fieldAppliesToTransport, fieldKey } from '../../configuredServerEdit/configuredServerEditDraft';
+import { EmptyState, Panel } from '../AdminConsoleShared';
+import { ConfiguredServerFieldDraft, editGroupHelp } from '../configuredServerEditor/EditControls';
+import { PreviewResult } from '../configuredServerEditor/PreviewResult';
+
+export function ConfiguredServerCreator({ model }: { model: ConfiguredServerCreateModel }) {
+  const { state } = model;
+  if (state.status === 'idle') return null;
+  if (state.status === 'loading') {
+    return (
+      <Panel title="Configure custom server" utility="loading" icon={<ServerCog size={17} />}>
+        <EmptyState message="Loading creation controls." />
+      </Panel>
+    );
+  }
+  if (state.status === 'failed') {
+    return (
+      <Panel title="Configure custom server" utility="unavailable" icon={<ServerCog size={17} />}>
+        <Stack gap="sm">
+          <Alert color="red" role="alert">
+            {state.message}
+          </Alert>
+          <Group>
+            <Button onClick={() => void model.open()}>Retry loading</Button>
+            <Button variant="default" onClick={() => void model.close()}>
+              Back to servers
+            </Button>
+          </Group>
+        </Stack>
+      </Panel>
+    );
+  }
+  if (state.status === 'committed') {
+    return (
+      <Panel title="Configured server created" utility={state.serverId} icon={<ShieldCheck size={17} />}>
+        <Stack gap="sm">
+          <Alert color="teal" role="status">
+            Created {state.serverId}.
+          </Alert>
+          {state.warning ? <Alert color="yellow">{state.warning}</Alert> : null}
+          <Text c="dimmed" size="sm">
+            Refreshing the inventory and opening the created target.
+          </Text>
+          <Button onClick={() => void model.close(`/admin/servers/${encodeURIComponent(state.serverId)}`)}>
+            Open server detail
+          </Button>
+        </Stack>
+      </Panel>
+    );
+  }
+
+  const transportType = state.fieldDraft[fieldKey(['transport', 'type'])];
+  const selectedTransport = transportType === 'http' || transportType === 'sse' ? transportType : 'stdio';
+  const groups = state.contract.createContract.fieldGroups
+    .map((group) => ({
+      ...group,
+      fields: group.fields.filter((field) => fieldAppliesToTransport(field, selectedTransport)),
+    }))
+    .filter((group) => group.fields.length > 0);
+  const eligibility = configuredServerCreateApplyEligibility(state);
+  const staticNameConflict =
+    state.preview?.configChange.target.source === 'mcpServers' &&
+    state.preview.validation.errors.some((error) =>
+      ['configured_server_name_conflict', 'configured_server_destination_conflict'].includes(error.code),
+    );
+
+  return (
+    <Panel title="Configure custom server" utility="new static target" icon={<Plus size={17} />}>
+      <Stack gap="sm">
+        <Group justify="space-between" align="flex-start">
+          <div>
+            <Text className="eyebrow" size="xs">
+              Configured Server Target
+            </Text>
+            <Title order={2}>New custom server</Title>
+            <Text c="dimmed" size="sm">
+              Configure -&gt; Preview -&gt; Confirm creation
+            </Text>
+          </div>
+          <Button variant="default" onClick={() => void model.close()}>
+            Back
+          </Button>
+        </Group>
+        {selectedTransport === 'sse' ? (
+          <Alert color="yellow" title="Legacy transport">
+            SSE is deprecated. Use HTTP for new remote servers when the endpoint supports it.
+          </Alert>
+        ) : null}
+        {groups.map((group) => (
+          <Paper key={group.id} className="edit-section" withBorder>
+            <Stack gap="xs">
+              <Group justify="space-between" align="flex-start">
+                <div>
+                  <Text fw={800}>{group.label}</Text>
+                  <Text c="dimmed" size="xs">
+                    {editGroupHelp(group.id)}
+                  </Text>
+                </div>
+                <Badge variant="outline">{group.fields.length} fields</Badge>
+              </Group>
+              {group.fields.map((field) => (
+                <ConfiguredServerFieldDraft
+                  key={fieldKey(field.fieldPath)}
+                  field={field}
+                  value={state.fieldDraft[fieldKey(field.fieldPath)]}
+                  onChange={(value) => model.changeField(field.fieldPath, value)}
+                />
+              ))}
+            </Stack>
+          </Paper>
+        ))}
+        <DynamicSecrets
+          transport={selectedTransport}
+          secrets={state.secrets}
+          inlineSupported
+          onAdd={model.addSecret}
+          onChange={model.changeSecret}
+          onRemove={model.removeSecret}
+        />
+        <Group className="draft-action-bar" justify="space-between" gap="sm">
+          <div>
+            <Badge color={state.dirty ? 'yellow' : 'gray'} variant={state.dirty ? 'light' : 'outline'}>
+              {state.dirty ? 'Unpreviewed draft' : 'Complete the server details'}
+            </Badge>
+            <Text c="dimmed" size="xs">
+              Preview validates the new target without writing configuration.
+            </Text>
+          </div>
+          <Group gap="xs">
+            <Button
+              loading={state.previewBusy}
+              disabled={!state.dirty || state.previewBusy || state.applyBusy}
+              onClick={() => void model.preview('auto')}
+            >
+              Preview server
+            </Button>
+            {state.preview ? (
+              <Button variant="default" disabled={state.applyBusy} onClick={() => void model.preview('manual')}>
+                Rerun connectivity
+              </Button>
+            ) : null}
+          </Group>
+        </Group>
+        {state.previewError ? (
+          <Alert color="red" role="alert">
+            {state.previewError}
+          </Alert>
+        ) : null}
+        {state.applyError ? (
+          <Alert color="red" role="alert">
+            {state.applyError}
+          </Alert>
+        ) : null}
+        {state.preview ? (
+          <>
+            <PreviewResult preview={state.preview} />
+            <Group justify="flex-end" align="center">
+              {staticNameConflict ? (
+                <Button
+                  leftSection={<Pencil size={16} />}
+                  variant="default"
+                  onClick={() => void model.editExisting(state.preview?.targetName ?? '')}
+                >
+                  Edit existing server
+                </Button>
+              ) : null}
+              {!eligibility.eligible ? (
+                <Text c="dimmed" size="sm">
+                  {eligibility.reason}
+                </Text>
+              ) : null}
+              <Button
+                leftSection={<ShieldCheck size={16} />}
+                loading={state.applyBusy}
+                disabled={!eligibility.eligible || state.applyBusy}
+                onClick={() => void model.apply()}
+              >
+                Create server
+              </Button>
+            </Group>
+          </>
+        ) : null}
+      </Stack>
+    </Panel>
+  );
+}
+
+function DynamicSecrets({
+  transport,
+  secrets,
+  inlineSupported,
+  onAdd,
+  onChange,
+  onRemove,
+}: {
+  transport: 'stdio' | 'http' | 'sse';
+  secrets: ConfiguredServerCreateSecretDraft[];
+  inlineSupported: boolean;
+  onAdd(secret: ConfiguredServerCreateSecretDraft): void;
+  onChange(secret: ConfiguredServerCreateSecretDraft): void;
+  onRemove(id: string): void;
+}) {
+  const container = transport === 'stdio' ? 'env' : 'headers';
+  const visible = secrets.filter((secret) => secret.container === container);
+  const label = container === 'env' ? 'Environment secrets' : 'Header secrets';
+  return (
+    <Paper className="edit-section" withBorder>
+      <Stack gap="xs">
+        <Group justify="space-between">
+          <div>
+            <Text fw={800}>{label}</Text>
+            <Text c="dimmed" size="xs">
+              Environment Secret Reference is recommended. Only the reference is stored in configuration.
+            </Text>
+          </div>
+          <Button
+            size="compact-sm"
+            variant="default"
+            leftSection={<Plus size={14} />}
+            onClick={() =>
+              onAdd({
+                id: createSecretId(),
+                container,
+                key: '',
+                replacementKind: 'environmentReference',
+                replacementValue: '',
+              })
+            }
+          >
+            Add secret
+          </Button>
+        </Group>
+        {visible.length === 0 ? (
+          <Text c="dimmed" size="sm">
+            No secret inputs configured.
+          </Text>
+        ) : (
+          visible.map((secret) => (
+            <Paper key={secret.id} className="secret-editor" withBorder>
+              <Stack gap="xs">
+                <Group align="flex-end" wrap="nowrap">
+                  <TextInput
+                    label={container === 'env' ? 'Environment variable' : 'Header name'}
+                    value={secret.key}
+                    onChange={(event) => onChange({ ...secret, key: event.currentTarget.value })}
+                  />
+                  <NativeSelect
+                    label="Secret source"
+                    value={secret.replacementKind}
+                    data={[
+                      { value: 'environmentReference', label: 'Environment Secret Reference' },
+                      ...(inlineSupported ? [{ value: 'inlineSecret', label: 'Advanced inline secret' }] : []),
+                    ]}
+                    onChange={(event) =>
+                      onChange({
+                        ...secret,
+                        replacementKind: event.currentTarget
+                          .value as ConfiguredServerCreateSecretDraft['replacementKind'],
+                        replacementValue: '',
+                      })
+                    }
+                  />
+                  <Button
+                    aria-label={`Remove ${secret.key || 'secret'} input`}
+                    variant="subtle"
+                    color="red"
+                    onClick={() => onRemove(secret.id)}
+                  >
+                    <Trash2 size={16} />
+                  </Button>
+                </Group>
+                {secret.replacementKind === 'environmentReference' ? (
+                  <TextInput
+                    label={`Environment reference for ${secret.key || label}`}
+                    placeholder="MY_SECRET or ${MY_SECRET}"
+                    value={secret.replacementValue}
+                    onChange={(event) => onChange({ ...secret, replacementValue: event.currentTarget.value })}
+                  />
+                ) : (
+                  <>
+                    <Alert color="yellow">
+                      Advanced path: inline replacement stores secret material in configuration. Prefer an Environment
+                      Secret Reference.
+                    </Alert>
+                    <PasswordInput
+                      label={`Inline secret for ${secret.key || label}`}
+                      value={secret.replacementValue}
+                      onChange={(event) => onChange({ ...secret, replacementValue: event.currentTarget.value })}
+                    />
+                  </>
+                )}
+              </Stack>
+            </Paper>
+          ))
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+let secretSequence = 0;
+function createSecretId(): string {
+  secretSequence += 1;
+  return `create-secret-${secretSequence}`;
+}

--- a/web/admin/src/components/configuredServerCreator/index.ts
+++ b/web/admin/src/components/configuredServerCreator/index.ts
@@ -1,0 +1,1 @@
+export { ConfiguredServerCreator } from './ConfiguredServerCreator';

--- a/web/admin/src/components/configuredServerEditor/PreviewResult.tsx
+++ b/web/admin/src/components/configuredServerEditor/PreviewResult.tsx
@@ -1,11 +1,15 @@
 import { Alert, Badge, Code, Group, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
 
-import type { ConfiguredServerPreviewResponse } from '../../api/adminApi';
+import type { ConfiguredServerCreatePreviewResponse, ConfiguredServerPreviewResponse } from '../../api/adminApi';
 import { fieldKey, formatPreviewValue } from '../../configuredServerEdit/configuredServerEditDraft';
 import { DetailRow } from '../AdminConsoleShared';
 import { connectivityMeta, connectivitySummary, riskFlagColor, riskFlagLabel } from '../adminConsoleUtils';
 
-export function PreviewResult({ preview }: { preview: ConfiguredServerPreviewResponse['preview'] }) {
+export function PreviewResult({
+  preview,
+}: {
+  preview: ConfiguredServerPreviewResponse['preview'] | ConfiguredServerCreatePreviewResponse['preview'];
+}) {
   const connectivity = preview.connectivityCheck;
   const validationTone = preview.validation.status === 'valid' ? 'teal' : 'red';
   const connectivityTone =
@@ -27,7 +31,11 @@ export function PreviewResult({ preview }: { preview: ConfiguredServerPreviewRes
           Preview only - no config has been written.
         </Alert>
         <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
-          <DetailRow label="Target" value={preview.targetName} meta={`Proposed: ${preview.proposedTargetName}`} />
+          <DetailRow
+            label="Target"
+            value={preview.targetName}
+            meta={`Proposed: ${preview.proposedTargetName ?? preview.targetName}`}
+          />
           <DetailRow
             label="Validation"
             value={preview.validation.status}
@@ -42,11 +50,19 @@ export function PreviewResult({ preview }: { preview: ConfiguredServerPreviewRes
             value={preview.configChange.status}
             meta={`${preview.configChange.operation} / ${preview.configChange.changed ? 'changed' : 'unchanged'}`}
           />
-          <DetailRow
-            label="Reload"
-            value={preview.configChange.reload.status}
-            meta={preview.configChange.reload.error}
-          />
+          {'expectedReload' in preview ? (
+            <DetailRow
+              label="Expected reload"
+              value={preview.expectedReload.policy.replaceAll('_', ' ')}
+              meta={preview.expectedReload.possibleStatuses.join(', ')}
+            />
+          ) : (
+            <DetailRow
+              label="Reload"
+              value={preview.configChange.reload.status}
+              meta={preview.configChange.reload.error}
+            />
+          )}
           <DetailRow
             label="Backup"
             value={preview.configChange.backup.created ? 'created' : 'not created'}

--- a/web/admin/src/components/workspaces/RuntimeOperationsWorkspace.tsx
+++ b/web/admin/src/components/workspaces/RuntimeOperationsWorkspace.tsx
@@ -6,6 +6,7 @@ import { type MouseEvent, useState } from 'react';
 import type { AdminConsoleRoute, OperatorWorkspaceModel } from '../../session/AdminConsoleSessionModel';
 import { DetailRow, Panel } from '../AdminConsoleShared';
 import { disabledServers, enabledServers, humanize, isOAuthAttention } from '../adminConsoleUtils';
+import { ConfiguredServerCreator } from '../configuredServerCreator';
 import { ConfiguredServerEditor } from '../configuredServerEditor';
 import { ConfiguredServersPanel } from '../ConfiguredServersPanel';
 import { AuditPanel } from '../OperationsStatusPanels';
@@ -116,10 +117,15 @@ export function ServersWorkspace({ model }: { model: OperatorWorkspaceModel }) {
             state={state}
             onServerAction={configuredServers.mutate}
             onOpenServerDetail={configuredServers.edit.open}
+            onConfigureCustomServer={configuredServers.create.open}
           />
         </div>
         <div className="inspector-column">
-          <ConfiguredServerEditor model={configuredServers.edit} />
+          {configuredServers.create.state.status === 'idle' ? (
+            <ConfiguredServerEditor model={configuredServers.edit} />
+          ) : (
+            <ConfiguredServerCreator model={configuredServers.create} />
+          )}
         </div>
       </div>
     </section>

--- a/web/admin/src/configuredServerCreate/configuredServerCreate.fixtures.ts
+++ b/web/admin/src/configuredServerCreate/configuredServerCreate.fixtures.ts
@@ -1,0 +1,89 @@
+import type { ConfiguredServerCreateContractResponse } from '../api/adminApi';
+
+export function configuredServerCreateContract(): ConfiguredServerCreateContractResponse {
+  return {
+    ok: true,
+    operationId: 'contract-op',
+    createContract: {
+      schemaVersion: 1,
+      capabilities: { create: { supported: true }, preview: { supported: true }, apply: { supported: true } },
+      fieldGroups: [
+        {
+          id: 'identity',
+          label: 'Target',
+          fields: [
+            { fieldPath: ['name'], label: 'Name', control: 'text', value: '', editable: true },
+            { fieldPath: ['enabled'], label: 'Enabled', control: 'switch', value: true, editable: true },
+            { fieldPath: ['tags'], label: 'Tags', control: 'tag-list', value: [], editable: true },
+          ],
+        },
+        {
+          id: 'transport',
+          label: 'Transport',
+          fields: [
+            {
+              fieldPath: ['transport', 'type'],
+              label: 'Transport Type',
+              control: 'select',
+              value: 'stdio',
+              options: ['stdio', 'http', 'sse'],
+              editable: true,
+            },
+            {
+              fieldPath: ['transport', 'command'],
+              label: 'Command',
+              control: 'text',
+              value: '',
+              editable: true,
+              applicableTransportTypes: ['stdio'],
+            },
+            {
+              fieldPath: ['transport', 'args'],
+              label: 'Args',
+              control: 'string-list',
+              value: [],
+              editable: true,
+              applicableTransportTypes: ['stdio'],
+            },
+            {
+              fieldPath: ['transport', 'env'],
+              label: 'Environment',
+              control: 'record',
+              value: {},
+              editable: true,
+              applicableTransportTypes: ['stdio'],
+            },
+            {
+              fieldPath: ['transport', 'url'],
+              label: 'URL',
+              control: 'text',
+              value: '',
+              editable: true,
+              applicableTransportTypes: ['http', 'sse'],
+            },
+            {
+              fieldPath: ['transport', 'headers'],
+              label: 'Headers',
+              control: 'record',
+              value: {},
+              editable: true,
+              applicableTransportTypes: ['http', 'sse'],
+            },
+          ],
+        },
+      ],
+      secretPolicy: {
+        allowedActions: ['replace'],
+        environmentReference: {
+          recommended: true,
+          storesSecretMaterial: false,
+          guidance: 'Keep secret material in the runtime environment.',
+        },
+        inlineReplacement: {
+          emphasis: 'secondary',
+          guidance: 'Use inline replacement only when an environment reference is unsuitable.',
+        },
+      },
+    },
+  };
+}

--- a/web/admin/src/configuredServerCreate/configuredServerCreate.fixtures.ts
+++ b/web/admin/src/configuredServerCreate/configuredServerCreate.fixtures.ts
@@ -6,7 +6,13 @@ export function configuredServerCreateContract(): ConfiguredServerCreateContract
     operationId: 'contract-op',
     createContract: {
       schemaVersion: 1,
-      capabilities: { create: { supported: true }, preview: { supported: true }, apply: { supported: true } },
+      capabilities: {
+        create: { supported: true },
+        forceReplacement: { supported: false },
+        rawJson: { supported: false },
+        preview: { supported: true },
+        apply: { supported: true },
+      },
       fieldGroups: [
         {
           id: 'identity',

--- a/web/admin/src/configuredServerCreate/configuredServerCreateState.test.ts
+++ b/web/admin/src/configuredServerCreate/configuredServerCreateState.test.ts
@@ -1,0 +1,82 @@
+import { configuredServerCreateContract } from './configuredServerCreate.fixtures';
+import {
+  configuredServerCreateDraft,
+  createConfiguredServerCreateState,
+  reduceConfiguredServerCreateState,
+} from './configuredServerCreateState';
+
+describe('configured server create state', () => {
+  it('serializes only fields for the selected transport and keeps secrets replace-only', () => {
+    let state = reduceConfiguredServerCreateState(createConfiguredServerCreateState(), {
+      type: 'contractLoaded',
+      contract: configuredServerCreateContract(),
+    });
+    state = reduceConfiguredServerCreateState(state, { type: 'fieldChanged', fieldPath: ['name'], value: 'custom' });
+    state = reduceConfiguredServerCreateState(state, {
+      type: 'fieldChanged',
+      fieldPath: ['transport', 'command'],
+      value: 'node',
+    });
+    state = reduceConfiguredServerCreateState(state, {
+      type: 'fieldChanged',
+      fieldPath: ['transport', 'url'],
+      value: 'https://ignored.example/mcp',
+    });
+    state = reduceConfiguredServerCreateState(state, {
+      type: 'secretAdded',
+      secret: {
+        id: 'secret-1',
+        container: 'env',
+        key: 'API_TOKEN',
+        replacementKind: 'environmentReference',
+        replacementValue: 'CUSTOM_TOKEN',
+      },
+    });
+
+    expect(configuredServerCreateDraft(state)).toEqual({
+      name: 'custom',
+      enabled: true,
+      tags: [],
+      transport: { type: 'stdio', command: 'node', args: [], env: {} },
+      secrets: [
+        {
+          fieldPath: ['env', 'API_TOKEN'],
+          action: 'replace',
+          replacement: { kind: 'environmentReference', value: 'CUSTOM_TOKEN' },
+        },
+      ],
+    });
+
+    state = reduceConfiguredServerCreateState(state, {
+      type: 'fieldChanged',
+      fieldPath: ['transport', 'type'],
+      value: 'sse',
+    });
+    expect(configuredServerCreateDraft(state)).toEqual({
+      name: 'custom',
+      enabled: true,
+      tags: [],
+      transport: { type: 'sse', url: 'https://ignored.example/mcp', headers: {} },
+    });
+  });
+
+  it('clears in-memory inline secrets when creation closes', () => {
+    let state = reduceConfiguredServerCreateState(createConfiguredServerCreateState(), {
+      type: 'contractLoaded',
+      contract: configuredServerCreateContract(),
+    });
+    state = reduceConfiguredServerCreateState(state, {
+      type: 'secretAdded',
+      secret: {
+        id: 'secret-1',
+        container: 'env',
+        key: 'API_TOKEN',
+        replacementKind: 'inlineSecret',
+        replacementValue: 'raw-secret',
+      },
+    });
+
+    expect(state).toMatchObject({ status: 'editing', secrets: [{ replacementValue: 'raw-secret' }] });
+    expect(reduceConfiguredServerCreateState(state, { type: 'closed' })).toEqual({ status: 'idle' });
+  });
+});

--- a/web/admin/src/configuredServerCreate/configuredServerCreateState.ts
+++ b/web/admin/src/configuredServerCreate/configuredServerCreateState.ts
@@ -1,0 +1,185 @@
+import type {
+  ConfiguredServerCreateContractResponse,
+  ConfiguredServerCreateDraft,
+  ConfiguredServerCreatePreviewResponse,
+  ConfiguredServerCreateResponse,
+} from '../api/adminApi';
+import {
+  fieldAppliesToTransport,
+  fieldKey,
+  initialDraftValue,
+  objectRecord,
+  stringArray,
+} from '../configuredServerEdit/configuredServerEditDraft';
+
+export interface ConfiguredServerCreateSecretDraft {
+  id: string;
+  container: 'env' | 'headers';
+  key: string;
+  replacementKind: 'environmentReference' | 'inlineSecret';
+  replacementValue: string;
+}
+
+interface EditingConfiguredServerCreateState {
+  status: 'editing';
+  contract: ConfiguredServerCreateContractResponse;
+  fieldDraft: Record<string, unknown>;
+  secrets: ConfiguredServerCreateSecretDraft[];
+  dirty: boolean;
+  preview?: ConfiguredServerCreatePreviewResponse['preview'];
+  previewBusy: boolean;
+  previewError?: string;
+  applyBusy: boolean;
+  applyError?: string;
+}
+
+export type ConfiguredServerCreateState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'failed'; message: string }
+  | EditingConfiguredServerCreateState
+  | { status: 'committed'; serverId: string; result: ConfiguredServerCreateResponse['result']; warning?: string };
+
+export type ConfiguredServerCreateAction =
+  | { type: 'closed' }
+  | { type: 'contractLoadStarted' }
+  | { type: 'contractLoaded'; contract: ConfiguredServerCreateContractResponse }
+  | { type: 'contractFailed'; message: string }
+  | { type: 'fieldChanged'; fieldPath: string[]; value: unknown }
+  | { type: 'secretAdded'; secret: ConfiguredServerCreateSecretDraft }
+  | { type: 'secretChanged'; secret: ConfiguredServerCreateSecretDraft }
+  | { type: 'secretRemoved'; id: string }
+  | { type: 'previewStarted' }
+  | { type: 'previewSucceeded'; preview: ConfiguredServerCreatePreviewResponse['preview'] }
+  | { type: 'previewFailed'; message: string }
+  | { type: 'applyStarted' }
+  | { type: 'applyFailed'; message: string; clearPreview?: boolean }
+  | { type: 'applySucceeded'; response: ConfiguredServerCreateResponse };
+
+export function createConfiguredServerCreateState(): ConfiguredServerCreateState {
+  return { status: 'idle' };
+}
+
+export function reduceConfiguredServerCreateState(
+  state: ConfiguredServerCreateState,
+  action: ConfiguredServerCreateAction,
+): ConfiguredServerCreateState {
+  switch (action.type) {
+    case 'closed':
+      return { status: 'idle' };
+    case 'contractLoadStarted':
+      return { status: 'loading' };
+    case 'contractLoaded': {
+      const fieldDraft: Record<string, unknown> = {};
+      for (const field of action.contract.createContract.fieldGroups.flatMap((group) => group.fields)) {
+        fieldDraft[fieldKey(field.fieldPath)] = initialDraftValue(field);
+      }
+      const transportTypeKey = fieldKey(['transport', 'type']);
+      if (!['stdio', 'http', 'sse'].includes(String(fieldDraft[transportTypeKey] ?? ''))) {
+        fieldDraft[transportTypeKey] = 'stdio';
+      }
+      return {
+        status: 'editing',
+        contract: action.contract,
+        fieldDraft,
+        secrets: [],
+        dirty: false,
+        previewBusy: false,
+        applyBusy: false,
+      };
+    }
+    case 'contractFailed':
+      return { status: 'failed', message: action.message };
+    case 'fieldChanged':
+      if (state.status !== 'editing' || state.applyBusy) return state;
+      return changed(state, { fieldDraft: { ...state.fieldDraft, [fieldKey(action.fieldPath)]: action.value } });
+    case 'secretAdded':
+      if (state.status !== 'editing' || state.applyBusy) return state;
+      return changed(state, { secrets: [...state.secrets, action.secret] });
+    case 'secretChanged':
+      if (state.status !== 'editing' || state.applyBusy) return state;
+      return changed(state, {
+        secrets: state.secrets.map((secret) => (secret.id === action.secret.id ? action.secret : secret)),
+      });
+    case 'secretRemoved':
+      if (state.status !== 'editing' || state.applyBusy) return state;
+      return changed(state, { secrets: state.secrets.filter((secret) => secret.id !== action.id) });
+    case 'previewStarted':
+      return state.status === 'editing' ? { ...state, previewBusy: true, previewError: undefined } : state;
+    case 'previewSucceeded':
+      return state.status === 'editing'
+        ? { ...state, preview: action.preview, previewBusy: false, previewError: undefined }
+        : state;
+    case 'previewFailed':
+      return state.status === 'editing' ? { ...state, previewBusy: false, previewError: action.message } : state;
+    case 'applyStarted':
+      return state.status === 'editing' ? { ...state, applyBusy: true, applyError: undefined } : state;
+    case 'applyFailed':
+      return state.status === 'editing'
+        ? {
+            ...state,
+            applyBusy: false,
+            applyError: action.message,
+            preview: action.clearPreview ? undefined : state.preview,
+          }
+        : state;
+    case 'applySucceeded':
+      return {
+        status: 'committed',
+        serverId: action.response.result.targetName,
+        result: action.response.result,
+        warning:
+          action.response.result.configChange.reload.status === 'failed'
+            ? (action.response.result.configChange.reload.error ??
+              'Runtime reload failed after configuration was written.')
+            : undefined,
+      };
+  }
+}
+
+export function configuredServerCreateDraft(state: ConfiguredServerCreateState): ConfiguredServerCreateDraft | null {
+  if (state.status !== 'editing') return null;
+  const transportType = state.fieldDraft[fieldKey(['transport', 'type'])];
+  if (transportType !== 'stdio' && transportType !== 'http' && transportType !== 'sse') return null;
+  const transport: Record<string, unknown> & { type: typeof transportType } = { type: transportType };
+  for (const field of state.contract.createContract.fieldGroups.flatMap((group) => group.fields)) {
+    if (field.fieldPath[0] !== 'transport' || field.fieldPath.length !== 2) continue;
+    if (!fieldAppliesToTransport(field, transportType)) continue;
+    const key = field.fieldPath[1];
+    if (key === 'type') continue;
+    const value = state.fieldDraft[fieldKey(field.fieldPath)];
+    if (field.control === 'string-list') transport[key] = stringArray(value);
+    else if (field.control === 'record') transport[key] = objectRecord(value);
+    else if (value !== '' && value !== undefined) transport[key] = value;
+  }
+  const applicableContainer = transportType === 'stdio' ? 'env' : 'headers';
+  const secrets = state.secrets
+    .filter((secret) => secret.container === applicableContainer && secret.key.trim() && secret.replacementValue.trim())
+    .map((secret) => ({
+      fieldPath: [secret.container, secret.key.trim()],
+      action: 'replace' as const,
+      replacement: { kind: secret.replacementKind, value: secret.replacementValue },
+    }));
+  return {
+    name: String(state.fieldDraft[fieldKey(['name'])] ?? ''),
+    enabled: Boolean(state.fieldDraft[fieldKey(['enabled'])]),
+    tags: stringArray(state.fieldDraft[fieldKey(['tags'])]),
+    transport,
+    ...(secrets.length > 0 ? { secrets } : {}),
+  };
+}
+
+function changed(
+  state: EditingConfiguredServerCreateState,
+  change: Partial<Pick<EditingConfiguredServerCreateState, 'fieldDraft' | 'secrets'>>,
+): EditingConfiguredServerCreateState {
+  return {
+    ...state,
+    ...change,
+    dirty: true,
+    preview: undefined,
+    previewBusy: false,
+    previewError: undefined,
+    applyError: undefined,
+  };
+}

--- a/web/admin/src/configuredServerCreate/useConfiguredServerCreate.test.tsx
+++ b/web/admin/src/configuredServerCreate/useConfiguredServerCreate.test.tsx
@@ -1,0 +1,362 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { AdminApiError } from '../api/adminApi';
+import type { AdminApiClient, AdminSession, ConfiguredServerPreviewResponse } from '../api/adminApi';
+import { configuredServerCreateContract } from './configuredServerCreate.fixtures';
+import type { ConfiguredServerCreateBrowser } from './useConfiguredServerCreate';
+import { useConfiguredServerCreate } from './useConfiguredServerCreate';
+
+const session: AdminSession = {
+  authenticated: true,
+  account: { id: 'admin-1', username: 'admin', role: 'full-admin' },
+  csrfToken: 'csrf-token',
+  expiresAt: '2099-01-01T00:00:00.000Z',
+};
+
+function browser(initialPathname = '/admin/servers') {
+  let pathname = initialPathname;
+  let popstate: (() => void) | undefined;
+  const adapter: ConfiguredServerCreateBrowser = {
+    pathname: () => pathname,
+    push: vi.fn((next) => {
+      pathname = next;
+    }),
+    replace: vi.fn((next) => {
+      pathname = next;
+    }),
+    confirm: vi.fn(async () => true),
+    subscribePopState: vi.fn((listener) => {
+      popstate = listener;
+      return () => {
+        popstate = undefined;
+      };
+    }),
+  };
+  return {
+    adapter,
+    navigate(next: string) {
+      pathname = next;
+      popstate?.();
+    },
+  };
+}
+
+function preview(fingerprint = 'preview-1'): ConfiguredServerPreviewResponse {
+  return {
+    ok: true,
+    operationId: 'preview-op',
+    preview: {
+      targetName: 'custom',
+      proposedTargetName: 'custom',
+      previewFingerprint: fingerprint,
+      validation: { status: 'valid', errors: [] },
+      diff: [
+        {
+          fieldPath: ['transport', 'command'],
+          oldValue: undefined,
+          newValue: 'node',
+          riskFlags: ['connection_critical'],
+        },
+      ],
+      configChange: {
+        status: 'preview',
+        operation: 'create_static',
+        target: { name: 'custom', source: 'mcpServers' },
+        changed: true,
+        backup: { created: false },
+        retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+        reload: { status: 'not_attempted' },
+      },
+      connectivityCheck: { status: 'skipped', reason: 'local_stdio_transport' },
+    },
+  };
+}
+
+function api(overrides: Partial<AdminApiClient> = {}): AdminApiClient {
+  return {
+    getConfiguredServerCreateContract: vi.fn(async () => configuredServerCreateContract()),
+    previewConfiguredServerCreate: vi.fn(async () => preview()),
+    createConfiguredServer: vi.fn(async () => ({
+      ok: true,
+      operationId: 'apply-op',
+      result: {
+        targetName: 'custom',
+        previewFingerprint: 'preview-1',
+        configChange: {
+          status: 'changed',
+          operation: 'create_static',
+          target: { name: 'custom', source: 'mcpServers' },
+          changed: true,
+          backup: { created: false },
+          retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+          reload: { status: 'observed' },
+        },
+      },
+    })),
+    ...overrides,
+  } as AdminApiClient;
+}
+
+describe('useConfiguredServerCreate', () => {
+  it('loads the contract and previews the active transport draft', async () => {
+    const adminApi = api();
+    const browserAdapter = browser();
+    const { result } = renderHook(() =>
+      useConfiguredServerCreate({
+        api: adminApi,
+        session,
+        browser: browserAdapter.adapter,
+        onUnauthenticated: vi.fn(),
+      }),
+    );
+
+    await act(() => result.current.open());
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() => result.current.changeField(['name'], 'custom'));
+    act(() => result.current.changeField(['transport', 'command'], 'node'));
+    await act(() => result.current.preview('auto'));
+
+    expect(browserAdapter.adapter.push).toHaveBeenCalledWith('/admin/servers/new');
+    expect(adminApi.previewConfiguredServerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        csrfToken: 'csrf-token',
+        connectivityCheck: 'auto',
+        draft: expect.objectContaining({
+          name: 'custom',
+          transport: expect.objectContaining({ type: 'stdio', command: 'node' }),
+        }),
+      }),
+    );
+  });
+
+  it('confirms once, applies the preview, refreshes inventory, and opens the created detail', async () => {
+    const adminApi = api();
+    const browserAdapter = browser('/admin/servers/new');
+    const onCreated = vi.fn(async () => undefined);
+    const onOpenCreated = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useConfiguredServerCreate({
+        api: adminApi,
+        session,
+        browser: browserAdapter.adapter,
+        onUnauthenticated: vi.fn(),
+        onCreated,
+        onOpenCreated,
+      }),
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() => result.current.changeField(['name'], 'custom'));
+    act(() => result.current.changeField(['transport', 'command'], 'node'));
+    await act(() => result.current.preview('auto'));
+    await act(() => Promise.all([result.current.apply(), result.current.apply()]));
+
+    expect(browserAdapter.adapter.confirm).toHaveBeenCalledOnce();
+    expect(adminApi.createConfiguredServer).toHaveBeenCalledOnce();
+    expect(adminApi.createConfiguredServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        confirmationFacts: expect.objectContaining({ connectionCriticalConfirmed: true }),
+      }),
+    );
+    expect(onCreated).toHaveBeenCalledOnce();
+    expect(onOpenCreated).toHaveBeenCalledWith('custom');
+  });
+
+  it('invalidates an in-flight preview when the draft changes', async () => {
+    let resolvePreview!: (value: ConfiguredServerPreviewResponse) => void;
+    const pending = new Promise<ConfiguredServerPreviewResponse>((resolve) => {
+      resolvePreview = resolve;
+    });
+    const browserAdapter = browser('/admin/servers/new');
+    const { result } = renderHook(() =>
+      useConfiguredServerCreate({
+        api: api({ previewConfiguredServerCreate: vi.fn(() => pending) }),
+        session,
+        browser: browserAdapter.adapter,
+        onUnauthenticated: vi.fn(),
+      }),
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() => result.current.changeField(['name'], 'first'));
+    act(() => void result.current.preview('auto'));
+    act(() => result.current.changeField(['name'], 'second'));
+    resolvePreview(preview('stale'));
+    await act(async () => undefined);
+
+    expect(result.current.state).toMatchObject({ status: 'editing', preview: undefined });
+  });
+
+  it('ignores an in-flight apply after confirmed Back navigation', async () => {
+    let resolveCreate!: (value: Awaited<ReturnType<AdminApiClient['createConfiguredServer']>>) => void;
+    const pending = new Promise<Awaited<ReturnType<AdminApiClient['createConfiguredServer']>>>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const create = vi.fn(() => pending);
+    const browserAdapter = browser('/admin/servers/new');
+    const onCreated = vi.fn(async () => undefined);
+    const onOpenCreated = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useConfiguredServerCreate({
+        api: api({ createConfiguredServer: create }),
+        session,
+        browser: browserAdapter.adapter,
+        onUnauthenticated: vi.fn(),
+        onCreated,
+        onOpenCreated,
+      }),
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() => result.current.changeField(['name'], 'custom'));
+    act(() => result.current.changeField(['transport', 'command'], 'node'));
+    await act(() => result.current.preview('auto'));
+
+    let applyPromise: void | Promise<void>;
+    act(() => {
+      applyPromise = result.current.apply();
+    });
+    await waitFor(() => expect(create).toHaveBeenCalledOnce());
+    act(() => browserAdapter.navigate('/admin/servers'));
+    await waitFor(() => expect(result.current.state).toEqual({ status: 'idle' }));
+
+    resolveCreate({
+      ok: true,
+      operationId: 'apply-op',
+      result: {
+        targetName: 'custom',
+        previewFingerprint: 'preview-1',
+        configChange: {
+          status: 'changed',
+          operation: 'create_static',
+          target: { name: 'custom', source: 'mcpServers' },
+          changed: true,
+          backup: { created: false },
+          retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+          reload: { status: 'observed' },
+        },
+      },
+    });
+    await act(async () => applyPromise);
+
+    expect(result.current.state).toEqual({ status: 'idle' });
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(onOpenCreated).not.toHaveBeenCalled();
+  });
+
+  it('keeps inline secret material out of browser persistence and clears it on session loss', async () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    const browserAdapter = browser('/admin/servers/new');
+    const { result, rerender } = renderHook(
+      ({ activeSession }) =>
+        useConfiguredServerCreate({
+          api: api(),
+          session: activeSession,
+          browser: browserAdapter.adapter,
+          onUnauthenticated: vi.fn(),
+        }),
+      { initialProps: { activeSession: session as AdminSession | null } },
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() =>
+      result.current.addSecret({
+        id: 'inline',
+        container: 'env',
+        key: 'API_TOKEN',
+        replacementKind: 'inlineSecret',
+        replacementValue: 'sentinel-secret',
+      }),
+    );
+
+    expect(JSON.stringify(browserAdapter.adapter.push.mock.calls)).not.toContain('sentinel-secret');
+    expect(JSON.stringify(browserAdapter.adapter.replace.mock.calls)).not.toContain('sentinel-secret');
+    expect(setItem).not.toHaveBeenCalled();
+    rerender({ activeSession: null });
+    await waitFor(() => expect(result.current.state).toEqual({ status: 'idle' }));
+    setItem.mockRestore();
+  });
+
+  it('reuses the idempotency key when a confirmed apply is retried', async () => {
+    const create = vi
+      .fn()
+      .mockRejectedValueOnce(new AdminApiError(503, { code: 'runtime_unavailable' }, 'runtime_unavailable'))
+      .mockResolvedValueOnce({
+        ok: true,
+        operationId: 'apply-op',
+        result: {
+          targetName: 'custom',
+          previewFingerprint: 'preview-1',
+          configChange: {
+            status: 'changed',
+            operation: 'create_static',
+            target: { name: 'custom', source: 'mcpServers' },
+            changed: true,
+            backup: { created: false },
+            retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+            reload: { status: 'observed' },
+          },
+        },
+      });
+    const browserAdapter = browser('/admin/servers/new');
+    const { result } = renderHook(() =>
+      useConfiguredServerCreate({
+        api: api({ createConfiguredServer: create }),
+        session,
+        browser: browserAdapter.adapter,
+        onUnauthenticated: vi.fn(),
+      }),
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() => result.current.changeField(['name'], 'custom'));
+    act(() => result.current.changeField(['transport', 'command'], 'node'));
+    await act(() => result.current.preview('auto'));
+    await act(() => result.current.apply());
+    await act(() => result.current.apply());
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0][0].idempotencyKey).toBe(create.mock.calls[1][0].idempotencyKey);
+  });
+
+  it('keeps a truthful reload failure visible after the target was created', async () => {
+    const create = vi.fn(async () => ({
+      ok: true as const,
+      operationId: 'apply-op',
+      result: {
+        targetName: 'custom',
+        previewFingerprint: 'preview-1',
+        configChange: {
+          status: 'changed' as const,
+          operation: 'create_static' as const,
+          target: { name: 'custom', source: 'mcpServers' as const },
+          changed: true,
+          backup: { created: false },
+          retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
+          reload: { status: 'failed' as const, error: 'reload observation timed out' },
+        },
+      },
+    }));
+    const onCreated = vi.fn(async () => undefined);
+    const onOpenCreated = vi.fn(async () => undefined);
+    const browserAdapter = browser('/admin/servers/new');
+    const { result } = renderHook(() =>
+      useConfiguredServerCreate({
+        api: api({ createConfiguredServer: create }),
+        session,
+        browser: browserAdapter.adapter,
+        onUnauthenticated: vi.fn(),
+        onCreated,
+        onOpenCreated,
+      }),
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() => result.current.changeField(['name'], 'custom'));
+    act(() => result.current.changeField(['transport', 'command'], 'node'));
+    await act(() => result.current.preview('auto'));
+    await act(() => result.current.apply());
+
+    expect(result.current.state).toMatchObject({
+      status: 'committed',
+      serverId: 'custom',
+      warning: 'reload observation timed out',
+    });
+    expect(onCreated).toHaveBeenCalledOnce();
+    expect(onOpenCreated).toHaveBeenCalledWith('custom');
+  });
+});

--- a/web/admin/src/configuredServerCreate/useConfiguredServerCreate.test.tsx
+++ b/web/admin/src/configuredServerCreate/useConfiguredServerCreate.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { AdminApiError } from '../api/adminApi';
-import type { AdminApiClient, AdminSession, ConfiguredServerPreviewResponse } from '../api/adminApi';
+import type { AdminApiClient, AdminSession, ConfiguredServerCreatePreviewResponse } from '../api/adminApi';
 import { configuredServerCreateContract } from './configuredServerCreate.fixtures';
 import type { ConfiguredServerCreateBrowser } from './useConfiguredServerCreate';
 import { useConfiguredServerCreate } from './useConfiguredServerCreate';
@@ -41,7 +41,13 @@ function browser(initialPathname = '/admin/servers') {
   };
 }
 
-function preview(fingerprint = 'preview-1'): ConfiguredServerPreviewResponse {
+function preview(
+  fingerprint = 'preview-1',
+  connectivityCheck: ConfiguredServerCreatePreviewResponse['preview']['connectivityCheck'] = {
+    status: 'skipped',
+    reason: 'local_stdio_transport',
+  },
+): ConfiguredServerCreatePreviewResponse {
   return {
     ok: true,
     operationId: 'preview-op',
@@ -67,7 +73,11 @@ function preview(fingerprint = 'preview-1'): ConfiguredServerPreviewResponse {
         retentionCleanup: { attempted: false, deletedPaths: [], warnings: [] },
         reload: { status: 'not_attempted' },
       },
-      connectivityCheck: { status: 'skipped', reason: 'local_stdio_transport' },
+      connectivityCheck,
+      expectedReload: {
+        policy: 'observe_after_write',
+        possibleStatuses: ['observed', 'runtime_not_running', 'reload_disabled', 'failed'],
+      },
     },
   };
 }
@@ -129,6 +139,61 @@ describe('useConfiguredServerCreate', () => {
     );
   });
 
+  it('keeps a dirty draft when reopening creation is not confirmed', async () => {
+    const adminApi = api();
+    const browserAdapter = browser('/admin/servers/new');
+    browserAdapter.adapter.confirm = vi.fn(async () => false);
+    const { result } = renderHook(() =>
+      useConfiguredServerCreate({
+        api: adminApi,
+        session,
+        browser: browserAdapter.adapter,
+        onUnauthenticated: vi.fn(),
+      }),
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() => result.current.changeField(['name'], 'keep-me'));
+
+    await act(() => result.current.open());
+
+    expect(browserAdapter.adapter.confirm).toHaveBeenCalledOnce();
+    expect(browserAdapter.adapter.push).not.toHaveBeenCalled();
+    expect(adminApi.getConfiguredServerCreateContract).toHaveBeenCalledOnce();
+    expect(result.current.state).toMatchObject({ status: 'editing', fieldDraft: { name: 'keep-me' } });
+  });
+
+  it('allows an enabled remote create when the connectivity checker is unavailable', async () => {
+    const create = vi.fn(async () => api().createConfiguredServer({} as never));
+    const adminApi = api({
+      previewConfiguredServerCreate: vi.fn(async () =>
+        preview('preview-unchecked', { status: 'skipped', reason: 'checker_unavailable' }),
+      ),
+      createConfiguredServer: create,
+    });
+    const browserAdapter = browser('/admin/servers/new');
+    const { result } = renderHook(() =>
+      useConfiguredServerCreate({
+        api: adminApi,
+        session,
+        browser: browserAdapter.adapter,
+        onUnauthenticated: vi.fn(),
+      }),
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('editing'));
+    act(() => result.current.changeField(['name'], 'remote'));
+    act(() => result.current.changeField(['transport', 'type'], 'http'));
+    act(() => result.current.changeField(['transport', 'url'], 'https://mcp.example'));
+    await act(() => result.current.preview('auto'));
+    await act(() => result.current.apply());
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        confirmationFacts: expect.not.objectContaining({ connectivityFailureOverrideConfirmed: true }),
+      }),
+    );
+  });
+
   it('confirms once, applies the preview, refreshes inventory, and opens the created detail', async () => {
     const adminApi = api();
     const browserAdapter = browser('/admin/servers/new');
@@ -162,8 +227,8 @@ describe('useConfiguredServerCreate', () => {
   });
 
   it('invalidates an in-flight preview when the draft changes', async () => {
-    let resolvePreview!: (value: ConfiguredServerPreviewResponse) => void;
-    const pending = new Promise<ConfiguredServerPreviewResponse>((resolve) => {
+    let resolvePreview!: (value: ConfiguredServerCreatePreviewResponse) => void;
+    const pending = new Promise<ConfiguredServerCreatePreviewResponse>((resolve) => {
       resolvePreview = resolve;
     });
     const browserAdapter = browser('/admin/servers/new');

--- a/web/admin/src/configuredServerCreate/useConfiguredServerCreate.ts
+++ b/web/admin/src/configuredServerCreate/useConfiguredServerCreate.ts
@@ -109,10 +109,13 @@ export function useConfiguredServerCreate({
   }, [dispatch, handleUnauthenticated]);
 
   const open = useCallback(async () => {
+    const current = stateRef.current;
+    if (current.status === 'editing' && current.dirty && !(await confirmDiscard(browser))) return;
+    reset();
     browser.push('/admin/servers/new');
     onPathCommitted?.('/admin/servers/new');
     await load();
-  }, [browser, load, onPathCommitted]);
+  }, [browser, load, onPathCommitted, reset]);
 
   const close = useCallback(
     async (destination = '/admin/servers') => {
@@ -321,7 +324,11 @@ export function configuredServerCreateApplyEligibility(state: ReturnType<typeof 
     draft.transport.type !== 'stdio' &&
     connectionCritical &&
     state.preview.connectivityCheck.status !== 'passed' &&
-    state.preview.connectivityCheck.status !== 'failed'
+    state.preview.connectivityCheck.status !== 'failed' &&
+    !(
+      state.preview.connectivityCheck.status === 'skipped' &&
+      state.preview.connectivityCheck.reason === 'checker_unavailable'
+    )
   )
     return { eligible: false, reason: 'A connectivity check must run before creation.' };
   return { eligible: true };

--- a/web/admin/src/configuredServerCreate/useConfiguredServerCreate.ts
+++ b/web/admin/src/configuredServerCreate/useConfiguredServerCreate.ts
@@ -1,0 +1,350 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+
+import {
+  type AdminApiClient,
+  AdminApiError,
+  type AdminSession,
+  createConfiguredServerCreateIdempotencyKey,
+} from '../api/adminApi';
+import type { ConfirmationRequest } from '../components/ConfirmationDialogProvider';
+import { useConfiguredServerMutationLifecycle } from '../configuredServerMutation/useConfiguredServerMutationLifecycle';
+import {
+  configuredServerCreateDraft,
+  type ConfiguredServerCreateSecretDraft,
+  createConfiguredServerCreateState,
+  reduceConfiguredServerCreateState,
+} from './configuredServerCreateState';
+
+export interface ConfiguredServerCreateBrowser {
+  pathname(): string;
+  push(pathname: string): void;
+  replace(pathname: string): void;
+  confirm(request: ConfirmationRequest): Promise<boolean>;
+  subscribePopState(listener: () => void): () => void;
+}
+
+export interface ConfiguredServerCreateModel {
+  state: ReturnType<typeof createConfiguredServerCreateState> | ReturnType<typeof reduceConfiguredServerCreateState>;
+  open(): void | Promise<void>;
+  close(destination?: string): Promise<boolean>;
+  editExisting(serverId: string): void | Promise<void>;
+  changeField(fieldPath: string[], value: unknown): void;
+  addSecret(secret: ConfiguredServerCreateSecretDraft): void;
+  changeSecret(secret: ConfiguredServerCreateSecretDraft): void;
+  removeSecret(id: string): void;
+  preview(connectivityCheck?: 'auto' | 'manual'): void | Promise<void>;
+  apply(): void | Promise<void>;
+}
+
+export function useConfiguredServerCreate({
+  api,
+  session,
+  browser,
+  onUnauthenticated,
+  onCreated,
+  onOpenCreated,
+  onPathCommitted,
+}: {
+  api: AdminApiClient;
+  session: AdminSession | null;
+  browser: ConfiguredServerCreateBrowser;
+  onUnauthenticated(status: 'setupRequired' | 'loginRequired'): void;
+  onCreated?: () => void | Promise<void>;
+  onOpenCreated?: (serverId: string) => void | Promise<void>;
+  onPathCommitted?: (path: string) => void;
+}): ConfiguredServerCreateModel {
+  const [state, rawDispatch] = useReducer(
+    reduceConfiguredServerCreateState,
+    undefined,
+    createConfiguredServerCreateState,
+  );
+  const stateRef = useRef(state);
+  const apiRef = useRef(api);
+  const sessionRef = useRef(session);
+  const onUnauthenticatedRef = useRef(onUnauthenticated);
+
+  apiRef.current = api;
+  sessionRef.current = session;
+  onUnauthenticatedRef.current = onUnauthenticated;
+  const dispatch = useCallback((action: Parameters<typeof reduceConfiguredServerCreateState>[1]) => {
+    const next = reduceConfiguredServerCreateState(stateRef.current, action);
+    stateRef.current = next;
+    rawDispatch(action);
+  }, []);
+  const {
+    loadRequestRef: contractRequestRef,
+    previewRequestRef,
+    applyRequestRef,
+    applyInteractionRef,
+    applyAttemptRef,
+    invalidatePreview,
+    reset,
+  } = useConfiguredServerMutationLifecycle(() => dispatch({ type: 'closed' }));
+
+  const handleUnauthenticated = useCallback(
+    (error: unknown) => {
+      if (!(error instanceof AdminApiError) || error.failure.kind !== 'unauthenticated') return false;
+      reset();
+      onUnauthenticatedRef.current(error.failure.adminStatus);
+      return true;
+    },
+    [reset],
+  );
+
+  const load = useCallback(async () => {
+    const activeSession = sessionRef.current;
+    if (!activeSession) return;
+    const requestId = contractRequestRef.current + 1;
+    contractRequestRef.current = requestId;
+    const sessionKey = activeSession.csrfToken;
+    dispatch({ type: 'contractLoadStarted' });
+    try {
+      const contract = await apiRef.current.getConfiguredServerCreateContract();
+      if (requestId !== contractRequestRef.current || sessionRef.current?.csrfToken !== sessionKey) return;
+      dispatch({ type: 'contractLoaded', contract });
+    } catch (error) {
+      if (requestId !== contractRequestRef.current || sessionRef.current?.csrfToken !== sessionKey) return;
+      if (!handleUnauthenticated(error)) dispatch({ type: 'contractFailed', message: failureMessage(error) });
+    }
+  }, [dispatch, handleUnauthenticated]);
+
+  const open = useCallback(async () => {
+    browser.push('/admin/servers/new');
+    onPathCommitted?.('/admin/servers/new');
+    await load();
+  }, [browser, load, onPathCommitted]);
+
+  const close = useCallback(
+    async (destination = '/admin/servers') => {
+      const current = stateRef.current;
+      if (current.status === 'editing' && current.dirty && !(await confirmDiscard(browser))) return false;
+      reset();
+      browser.push(destination);
+      onPathCommitted?.(destination);
+      return true;
+    },
+    [browser, onPathCommitted, reset],
+  );
+
+  const editExisting = useCallback(
+    async (serverId: string) => {
+      if (!(await close('/admin/servers'))) return;
+      await onOpenCreated?.(serverId);
+    },
+    [close, onOpenCreated],
+  );
+
+  const changeField = useCallback(
+    (fieldPath: string[], value: unknown) => {
+      invalidatePreview();
+      dispatch({ type: 'fieldChanged', fieldPath, value });
+    },
+    [dispatch, invalidatePreview],
+  );
+  const addSecret = useCallback(
+    (secret: ConfiguredServerCreateSecretDraft) => {
+      invalidatePreview();
+      dispatch({ type: 'secretAdded', secret });
+    },
+    [dispatch, invalidatePreview],
+  );
+  const changeSecret = useCallback(
+    (secret: ConfiguredServerCreateSecretDraft) => {
+      invalidatePreview();
+      dispatch({ type: 'secretChanged', secret });
+    },
+    [dispatch, invalidatePreview],
+  );
+  const removeSecret = useCallback(
+    (id: string) => {
+      invalidatePreview();
+      dispatch({ type: 'secretRemoved', id });
+    },
+    [dispatch, invalidatePreview],
+  );
+
+  const preview = useCallback(
+    async (connectivityCheck: 'auto' | 'manual' = 'auto') => {
+      const activeSession = sessionRef.current;
+      const current = stateRef.current;
+      const draft = configuredServerCreateDraft(current);
+      if (!activeSession || current.status !== 'editing' || !draft) return;
+      const requestId = previewRequestRef.current + 1;
+      previewRequestRef.current = requestId;
+      const sessionKey = activeSession.csrfToken;
+      dispatch({ type: 'previewStarted' });
+      try {
+        const response = await apiRef.current.previewConfiguredServerCreate({
+          draft,
+          csrfToken: sessionKey,
+          connectivityCheck,
+        });
+        if (requestId !== previewRequestRef.current || sessionRef.current?.csrfToken !== sessionKey) return;
+        if (applyAttemptRef.current?.previewFingerprint !== response.preview.previewFingerprint) {
+          applyAttemptRef.current = undefined;
+        }
+        dispatch({ type: 'previewSucceeded', preview: response.preview });
+      } catch (error) {
+        if (requestId !== previewRequestRef.current || sessionRef.current?.csrfToken !== sessionKey) return;
+        if (!handleUnauthenticated(error))
+          dispatch({ type: 'previewFailed', message: `Preview failed: ${failureMessage(error)}` });
+      }
+    },
+    [dispatch, handleUnauthenticated],
+  );
+
+  const apply = useCallback(async () => {
+    if (applyInteractionRef.current) return;
+    const activeSession = sessionRef.current;
+    const current = stateRef.current;
+    const draft = configuredServerCreateDraft(current);
+    if (!activeSession || current.status !== 'editing' || !current.preview || !draft) return;
+    const eligibility = configuredServerCreateApplyEligibility(current);
+    if (!eligibility.eligible) return;
+    applyInteractionRef.current = true;
+    try {
+      const previewResult = current.preview;
+      const connectivityFailed = previewResult.connectivityCheck.status === 'failed';
+      const confirmed = await browser.confirm({
+        title: connectivityFailed
+          ? `Create ${draft.name} despite failed connectivity?`
+          : `Create configured server ${draft.name}?`,
+        message: connectivityFailed
+          ? 'The bounded connectivity check failed. Creating this target may leave it unavailable.'
+          : 'This writes a new static target and reloads the Runtime Scope.',
+        confirmLabel: connectivityFailed ? 'Create despite failure' : 'Create server',
+        tone: connectivityFailed ? 'danger' : undefined,
+        details: [
+          { label: 'Target', value: draft.name },
+          { label: 'Transport', value: draft.transport.type },
+          { label: 'Connectivity', value: previewResult.connectivityCheck.status },
+          { label: 'Existing target', value: 'Must remain absent' },
+        ],
+      });
+      if (!confirmed) return;
+      const attempt =
+        applyAttemptRef.current?.previewFingerprint === previewResult.previewFingerprint
+          ? applyAttemptRef.current
+          : {
+              previewFingerprint: previewResult.previewFingerprint,
+              idempotencyKey: createConfiguredServerCreateIdempotencyKey(draft.name),
+            };
+      applyAttemptRef.current = attempt;
+      const requestId = applyRequestRef.current + 1;
+      applyRequestRef.current = requestId;
+      const sessionKey = activeSession.csrfToken;
+      dispatch({ type: 'applyStarted' });
+      try {
+        const response = await apiRef.current.createConfiguredServer({
+          draft,
+          csrfToken: sessionKey,
+          idempotencyKey: attempt.idempotencyKey,
+          previewFingerprint: previewResult.previewFingerprint,
+          confirmationFacts: {
+            previewConfirmed: previewResult.previewFingerprint,
+            targetNameConfirmed: draft.name,
+            connectionCriticalConfirmed: true,
+            ...(previewResult.diff.some((entry) => entry.riskFlags.includes('secret'))
+              ? { secretChangeConfirmed: true }
+              : {}),
+            ...(connectivityFailed ? { connectivityFailureOverrideConfirmed: true } : {}),
+          },
+        });
+        if (requestId !== applyRequestRef.current || sessionRef.current?.csrfToken !== sessionKey) return;
+        applyAttemptRef.current = undefined;
+        dispatch({ type: 'applySucceeded', response });
+        await onCreated?.();
+        await onOpenCreated?.(response.result.targetName);
+        if (response.result.configChange.reload.status !== 'failed') {
+          dispatch({ type: 'closed' });
+        }
+      } catch (error) {
+        if (requestId !== applyRequestRef.current || sessionRef.current?.csrfToken !== sessionKey) return;
+        if (!handleUnauthenticated(error)) {
+          const stale = isStalePreview(error);
+          if (stale) applyAttemptRef.current = undefined;
+          dispatch({ type: 'applyFailed', message: `Create failed: ${failureMessage(error)}`, clearPreview: stale });
+        }
+      }
+    } finally {
+      applyInteractionRef.current = false;
+    }
+  }, [browser, dispatch, handleUnauthenticated, onCreated, onOpenCreated]);
+
+  useEffect(() => {
+    if (!session) {
+      reset();
+      return;
+    }
+    if (browser.pathname() === '/admin/servers/new') void load();
+  }, [browser, load, reset, session?.csrfToken]);
+
+  useEffect(
+    () =>
+      browser.subscribePopState(() => {
+        void (async () => {
+          const requestedPath = browser.pathname();
+          const current = stateRef.current;
+          if (current.status === 'editing' && current.dirty) {
+            browser.replace('/admin/servers/new');
+            if (!(await confirmDiscard(browser))) {
+              onPathCommitted?.('/admin/servers/new');
+              return;
+            }
+            browser.replace(requestedPath);
+          }
+          reset();
+          onPathCommitted?.(requestedPath);
+        })();
+      }),
+    [browser, onPathCommitted, reset],
+  );
+
+  return { state, open, close, editExisting, changeField, addSecret, changeSecret, removeSecret, preview, apply };
+}
+
+export function configuredServerCreateApplyEligibility(state: ReturnType<typeof reduceConfiguredServerCreateState>): {
+  eligible: boolean;
+  reason?: string;
+} {
+  if (state.status !== 'editing' || !state.preview) return { eligible: false, reason: 'Preview this server first.' };
+  if (!state.contract.createContract.capabilities.apply.supported)
+    return { eligible: false, reason: 'Creation is unavailable.' };
+  if (state.preview.validation.status !== 'valid') return { eligible: false, reason: 'Resolve validation issues.' };
+  if (!state.preview.configChange.changed || state.preview.diff.length === 0)
+    return { eligible: false, reason: 'The preview contains no changes.' };
+  const draft = configuredServerCreateDraft(state);
+  if (!draft) return { eligible: false, reason: 'Complete the server configuration.' };
+  const connectionCritical = state.preview.diff.some((entry) => entry.riskFlags.includes('connection_critical'));
+  if (
+    draft.enabled &&
+    draft.transport.type !== 'stdio' &&
+    connectionCritical &&
+    state.preview.connectivityCheck.status !== 'passed' &&
+    state.preview.connectivityCheck.status !== 'failed'
+  )
+    return { eligible: false, reason: 'A connectivity check must run before creation.' };
+  return { eligible: true };
+}
+
+function confirmDiscard(browser: ConfiguredServerCreateBrowser): Promise<boolean> {
+  return browser.confirm({
+    title: 'Discard custom server?',
+    message: 'The configured-server draft, preview, and secret replacements will be lost.',
+    confirmLabel: 'Discard draft',
+    tone: 'danger',
+  });
+}
+
+function isStalePreview(error: unknown): boolean {
+  return (
+    error instanceof AdminApiError &&
+    error.failure.kind === 'rejected' &&
+    error.failure.code === 'configured_server_stale_preview'
+  );
+}
+
+function failureMessage(error: unknown): string {
+  if (error instanceof AdminApiError) return error.failure.message;
+  throw error;
+}

--- a/web/admin/src/configuredServerEdit/useConfiguredServerEdit.test.tsx
+++ b/web/admin/src/configuredServerEdit/useConfiguredServerEdit.test.tsx
@@ -69,6 +69,17 @@ function api(overrides: Partial<AdminApiClient> = {}): AdminApiClient {
 }
 
 describe('useConfiguredServerEdit', () => {
+  it('does not load the reserved create route after decoding its path segment', async () => {
+    const adminApi = api();
+    const browserAdapter = browser('/admin/servers/%6E%65%77');
+    const { result } = renderHook(() =>
+      useConfiguredServerEdit({ api: adminApi, session, browser: browserAdapter.adapter, onUnauthenticated: vi.fn() }),
+    );
+
+    await waitFor(() => expect(result.current.state).toEqual({ status: 'list' }));
+    expect(adminApi.getConfiguredServerDetail).not.toHaveBeenCalled();
+  });
+
   it('loads a deep link and owns normalized preview input', async () => {
     const browserAdapter = browser('/admin/servers/github');
     const adminApi = api({

--- a/web/admin/src/configuredServerEdit/useConfiguredServerEdit.ts
+++ b/web/admin/src/configuredServerEdit/useConfiguredServerEdit.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useReducer, useRef } from 'react';
 import { AdminApiError, createConfiguredServerApplyIdempotencyKey } from '../api/adminApi';
 import type { AdminApiClient, AdminSession } from '../api/adminApi';
 import type { ConfirmationRequest } from '../components/ConfirmationDialogProvider';
+import { useConfiguredServerMutationLifecycle } from '../configuredServerMutation/useConfiguredServerMutationLifecycle';
 import { type SecretDraftState, selectedTransportType } from './configuredServerEditDraft';
 import {
   configuredServerEditDraft,
@@ -50,24 +51,21 @@ export function useConfiguredServerEdit({
   const sessionRef = useRef(session);
   const apiRef = useRef(api);
   const onUnauthenticatedRef = useRef(onUnauthenticated);
-  const detailRequestRef = useRef(0);
-  const previewRequestRef = useRef(0);
-  const applyRequestRef = useRef(0);
-  const applyInteractionRef = useRef(false);
-  const applyAttemptRef = useRef<{ previewFingerprint: string; idempotencyKey: string }>();
   stateRef.current = state;
   sessionRef.current = session;
   apiRef.current = api;
   onUnauthenticatedRef.current = onUnauthenticated;
 
-  const reset = useCallback(() => {
-    detailRequestRef.current += 1;
-    previewRequestRef.current += 1;
-    applyRequestRef.current += 1;
-    applyInteractionRef.current = false;
-    applyAttemptRef.current = undefined;
-    dispatch({ type: 'closed' });
-  }, []);
+  const {
+    loadRequestRef: detailRequestRef,
+    previewRequestRef,
+    applyRequestRef,
+    applyInteractionRef,
+    applyAttemptRef,
+    invalidatePreview,
+    invalidateApply,
+    reset,
+  } = useConfiguredServerMutationLifecycle(() => dispatch({ type: 'closed' }));
 
   const handleUnauthenticated = useCallback(
     (error: unknown) => {
@@ -83,12 +81,11 @@ export function useConfiguredServerEdit({
     async (serverId: string) => {
       const activeSession = sessionRef.current;
       if (!activeSession) return;
-      applyRequestRef.current += 1;
-      applyAttemptRef.current = undefined;
+      invalidateApply();
       const sessionKey = activeSession.csrfToken;
       const requestId = detailRequestRef.current + 1;
       detailRequestRef.current = requestId;
-      previewRequestRef.current += 1;
+      invalidatePreview();
       dispatch({ type: 'detailLoadStarted', serverId });
       try {
         const detail = await apiRef.current.getConfiguredServerDetail(serverId);
@@ -104,7 +101,7 @@ export function useConfiguredServerEdit({
         dispatch({ type: 'detailFailed', serverId, message: `Server detail failed: ${failureMessage(error)}` });
       }
     },
-    [handleUnauthenticated],
+    [handleUnauthenticated, invalidateApply, invalidatePreview],
   );
 
   const open = useCallback(
@@ -137,23 +134,29 @@ export function useConfiguredServerEdit({
     [browser, reset],
   );
 
-  const changeField = useCallback((fieldPath: string[], value: unknown) => {
-    previewRequestRef.current += 1;
-    applyAttemptRef.current = undefined;
-    dispatch({ type: 'fieldChanged', fieldPath, value });
-  }, []);
+  const changeField = useCallback(
+    (fieldPath: string[], value: unknown) => {
+      invalidatePreview();
+      dispatch({ type: 'fieldChanged', fieldPath, value });
+    },
+    [invalidatePreview],
+  );
 
-  const changeSecret = useCallback((fieldPath: string[], value: SecretDraftState[string]) => {
-    previewRequestRef.current += 1;
-    applyAttemptRef.current = undefined;
-    dispatch({ type: 'secretChanged', fieldPath, value });
-  }, []);
+  const changeSecret = useCallback(
+    (fieldPath: string[], value: SecretDraftState[string]) => {
+      invalidatePreview();
+      dispatch({ type: 'secretChanged', fieldPath, value });
+    },
+    [invalidatePreview],
+  );
 
-  const changeTransportOverride = useCallback((key: string, clear: boolean) => {
-    previewRequestRef.current += 1;
-    applyAttemptRef.current = undefined;
-    dispatch({ type: 'transportOverrideChanged', key, clear });
-  }, []);
+  const changeTransportOverride = useCallback(
+    (key: string, clear: boolean) => {
+      invalidatePreview();
+      dispatch({ type: 'transportOverrideChanged', key, clear });
+    },
+    [invalidatePreview],
+  );
 
   const preview = useCallback(
     async (connectivityCheck: 'auto' | 'manual' = 'auto') => {
@@ -386,7 +389,7 @@ function serverIdFromPath(pathname: string): string | null {
   const prefix = '/admin/servers/';
   if (!pathname.startsWith(prefix)) return null;
   const encoded = pathname.slice(prefix.length).split('#', 1)[0];
-  if (!encoded) return null;
+  if (!encoded || encoded === 'new') return null;
   try {
     return decodeURIComponent(encoded);
   } catch {

--- a/web/admin/src/configuredServerEdit/useConfiguredServerEdit.ts
+++ b/web/admin/src/configuredServerEdit/useConfiguredServerEdit.ts
@@ -389,10 +389,12 @@ function serverIdFromPath(pathname: string): string | null {
   const prefix = '/admin/servers/';
   if (!pathname.startsWith(prefix)) return null;
   const encoded = pathname.slice(prefix.length).split('#', 1)[0];
-  if (!encoded || encoded === 'new') return null;
+  if (!encoded) return null;
+  let decoded: string;
   try {
-    return decodeURIComponent(encoded);
+    decoded = decodeURIComponent(encoded);
   } catch {
-    return encoded;
+    decoded = encoded;
   }
+  return decoded === 'new' ? null : decoded;
 }

--- a/web/admin/src/configuredServerMutation/useConfiguredServerMutationLifecycle.ts
+++ b/web/admin/src/configuredServerMutation/useConfiguredServerMutationLifecycle.ts
@@ -1,0 +1,46 @@
+import { useCallback, useRef } from 'react';
+
+interface ApplyAttempt {
+  previewFingerprint: string;
+  idempotencyKey: string;
+}
+
+export function useConfiguredServerMutationLifecycle(onReset: () => void) {
+  const onResetRef = useRef(onReset);
+  const loadRequestRef = useRef(0);
+  const previewRequestRef = useRef(0);
+  const applyRequestRef = useRef(0);
+  const applyInteractionRef = useRef(false);
+  const applyAttemptRef = useRef<ApplyAttempt>();
+  onResetRef.current = onReset;
+
+  const invalidatePreview = useCallback(() => {
+    previewRequestRef.current += 1;
+    applyAttemptRef.current = undefined;
+  }, []);
+
+  const invalidateApply = useCallback(() => {
+    applyRequestRef.current += 1;
+    applyAttemptRef.current = undefined;
+  }, []);
+
+  const reset = useCallback(() => {
+    loadRequestRef.current += 1;
+    previewRequestRef.current += 1;
+    applyRequestRef.current += 1;
+    applyInteractionRef.current = false;
+    applyAttemptRef.current = undefined;
+    onResetRef.current();
+  }, []);
+
+  return {
+    loadRequestRef,
+    previewRequestRef,
+    applyRequestRef,
+    applyInteractionRef,
+    applyAttemptRef,
+    invalidatePreview,
+    invalidateApply,
+    reset,
+  };
+}

--- a/web/admin/src/controller.test.tsx
+++ b/web/admin/src/controller.test.tsx
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { AdminApiError } from './api/adminApi';
 import type { AdminApiClient } from './api/adminApi';
+import { configuredServerCreateContract } from './configuredServerCreate/configuredServerCreate.fixtures';
 import { AdminConsoleRoot } from './session/AdminConsoleSession';
 
 const session = {
@@ -68,6 +69,33 @@ describe('AdminConsoleRoot', () => {
     await user.click(screen.getByRole('button', { name: /log out/i }));
     expect(api.logout).toHaveBeenCalledWith('csrf_123');
     expect(await screen.findByRole('heading', { name: /operator login/i })).toBeInTheDocument();
+  });
+
+  it('keeps a dirty create draft and route when reopening creation is cancelled', async () => {
+    const user = userEvent.setup();
+    const routeWindow = createRouteWindow('/admin/servers');
+    const api = apiClient({
+      getSession: vi.fn(async () => session),
+      getStatus: vi.fn(async () => status),
+      listConfiguredServers: vi.fn(async () => []),
+      getConfiguredServerCreateContract: vi.fn(async () => configuredServerCreateContract()),
+    });
+
+    renderRoot(api, { windowRef: routeWindow });
+
+    expect(await screen.findByRole('heading', { name: /server inventory/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /configure custom server/i }));
+    const nameInput = await screen.findByLabelText('Name');
+    await user.type(nameInput, 'keep-me');
+    expect(routeWindow.location.pathname).toBe('/admin/servers/new');
+
+    await user.click(screen.getByRole('button', { name: /configure custom server/i }));
+    expect(await screen.findByRole('dialog', { name: /discard custom server/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(routeWindow.location.pathname).toBe('/admin/servers/new');
+    expect(nameInput).toHaveValue('keep-me');
+    expect(api.getConfiguredServerCreateContract).toHaveBeenCalledOnce();
   });
 
   it('shows setup guidance for setup-required unauthenticated sessions', async () => {

--- a/web/admin/src/session/AdminConsoleSession.tsx
+++ b/web/admin/src/session/AdminConsoleSession.tsx
@@ -508,6 +508,10 @@ export function useAdminConsoleSession({
       create: {
         ...configuredServerCreate,
         open: async () => {
+          if (configuredServerCreate.state.status !== 'idle') {
+            await configuredServerCreate.open();
+            return;
+          }
           if (!(await configuredServerEdit.close('/admin/servers'))) return;
           await configuredServerCreate.open();
         },

--- a/web/admin/src/session/AdminConsoleSession.tsx
+++ b/web/admin/src/session/AdminConsoleSession.tsx
@@ -11,6 +11,7 @@ import type {
 } from '../api/adminApi';
 import { AdminConsoleApp } from '../components/AdminConsoleApp';
 import { ConfirmationDialogProvider, useConfirmationDialog } from '../components/ConfirmationDialogProvider';
+import { useConfiguredServerCreate } from '../configuredServerCreate/useConfiguredServerCreate';
 import { useConfiguredServerEdit } from '../configuredServerEdit/useConfiguredServerEdit';
 import { type AdminConsoleAction, createInitialState, reduceAdminConsoleState } from '../state/adminConsoleState';
 import { pollingDelayForVisibility, shouldPollConsole } from '../state/polling';
@@ -103,6 +104,7 @@ export function useAdminConsoleSession({
   const stateRef = useRef(state);
   const timerRef = useRef<ReturnType<Window['setTimeout']> | null>(null);
   const configuredServerAppliedRef = useRef<() => void | Promise<void>>();
+  const configuredServerCreatedRef = useRef<() => void | Promise<void>>();
   const presetSaveBusyRef = useRef(false);
   const presetDeleteBusyRef = useRef(false);
   const oauthOperationBusyRef = useRef(false);
@@ -176,6 +178,15 @@ export function useAdminConsoleSession({
     browser: configuredServerEditBrowser,
     onUnauthenticated: invalidateAdminSession,
     onApplied: () => configuredServerAppliedRef.current?.(),
+    onPathCommitted: commitBrowserPath,
+  });
+  const configuredServerCreate = useConfiguredServerCreate({
+    api,
+    session: state.session,
+    browser: configuredServerEditBrowser,
+    onUnauthenticated: invalidateAdminSession,
+    onCreated: () => configuredServerCreatedRef.current?.(),
+    onOpenCreated: configuredServerEdit.open,
     onPathCommitted: commitBrowserPath,
   });
   const backendLogs = useBackendLogs({
@@ -292,10 +303,15 @@ export function useAdminConsoleSession({
   const navigate = useCallback(
     async (nextRoute: AdminConsoleRoute) => {
       const pathname = adminRoutePath(nextRoute);
+      if (configuredServerCreate.state.status !== 'idle') {
+        if (!(await configuredServerCreate.close(pathname))) return;
+        setRoute(nextRoute);
+        return;
+      }
       if (!(await configuredServerEdit.close(pathname))) return;
       setRoute(nextRoute);
     },
-    [configuredServerEdit],
+    [configuredServerCreate, configuredServerEdit],
   );
 
   const refreshConsole = useCallback(
@@ -329,6 +345,7 @@ export function useAdminConsoleSession({
     [api, dispatch, formatNow, handleUnauthenticated, isCurrentSession],
   );
   configuredServerAppliedRef.current = () => refreshConsole('');
+  configuredServerCreatedRef.current = () => refreshConsole('');
 
   const schedulePoll = useCallback(() => {
     clearPoll();
@@ -488,6 +505,13 @@ export function useAdminConsoleSession({
     refresh: () => refreshConsole('Manual refresh failed: '),
     navigation: { route, navigate },
     configuredServers: {
+      create: {
+        ...configuredServerCreate,
+        open: async () => {
+          if (!(await configuredServerEdit.close('/admin/servers'))) return;
+          await configuredServerCreate.open();
+        },
+      },
       edit: configuredServerEdit,
       mutate: mutateServer,
       copy: copyText,

--- a/web/admin/src/session/AdminConsoleSessionModel.ts
+++ b/web/admin/src/session/AdminConsoleSessionModel.ts
@@ -1,4 +1,5 @@
 import type { AdminPresetDraft, AdminPresetListItem, AdminPresetPreview, AdminPresetTarget } from '../api/adminApi';
+import type { ConfiguredServerCreateModel } from '../configuredServerCreate/useConfiguredServerCreate';
 import type { ConfiguredServerEditModel } from '../configuredServerEdit/useConfiguredServerEdit';
 import type { AdminConsoleState } from '../state/adminConsoleState';
 import type { BackendLogsModel } from './useBackendLogs';
@@ -21,6 +22,7 @@ export interface AdminConsoleSessionModel {
     navigate(route: AdminConsoleRoute): void | Promise<void>;
   };
   configuredServers: {
+    create: ConfiguredServerCreateModel;
     edit: ConfiguredServerEditModel;
     mutate(serverId: string, action: 'enable' | 'disable'): void | Promise<void>;
     copy(label: string, value: string): void | Promise<void>;


### PR DESCRIPTION
## Summary

- add an atomic create-only configured-server mutation across static and template namespaces
- add normalized Admin preview/apply APIs and a packaged Console workflow for STDIO, HTTP, and legacy SSE targets
- bind previews to config, secret, validation, and connectivity facts with explicit confirmation, idempotency, redaction, reload reporting, and conflict recovery
- document the workflow in English and Chinese

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (4,485 unit tests and 118 Admin tests)
- `pnpm test:e2e` (824 passed, 1 skipped)
- `pnpm docs:build`
- `git diff --check HEAD`

Closes #431
