### PR TITLE
docs(windows): add Task Scheduler deployment guide

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -120,6 +120,7 @@ function sidebar(): DefaultTheme.Sidebar {
           { text: 'Fast Startup', link: '/guide/advanced/fast-startup' },
           { text: 'Reverse Proxy', link: '/guide/advanced/reverse-proxy' },
           { text: 'Cloud Deployment', link: '/guide/advanced/cloud-deployment' },
+          { text: 'Windows Task Scheduler', link: '/guide/advanced/windows-task-scheduler' },
           { text: 'Backend Logs', link: '/guide/advanced/backend-logs' },
           { text: 'Server Filtering', link: '/guide/advanced/server-filtering' },
         ],

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -130,6 +130,7 @@ function sidebar(): DefaultTheme.Sidebar {
           { text: '快速启动', link: '/zh/guide/advanced/fast-startup' },
           { text: '反向代理', link: '/zh/guide/advanced/reverse-proxy' },
           { text: '云端部署', link: '/zh/guide/advanced/cloud-deployment' },
+          { text: 'Windows 任务计划程序', link: '/zh/guide/advanced/windows-task-scheduler' },
           { text: '后端日志', link: '/zh/guide/advanced/backend-logs' },
           { text: '服务器过滤', link: '/zh/guide/advanced/server-filtering' },
         ],

--- a/docs/en/commands/serve.md
+++ b/docs/en/commands/serve.md
@@ -282,5 +282,6 @@ Use this when the client can authenticate against the HTTP runtime. Do not assum
 - **[CLI Mode Guide](/guide/integrations/cli-mode)**
 - **[Proxy Command](/commands/proxy)**
 - **[Cloud Deployment with Caddy](/guide/advanced/cloud-deployment)**
+- **[Windows Task Scheduler Deployment](/guide/advanced/windows-task-scheduler)**
 - **[Architecture](/reference/architecture)**
 - **[Configuration Guide](/guide/essentials/configuration)**

--- a/docs/en/guide/advanced/windows-task-scheduler.md
+++ b/docs/en/guide/advanced/windows-task-scheduler.md
@@ -1,0 +1,207 @@
+---
+title: Run 1MCP with Windows Task Scheduler
+description: Run 1MCP as a persistent foreground service on Windows with Task Scheduler, automatic restart, scoped logs, and post-boot health checks.
+head:
+  - [
+      'meta',
+      { name: 'keywords', content: '1MCP Windows,Task Scheduler,Windows service,persistent daemon,scheduled task' },
+    ]
+---
+
+# Run 1MCP with Windows Task Scheduler
+
+Use this guide when one 1MCP runtime must start at boot, survive sign-out, and recover after a process failure on Windows.
+
+## Deployment model
+
+Windows Task Scheduler is the only process supervisor in this setup. Its action runs foreground `1mcp serve` directly.
+
+Do not add `--background` or `--restart` to the task action. Those options start 1MCP's own detached [Background Runtime Supervisor](/commands/serve#start-in-the-background), so Task Scheduler would monitor the launcher instead of the long-lived runtime.
+
+Run the task as the same least-privileged Windows account that owns the selected [Runtime Scope](/commands/serve#runtime-scope-and-lifecycle). The examples bind to `127.0.0.1`; expose the runtime beyond the machine only after applying the [security guidance](/guide/advanced/security).
+
+## Prerequisites
+
+1. Install the [standalone Windows binary](/guide/installation#standalone-binaries) at a stable absolute path, or install `@1mcp/agent` globally with npm.
+2. Sign in as the account that will run 1MCP and create its configuration and log directories.
+3. Record the task account name and absolute paths. Do not derive them from `$env:APPDATA` in an elevated shell that belongs to another account.
+4. Open PowerShell as Administrator only when registering the task.
+
+For example, run this first as the task account:
+
+```powershell
+$scope = Join-Path $env:APPDATA '1mcp'
+$logDirectory = Join-Path $scope 'logs'
+New-Item -ItemType Directory -Force -Path $scope, $logDirectory | Out-Null
+
+Write-Host "Runtime Scope: $scope"
+Write-Host "Log directory: $logDirectory"
+```
+
+Place `mcp.json` in the displayed Runtime Scope, or use `--config` in the task arguments to select a specific file within it.
+
+## Register the task
+
+The examples enable async loading so the HTTP listener can become available while backends connect. They do not use the retired `--async-min-servers` or `--async-timeout` compatibility options.
+
+### Standalone binary (recommended)
+
+In an elevated PowerShell window, replace the task name, account name, binary path, and Runtime Scope for the task account:
+
+```powershell
+$taskName = '1mcp-daemon'
+$taskUser = 'CONTOSO\svc-1mcp'
+$binary = 'C:\Program Files\1MCP\1mcp-win32-x64.exe'
+$scope = 'C:\Users\svc-1mcp\AppData\Roaming\1mcp'
+$logFile = Join-Path $scope 'logs\server.log'
+$runtimeCommand = $binary
+
+if (-not (Test-Path -LiteralPath $binary)) { throw "1MCP binary not found: $binary" }
+if (-not (Test-Path -LiteralPath $scope)) { throw "Runtime Scope not found: $scope" }
+
+$arguments = @(
+  'serve'
+  '--transport http'
+  '--host 127.0.0.1'
+  '--port 3050'
+  "--config-dir `"$scope`""
+  '--enable-async-loading'
+  '--enable-config-reload'
+  '--log-level info'
+  "--log-file `"$logFile`""
+) -join ' '
+
+$action = New-ScheduledTaskAction `
+  -Execute $binary `
+  -Argument $arguments `
+  -WorkingDirectory (Split-Path $binary)
+$trigger = New-ScheduledTaskTrigger -AtStartup
+$settings = New-ScheduledTaskSettingsSet `
+  -AllowStartIfOnBatteries `
+  -DontStopIfGoingOnBatteries `
+  -ExecutionTimeLimit (New-TimeSpan) `
+  -RestartCount 5 `
+  -RestartInterval (New-TimeSpan -Minutes 2) `
+  -StartWhenAvailable `
+  -MultipleInstances IgnoreNew
+
+$credential = Get-Credential -UserName $taskUser -Message 'Enter the task account password'
+$password = $credential.GetNetworkCredential().Password
+Register-ScheduledTask `
+  -TaskName $taskName `
+  -Action $action `
+  -Trigger $trigger `
+  -Settings $settings `
+  -Description '1MCP Aggregated Runtime' `
+  -User $credential.UserName `
+  -Password $password `
+  -RunLevel Limited `
+  -Force
+Remove-Variable password, credential
+```
+
+The zero `ExecutionTimeLimit` allows the runtime to run indefinitely. Task Scheduler makes five restart attempts at two-minute intervals after a failure. `IgnoreNew` prevents overlapping task instances, and `StartWhenAvailable` starts a task whose boot trigger was missed. Battery use is allowed so a laptop power-state change does not stop the runtime.
+
+### npm installation
+
+For a global npm installation, replace the standalone action above with this `cmd.exe` action before calling `Register-ScheduledTask`. Use the task account's absolute npm shim path; do not call the package-internal `build/index.js`, which can move during upgrades.
+
+```powershell
+$npmShim = 'C:\Users\svc-1mcp\AppData\Roaming\npm\1mcp.cmd'
+$cmdExe = Join-Path $env:SystemRoot 'System32\cmd.exe'
+$cmdArguments = '/d /s /c ""{0}" {1}"' -f $npmShim, $arguments
+$runtimeCommand = $npmShim
+
+if (-not (Test-Path -LiteralPath $npmShim)) { throw "1MCP npm shim not found: $npmShim" }
+$action = New-ScheduledTaskAction `
+  -Execute $cmdExe `
+  -Argument $cmdArguments `
+  -WorkingDirectory (Split-Path $npmShim)
+```
+
+## Manage the task
+
+Use Task Scheduler for lifecycle operations so it remains the sole supervisor:
+
+```powershell
+# Start now instead of waiting for the next boot
+Start-ScheduledTask -TaskName $taskName
+
+# Stop without treating the stop as a process failure
+Stop-ScheduledTask -TaskName $taskName
+
+# Restart
+Stop-ScheduledTask -TaskName $taskName
+while ((Get-ScheduledTask -TaskName $taskName).State -ne 'Ready') {
+  Start-Sleep -Seconds 1
+}
+Start-ScheduledTask -TaskName $taskName
+```
+
+To keep the runtime stopped across reboots, disable the task before stopping it:
+
+```powershell
+Disable-ScheduledTask -TaskName $taskName
+Stop-ScheduledTask -TaskName $taskName
+```
+
+Enable and start it only when service should resume:
+
+```powershell
+Enable-ScheduledTask -TaskName $taskName
+Start-ScheduledTask -TaskName $taskName
+```
+
+## Verify the runtime
+
+The explicit `--config-dir` keeps configuration, `<config-dir>\server.pid` lifecycle metadata, and local status discovery in the same Runtime Scope. Use that exact path for every status command:
+
+```powershell
+Get-ScheduledTask -TaskName $taskName | Format-List TaskName, State
+Get-ScheduledTaskInfo -TaskName $taskName | Format-List LastRunTime, LastTaskResult, NextRunTime
+
+& $runtimeCommand serve --status --config-dir $scope
+Get-NetTCPConnection -LocalAddress 127.0.0.1 -LocalPort 3050 -State Listen
+Invoke-WebRequest http://127.0.0.1:3050/health/ready -UseBasicParsing | Select-Object StatusCode
+Invoke-WebRequest http://127.0.0.1:3050/health/mcp -UseBasicParsing | Select-Object StatusCode, Content
+Get-Content $logFile -Tail 50
+```
+
+`/health/ready` returns `200` when the runtime is ready and `503` when it is not. `/health/mcp` returns `202` while backend loading continues and `200` when loading has completed; inspect its JSON summary because completion can include failed backends.
+
+## Optional startup delay
+
+Do not gate the task on a Windows network profile, and do not add a fixed delay by default. Backends can reconnect as network dependencies become available.
+
+If a domain policy or VPN consistently needs extra boot time, open the task in Task Scheduler, edit the startup trigger, and set **Delay task for** to the shortest proven interval, such as 30 seconds. Treat the delay as an environment-specific workaround, not a readiness check.
+
+## Security and logon notes
+
+- Register from elevated PowerShell, but use `RunLevel Limited` for the runtime.
+- Use password-backed non-interactive logon so the task can start before sign-in and access network resources. The password is prompted for during registration and is not embedded in the script.
+- Update the stored task credential when the account password changes.
+- Do not use `SYSTEM`, `Highest`, or an interactive-token task by default.
+- S4U is an advanced local-only alternative. It has no network or encrypted-file access, so it is unsuitable when 1MCP or its backends require either.
+
+See Microsoft's documentation for [task logon types](https://learn.microsoft.com/windows/win32/api/taskschd/ne-taskschd-task_logon_type), [scheduled task settings](https://learn.microsoft.com/powershell/module/scheduledtasks/new-scheduledtasksettingsset), and [unlimited execution time](https://learn.microsoft.com/windows/win32/taskschd/tasksettings-executiontimelimit).
+
+## Windows validation checklist
+
+Validate both installation paths and every lifecycle check below on the actual Windows host before putting the deployment into service:
+
+- [ ] The standalone binary action starts successfully.
+- [ ] The npm `1mcp.cmd` action starts successfully.
+- [ ] A real reboot starts the task before interactive sign-in.
+- [ ] Terminating the runtime process causes one scheduled replacement.
+- [ ] A deliberate `Stop-ScheduledTask` does not respawn the runtime.
+- [ ] Starting the task again while it is running leaves only one runtime PID.
+- [ ] `serve --status` observes the intended Runtime Scope.
+- [ ] `/health/ready` and `/health/mcp` report the expected state.
+- [ ] The configured log contains expected lifecycle output and no credentials.
+
+## See also
+
+- **[Serve command](/commands/serve)**
+- **[Fast startup](/guide/advanced/fast-startup)**
+- **[Health checks](/reference/health-check)**
+- **[Security](/guide/advanced/security)**

--- a/docs/en/guide/getting-started.md
+++ b/docs/en/guide/getting-started.md
@@ -348,6 +348,8 @@ curl -X POST http://localhost:3050/token \
 
 For a public cloud runtime with Admin Console access and local CLI targets, use the blessed **[Cloud Deployment with Caddy](/guide/advanced/cloud-deployment)** path after this basic service setup.
 
+On Windows, follow **[Run 1MCP with Windows Task Scheduler](/guide/advanced/windows-task-scheduler)** instead of the systemd steps below.
+
 ### **What You'll Achieve**
 
 - ✅ Systemd service for automatic startup

--- a/docs/en/guide/installation.md
+++ b/docs/en/guide/installation.md
@@ -111,6 +111,8 @@ Expand-Archive -Path "1mcp-win32-x64.zip" -DestinationPath "."
 Remove-Item "1mcp-win32-x64.zip"
 ```
 
+To keep 1MCP running across Windows reboots, continue with **[Run 1MCP with Windows Task Scheduler](/guide/advanced/windows-task-scheduler)**.
+
 **Manual Download:**
 
 Visit the [latest release page](https://github.com/1mcp-app/agent/releases/latest) and download the appropriate binary for your platform.

--- a/docs/zh/commands/serve.md
+++ b/docs/zh/commands/serve.md
@@ -272,5 +272,6 @@ http://127.0.0.1:3051/mcp?app=cursor
 - **[CLI 模式指南](/zh/guide/integrations/cli-mode)**
 - **[Proxy 命令](/zh/commands/proxy)**
 - **[使用 Caddy 进行云端部署](/zh/guide/advanced/cloud-deployment)**
+- **[Windows 任务计划程序部署](/zh/guide/advanced/windows-task-scheduler)**
 - **[架构](/zh/reference/architecture)**
 - **[配置指南](/zh/guide/essentials/configuration)**

--- a/docs/zh/guide/advanced/windows-task-scheduler.md
+++ b/docs/zh/guide/advanced/windows-task-scheduler.md
@@ -1,0 +1,204 @@
+---
+title: 通过 Windows 任务计划程序运行 1MCP
+description: 使用 Windows 任务计划程序以前台服务方式持久运行 1MCP，并配置故障重启、作用域日志和开机后健康检查。
+head:
+  - ['meta', { name: 'keywords', content: '1MCP Windows,任务计划程序,Windows 服务,持久化守护进程,计划任务' }]
+---
+
+# 通过 Windows 任务计划程序运行 1MCP
+
+当一个 1MCP 运行时需要开机启动、在用户注销后继续运行，并在进程失败后自动恢复时，请使用本指南。
+
+## 部署模型
+
+在此方案中，Windows 任务计划程序是唯一的进程 supervisor，其 action 直接运行前台 `1mcp serve`。
+
+不要在任务 action 中添加 `--background` 或 `--restart`。这些选项会启动 1MCP 自己的分离式 [Background Runtime Supervisor](/zh/commands/serve#后台启动)，导致任务计划程序只能监控启动器，而不是长期运行的运行时。
+
+任务应使用拥有所选 [Runtime Scope（运行时作用域）](/zh/commands/serve#运行时作用域与生命周期)的同一个最小权限 Windows 账户运行。示例只绑定 `127.0.0.1`；只有在应用[安全指南](/zh/guide/advanced/security)后，才应让本机以外的客户端访问运行时。
+
+## 前置条件
+
+1. 将[独立 Windows 二进制文件](/zh/guide/installation#独立二进制文件)安装到稳定的绝对路径，或者使用 npm 全局安装 `@1mcp/agent`。
+2. 以将要运行 1MCP 的账户登录，并创建其配置与日志目录。
+3. 记录任务账户名和绝对路径。不要从属于其他账户的提权 PowerShell 中通过 `$env:APPDATA` 推导这些路径。
+4. 仅在注册任务时以管理员身份打开 PowerShell。
+
+例如，先以任务账户运行：
+
+```powershell
+$scope = Join-Path $env:APPDATA '1mcp'
+$logDirectory = Join-Path $scope 'logs'
+New-Item -ItemType Directory -Force -Path $scope, $logDirectory | Out-Null
+
+Write-Host "Runtime Scope: $scope"
+Write-Host "Log directory: $logDirectory"
+```
+
+将 `mcp.json` 放入显示的 Runtime Scope；也可以在任务参数中使用 `--config`，选择该作用域内的特定文件。
+
+## 注册任务
+
+示例启用异步加载，使 HTTP 监听器可以在后端连接期间先变为可用。示例不会使用已经退役的 `--async-min-servers` 或 `--async-timeout` 兼容选项。
+
+### 独立二进制文件（推荐）
+
+在提权 PowerShell 窗口中，替换任务名称、账户名称、二进制路径和任务账户的 Runtime Scope：
+
+```powershell
+$taskName = '1mcp-daemon'
+$taskUser = 'CONTOSO\svc-1mcp'
+$binary = 'C:\Program Files\1MCP\1mcp-win32-x64.exe'
+$scope = 'C:\Users\svc-1mcp\AppData\Roaming\1mcp'
+$logFile = Join-Path $scope 'logs\server.log'
+$runtimeCommand = $binary
+
+if (-not (Test-Path -LiteralPath $binary)) { throw "1MCP binary not found: $binary" }
+if (-not (Test-Path -LiteralPath $scope)) { throw "Runtime Scope not found: $scope" }
+
+$arguments = @(
+  'serve'
+  '--transport http'
+  '--host 127.0.0.1'
+  '--port 3050'
+  "--config-dir `"$scope`""
+  '--enable-async-loading'
+  '--enable-config-reload'
+  '--log-level info'
+  "--log-file `"$logFile`""
+) -join ' '
+
+$action = New-ScheduledTaskAction `
+  -Execute $binary `
+  -Argument $arguments `
+  -WorkingDirectory (Split-Path $binary)
+$trigger = New-ScheduledTaskTrigger -AtStartup
+$settings = New-ScheduledTaskSettingsSet `
+  -AllowStartIfOnBatteries `
+  -DontStopIfGoingOnBatteries `
+  -ExecutionTimeLimit (New-TimeSpan) `
+  -RestartCount 5 `
+  -RestartInterval (New-TimeSpan -Minutes 2) `
+  -StartWhenAvailable `
+  -MultipleInstances IgnoreNew
+
+$credential = Get-Credential -UserName $taskUser -Message 'Enter the task account password'
+$password = $credential.GetNetworkCredential().Password
+Register-ScheduledTask `
+  -TaskName $taskName `
+  -Action $action `
+  -Trigger $trigger `
+  -Settings $settings `
+  -Description '1MCP Aggregated Runtime' `
+  -User $credential.UserName `
+  -Password $password `
+  -RunLevel Limited `
+  -Force
+Remove-Variable password, credential
+```
+
+值为零的 `ExecutionTimeLimit` 允许运行时无限期运行。进程失败后，任务计划程序会以两分钟为间隔尝试重启五次。`IgnoreNew` 防止任务实例重叠，`StartWhenAvailable` 会补跑错过的开机触发。允许使用电池，避免笔记本电脑电源状态变化时停止运行时。
+
+### npm 安装
+
+如果使用全局 npm 安装，请在调用 `Register-ScheduledTask` 前，用下面的 `cmd.exe` action 替换上面的独立二进制 action。请使用任务账户的 npm shim 绝对路径；不要调用可能在升级时移动的包内部 `build/index.js`。
+
+```powershell
+$npmShim = 'C:\Users\svc-1mcp\AppData\Roaming\npm\1mcp.cmd'
+$cmdExe = Join-Path $env:SystemRoot 'System32\cmd.exe'
+$cmdArguments = '/d /s /c ""{0}" {1}"' -f $npmShim, $arguments
+$runtimeCommand = $npmShim
+
+if (-not (Test-Path -LiteralPath $npmShim)) { throw "1MCP npm shim not found: $npmShim" }
+$action = New-ScheduledTaskAction `
+  -Execute $cmdExe `
+  -Argument $cmdArguments `
+  -WorkingDirectory (Split-Path $npmShim)
+```
+
+## 管理任务
+
+使用任务计划程序完成生命周期操作，确保它始终是唯一的 supervisor：
+
+```powershell
+# 立即启动，不必等待下次开机
+Start-ScheduledTask -TaskName $taskName
+
+# 停止且不把主动停止视为进程失败
+Stop-ScheduledTask -TaskName $taskName
+
+# 重启
+Stop-ScheduledTask -TaskName $taskName
+while ((Get-ScheduledTask -TaskName $taskName).State -ne 'Ready') {
+  Start-Sleep -Seconds 1
+}
+Start-ScheduledTask -TaskName $taskName
+```
+
+如需让运行时在重启后仍保持停止，请先禁用任务，再停止任务：
+
+```powershell
+Disable-ScheduledTask -TaskName $taskName
+Stop-ScheduledTask -TaskName $taskName
+```
+
+只有在需要恢复服务时才重新启用并启动：
+
+```powershell
+Enable-ScheduledTask -TaskName $taskName
+Start-ScheduledTask -TaskName $taskName
+```
+
+## 验证运行时
+
+明确指定 `--config-dir` 后，配置、`<config-dir>\server.pid` 生命周期元数据与本地状态发现都会位于同一个 Runtime Scope。每个状态命令都应使用完全相同的路径：
+
+```powershell
+Get-ScheduledTask -TaskName $taskName | Format-List TaskName, State
+Get-ScheduledTaskInfo -TaskName $taskName | Format-List LastRunTime, LastTaskResult, NextRunTime
+
+& $runtimeCommand serve --status --config-dir $scope
+Get-NetTCPConnection -LocalAddress 127.0.0.1 -LocalPort 3050 -State Listen
+Invoke-WebRequest http://127.0.0.1:3050/health/ready -UseBasicParsing | Select-Object StatusCode
+Invoke-WebRequest http://127.0.0.1:3050/health/mcp -UseBasicParsing | Select-Object StatusCode, Content
+Get-Content $logFile -Tail 50
+```
+
+运行时就绪时，`/health/ready` 返回 `200`；未就绪时返回 `503`。后端仍在加载时，`/health/mcp` 返回 `202`；加载完成后返回 `200`。完成状态仍可能包含失败的后端，因此还应检查其 JSON 摘要。
+
+## 可选的启动延迟
+
+不要让任务依赖某个 Windows 网络配置文件，也不要默认添加固定延迟。后端可以在网络依赖可用后重新连接。
+
+如果域策略或 VPN 确实总是需要额外的开机时间，请在任务计划程序中打开此任务、编辑启动触发器，并把“延迟任务时间”设置为经过验证的最短间隔，例如 30 秒。该延迟只是特定环境的规避措施，不能替代就绪检查。
+
+## 安全与登录说明
+
+- 从提权 PowerShell 注册任务，但运行时使用 `RunLevel Limited`。
+- 使用密码支持的非交互登录，使任务可以在用户登录前启动并访问网络资源。密码只在注册时提示输入，不会嵌入脚本。
+- 账户密码变更后，需要更新任务中保存的凭据。
+- 默认不要使用 `SYSTEM`、`Highest` 或交互式 token 任务。
+- S4U 是高级的纯本地替代方案。它无法访问网络或加密文件，因此当 1MCP 或其后端需要其中任一能力时都不适用。
+
+参阅 Microsoft 关于[任务登录类型](https://learn.microsoft.com/windows/win32/api/taskschd/ne-taskschd-task_logon_type)、[计划任务设置](https://learn.microsoft.com/powershell/module/scheduledtasks/new-scheduledtasksettingsset)和[无限执行时间](https://learn.microsoft.com/windows/win32/taskschd/tasksettings-executiontimelimit)的文档。
+
+## Windows 验证清单
+
+在实际 Windows 主机上将部署投入使用前，请验证两种安装路径以及下面的每一项生命周期行为：
+
+- [ ] 独立二进制 action 可以成功启动。
+- [ ] npm `1mcp.cmd` action 可以成功启动。
+- [ ] 真实重启后，任务可在交互式登录前启动。
+- [ ] 终止运行时进程后，任务只启动一个替代进程。
+- [ ] 主动执行 `Stop-ScheduledTask` 后不会重新派生运行时。
+- [ ] 运行期间再次启动任务时仍只有一个运行时 PID。
+- [ ] `serve --status` 能观察到预期的 Runtime Scope。
+- [ ] `/health/ready` 与 `/health/mcp` 报告预期状态。
+- [ ] 配置的日志包含预期生命周期输出，且不含凭据。
+
+## 另请参阅
+
+- **[Serve 命令](/zh/commands/serve)**
+- **[快速启动](/zh/guide/advanced/fast-startup)**
+- **[健康检查](/zh/reference/health-check)**
+- **[安全](/zh/guide/advanced/security)**

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -337,6 +337,8 @@ curl -X POST http://localhost:3050/token \
 
 如果要公开云端运行时、Admin Console 和本地 CLI target，完成这个基础服务设置后，请使用推荐的 **[使用 Caddy 进行云端部署](/zh/guide/advanced/cloud-deployment)** 路径。
 
+在 Windows 上，请使用 **[通过 Windows 任务计划程序运行 1MCP](/zh/guide/advanced/windows-task-scheduler)**，不要执行下面的 systemd 步骤。
+
 ### **步骤 1：生产配置** (5 分钟)
 
 ```bash

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -105,6 +105,8 @@ Expand-Archive -Path "1mcp-win32-x64.zip" -DestinationPath "."
 Remove-Item "1mcp-win32-x64.zip"
 ```
 
+如需让 1MCP 在 Windows 重启后持续运行，请继续阅读 **[通过 Windows 任务计划程序运行 1MCP](/zh/guide/advanced/windows-task-scheduler)**。
+
 **手动下载:**
 
 访问[最新发布页面](https://github.com/1mcp-app/agent/releases/latest)并下载适合您平台的二进制文件。


### PR DESCRIPTION
## Summary

- add English and Chinese Windows Task Scheduler deployment guides
- document Task Scheduler as the sole supervisor for foreground `1mcp serve`, with least-privilege registration, restart policy, Runtime Scope, and health verification
- link the guide from navigation, getting started, installation, and serve command documentation

## Verification

- `pnpm docs:build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:unit` (307 files, 4,461 tests)
- independent standards and specification reviews

## Windows validation gate

Keep this PR in draft until a real Windows host validates both standalone and npm launch paths, reboot startup, forced-failure restart, deliberate stop behavior, `IgnoreNew`, Runtime Scope status, both health endpoints, and credential-free logs.

Closes #394