### PR TITLE
fix(serve): handle EPERM error on Windows in isOwnershipExistsError (fixes #445)

### DIFF
--- a/src/core/server/runtimeScopeOwnership.test.ts
+++ b/src/core/server/runtimeScopeOwnership.test.ts
@@ -245,6 +245,35 @@ describe('Runtime Scope ownership', () => {
     owner.release();
   });
 
+  it('reclaims valid ownership on Windows when fs.renameSync throws EPERM', () => {
+    writeOwnerRecord(
+      JSON.stringify({
+        version: 1,
+        pid: 99999999,
+        claimId: 'dead-owner',
+        kind: 'foreground-http',
+        claimedAt: '2026-07-22T00:00:00.000Z',
+      }),
+    );
+
+    const originalRenameSync = fs.renameSync;
+    vi.spyOn(fs, 'renameSync').mockImplementation(((source: fs.PathLike, destination: fs.PathLike) => {
+      // Simulate Windows EPERM directory collision error
+      if (String(source).endsWith('.candidate') && destination === ownerPath) {
+        throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' });
+      }
+      return originalRenameSync(source, destination);
+    }) as typeof fs.renameSync);
+
+    const owner = claimRuntimeScope(configDir, { kind: 'foreground-stdio', pid: process.pid });
+
+    expect(owner.record.pid).toBe(process.pid);
+    expect(owner.record.kind).toBe('foreground-stdio');
+    expect(owner.record.claimId).not.toBe('dead-owner');
+
+    owner.release();
+  });
+
   it('does not let an ownership release remove a replacement published before directory removal', () => {
     const staleRecord = {
       version: 1 as const,

--- a/src/core/server/runtimeScopeOwnership.test.ts
+++ b/src/core/server/runtimeScopeOwnership.test.ts
@@ -257,9 +257,11 @@ describe('Runtime Scope ownership', () => {
     );
 
     const originalRenameSync = fs.renameSync;
+    let collisionInjected = false;
     vi.spyOn(fs, 'renameSync').mockImplementation(((source: fs.PathLike, destination: fs.PathLike) => {
       // Simulate Windows EPERM directory collision error
-      if (String(source).endsWith('.candidate') && destination === ownerPath) {
+      if (!collisionInjected && String(source).endsWith('.candidate') && destination === ownerPath) {
+        collisionInjected = true;
         throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' });
       }
       return originalRenameSync(source, destination);

--- a/src/core/server/runtimeScopeOwnership.ts
+++ b/src/core/server/runtimeScopeOwnership.ts
@@ -727,7 +727,7 @@ function removeCandidateDirectoryIfPresent(candidateDir: string): void {
 }
 
 function isOwnershipExistsError(error: unknown): boolean {
-  return isCode(error, 'EEXIST') || isCode(error, 'ENOTEMPTY');
+  return isCode(error, 'EEXIST') || isCode(error, 'ENOTEMPTY') || isCode(error, 'EPERM');
 }
 
 function isCode(error: unknown, code: string): boolean {


### PR DESCRIPTION
This PR resolves issue #445 by adding support for `EPERM` error code to `isOwnershipExistsError` in `runtimeScopeOwnership.ts`.

On Windows, `fs.renameSync` throws `EPERM` when trying to rename a directory to an existing directory path (collision). Adding `EPERM` allows 1mcp serve to correctly detect and reclaim a stale lock directory on Windows when recovering from a crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime ownership recovery on Windows when stale ownership cannot be replaced normally.
  * Runtime scopes can now be successfully reclaimed after encountering permission-related filesystem errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->