### PR TITLE
fix(release): use basic parsing in Windows smoke test

### DIFF
--- a/scripts/test-binary-windows.ps1
+++ b/scripts/test-binary-windows.ps1
@@ -97,7 +97,7 @@ try {
         $ready = $false
         for ($attempt = 0; $attempt -lt 50; $attempt++) {
             try {
-                $response = Invoke-WebRequest -Uri "$adminBaseUrl/health/ready" -TimeoutSec 1 -ErrorAction Stop
+                $response = Invoke-WebRequest -UseBasicParsing -Uri "$adminBaseUrl/health/ready" -TimeoutSec 1 -ErrorAction Stop
                 if ($response.StatusCode -eq 200) {
                     $ready = $true
                     break
@@ -113,14 +113,14 @@ try {
             throw "Standalone binary did not become ready. $((Get-Content $adminStdout -Raw -ErrorAction SilentlyContinue) + (Get-Content $adminStderr -Raw -ErrorAction SilentlyContinue))"
         }
 
-        $adminHtml = (Invoke-WebRequest -Uri "$adminBaseUrl/admin/" -TimeoutSec 5 -ErrorAction Stop).Content
+        $adminHtml = (Invoke-WebRequest -UseBasicParsing -Uri "$adminBaseUrl/admin/" -TimeoutSec 5 -ErrorAction Stop).Content
         $jsMatch = [regex]::Match($adminHtml, 'src="/admin/(assets/[^"]+\.js)"')
         $cssMatch = [regex]::Match($adminHtml, 'href="/admin/(assets/[^"]+\.css)"')
         if (-not $jsMatch.Success -or -not $cssMatch.Success) {
             throw "Admin Console HTML did not reference JavaScript and CSS assets"
         }
         foreach ($asset in @($jsMatch.Groups[1].Value, $cssMatch.Groups[1].Value)) {
-            $assetResponse = Invoke-WebRequest -Uri "$adminBaseUrl/admin/$asset" -TimeoutSec 5 -ErrorAction Stop
+            $assetResponse = Invoke-WebRequest -UseBasicParsing -Uri "$adminBaseUrl/admin/$asset" -TimeoutSec 5 -ErrorAction Stop
             if ($assetResponse.StatusCode -ne 200 -or [string]::IsNullOrWhiteSpace($assetResponse.Content)) {
                 throw "Embedded Admin Console asset was missing or empty: $asset"
             }

--- a/src/release/windows-binary-smoke-test.test.ts
+++ b/src/release/windows-binary-smoke-test.test.ts
@@ -15,4 +15,14 @@ describe('Windows binary smoke test', () => {
     expect(script.match(/\[System\.IO\.File\]::WriteAllText/g)).toHaveLength(2);
     expect(script).not.toMatch(/Out-File[^\r\n]+-Encoding utf8/);
   });
+
+  it('uses basic response parsing for Windows PowerShell 5.1 web requests', () => {
+    const script = readWindowsBinarySmokeTest();
+    const webRequests = script.match(/Invoke-WebRequest[^\r\n]+/g);
+
+    expect(webRequests).toHaveLength(3);
+    for (const request of webRequests ?? []) {
+      expect(request).toContain('-UseBasicParsing');
+    }
+  });
 });


### PR DESCRIPTION
Fixes the follow-up Windows binary failure in release run 31010377350. PR #438 removed the BOM and the standalone runtime now starts correctly, but Windows PowerShell 5.1 throws while parsing Invoke-WebRequest responses even though /health/ready returns 200. Add -UseBasicParsing to readiness, Admin Console HTML, and asset requests, plus regression coverage for every web request. Local validation: lint, typecheck, build, 23 release tests, and all 4,461 unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows binary smoke tests for compatibility with Windows PowerShell 5.1.
  * Updated readiness checks and Admin Console retrieval to use compatible HTTP request handling.

* **Tests**
  * Added coverage verifying compatible request behavior across all Windows smoke-test checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->