### PR TITLE
feat: add Windows Task Scheduler install script and tests

### DIFF
--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -109,6 +109,7 @@ if ($PSCmdlet.ParameterSetName -eq 'Npm') {
 # ── 2. Path resolution ────────────────────────────────────────────────────────
 $resolvedConfigDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ConfigDir)
 $vbsPath = Join-Path $resolvedConfigDir '1mcp-start.vbs'
+$currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
 
 # ── 3. Uninstall path ─────────────────────────────────────────────────────────
 if ($Uninstall) {
@@ -145,7 +146,7 @@ $action = New-ScheduledTaskAction `
     -WorkingDirectory $resolvedConfigDir
 
 # ── 5. Trigger / settings ────────────────────────────────────────────────────
-$trigger  = New-ScheduledTaskTrigger -AtLogon
+$trigger  = New-ScheduledTaskTrigger -AtLogon -User $currentUser
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries `
     -DontStopIfGoingOnBatteries `
@@ -161,8 +162,6 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
     if (-not $isAdmin) {
         Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
     }
-
-    $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
 
     $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     if ($existingTask) {

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -137,7 +137,12 @@ if ($HostAddress -match '[&<>|@^(){};"`]') {
     Write-Error "HostAddress contains forbidden characters: '$HostAddress'. Only IPv4/IPv6 addresses and hostnames are allowed."
 }
 
-$argStr = "serve --transport http --host $HostAddress --port $Port --config-dir `"$resolvedConfigDir`""
+# Ensure logs directory exists for --log-file in Session 0
+$logDir  = Join-Path $resolvedConfigDir 'logs'
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+$logFile = Join-Path $logDir 'server.log'
+
+$argStr = "serve --transport http --host $HostAddress --port $Port --config-dir `"$resolvedConfigDir`" --log-file `"$logFile`""
 
 # ponytail: AtStartup + Password = Session 0, no console window visible — no VBS launcher needed.
 $action = if ($PSCmdlet.ParameterSetName -eq 'Binary') {

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -95,7 +95,14 @@ if ($PSCmdlet.ParameterSetName -eq 'Npm') {
     try {
         $cmdWrapper = (Get-Command '1mcp.cmd' -ErrorAction Stop).Source
     } catch [System.Management.Automation.CommandNotFoundException] {
-        Write-Error "1mcp.cmd not found in PATH. Ensure the package is installed globally (e.g., 'npm install -g @1mcp/agent') or use -BinaryPath instead."
+        # Fallback: Check npm global prefix if not in PATH
+        $npmPrefix = ''
+        try { $npmPrefix = npm prefix -g 2>$null } catch {}
+        
+        $cmdWrapper = if ($npmPrefix) { Join-Path $npmPrefix '1mcp.cmd' } else { '' }
+        if (-not $cmdWrapper -or -not (Test-Path $cmdWrapper -PathType Leaf)) {
+            Write-Error "1mcp.cmd not found in PATH or npm global prefix. Ensure the package is installed globally (e.g., 'npm install -g @1mcp/agent') or use -BinaryPath instead."
+        }
     }
 }
 

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -228,20 +228,31 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
 
     $probeHost = if ($HostAddress -in @('0.0.0.0', '::', '*')) { '127.0.0.1' } else { $HostAddress }
     if ($probeHost -match ':') { $probeHost = "[$probeHost]" }
-    $healthUrl = "http://${probeHost}:${Port}/health/ready"
+    $readyUrl = "http://${probeHost}:${Port}/health/ready"
+    $mcpUrl   = "http://${probeHost}:${Port}/health/mcp"
     $healthy = $false
 
     $healthDeadline = (Get-Date).AddSeconds(30)
     while ((Get-Date) -lt $healthDeadline) {
         try {
-            $resp = Invoke-WebRequest -UseBasicParsing -Uri $healthUrl -TimeoutSec 2 -ErrorAction Stop
+            $resp = Invoke-WebRequest -UseBasicParsing -Uri $readyUrl -TimeoutSec 2 -ErrorAction Stop
             if ($resp.StatusCode -eq 200) {
-                Write-Host "Health check: HTTP $($resp.StatusCode)"
+                Write-Host "Health /ready: HTTP $($resp.StatusCode)"
                 $healthy = $true
                 break
             }
         } catch {
             Start-Sleep -Seconds 1
+        }
+    }
+
+    # Also verify /health/mcp (MCP gateway readiness) per author contract
+    if ($healthy) {
+        try {
+            $mcpResp = Invoke-WebRequest -UseBasicParsing -Uri $mcpUrl -TimeoutSec 5 -ErrorAction Stop
+            Write-Host "Health /mcp:   HTTP $($mcpResp.StatusCode)"
+        } catch {
+            Write-Warning "/health/mcp not yet responding (MCP servers may still be starting)."
         }
     }
 

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -6,9 +6,11 @@
 .DESCRIPTION
   Requires an elevated (Administrator) PowerShell session.
 
-  The task runs as a specific Windows user account (LogonType Password).
-  Credentials are prompted interactively via Get-Credential — no passwords
-  are embedded in the script or the task definition.
+  The task runs as a specific Windows user account (LogonType Password)
+  and uses an AtStartup trigger so the daemon starts at boot in Session 0
+  (no desktop window). Credentials are prompted interactively via
+  Get-Credential at registration time - no passwords are embedded in the
+  script or stored anywhere besides the Windows Credential Manager.
 
 .PARAMETER BinaryPath
   Absolute path to the 1mcp standalone binary (.exe).
@@ -95,10 +97,8 @@ if ($PSCmdlet.ParameterSetName -eq 'Npm') {
     try {
         $cmdWrapper = (Get-Command '1mcp.cmd' -ErrorAction Stop).Source
     } catch [System.Management.Automation.CommandNotFoundException] {
-        # Fallback: Check npm global prefix if not in PATH
         $npmPrefix = ''
         try { $npmPrefix = npm prefix -g 2>$null } catch {}
-        
         $cmdWrapper = if ($npmPrefix) { Join-Path $npmPrefix '1mcp.cmd' } else { '' }
         if (-not $cmdWrapper -or -not (Test-Path $cmdWrapper -PathType Leaf)) {
             Write-Error "1mcp.cmd not found in PATH or npm global prefix. Ensure the package is installed globally (e.g., 'npm install -g @1mcp/agent') or use -BinaryPath instead."
@@ -106,9 +106,8 @@ if ($PSCmdlet.ParameterSetName -eq 'Npm') {
     }
 }
 
-# ── 2. Path resolution ────────────────────────────────────────────────────────
+# ── 2. Path resolution / current user ────────────────────────────────────────
 $resolvedConfigDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ConfigDir)
-$vbsPath = Join-Path $resolvedConfigDir '1mcp-start.vbs'
 $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
 
 # ── 3. Uninstall path ─────────────────────────────────────────────────────────
@@ -118,21 +117,16 @@ if ($Uninstall) {
         Write-Host "Task '$TaskName' not found — nothing to remove."
         exit 0
     }
-    
+
     $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-not $isAdmin -and -not $WhatIfPreference) {
         Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
     }
 
     if ($PSCmdlet.ShouldProcess($TaskName, 'Unregister-ScheduledTask')) {
-        Stop-ScheduledTask  -TaskName $TaskName -ErrorAction SilentlyContinue
+        Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
         Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
         Write-Host "Removed scheduled task '$TaskName'."
-
-        # Clean up launcher script if present
-        if (Test-Path $vbsPath -PathType Leaf) {
-            Remove-Item $vbsPath -Force
-        }
     }
     exit 0
 }
@@ -140,13 +134,22 @@ if ($Uninstall) {
 # ── 4. Build task action ──────────────────────────────────────────────────────
 $argStr = "serve --transport http --host $HostAddress --port $Port --config-dir `"$resolvedConfigDir`""
 
-$action = New-ScheduledTaskAction `
-    -Execute          'wscript.exe' `
-    -Argument         "//B `"$vbsPath`"" `
-    -WorkingDirectory $resolvedConfigDir
+# ponytail: AtStartup + Password = Session 0, no console window visible — no VBS launcher needed.
+$action = if ($PSCmdlet.ParameterSetName -eq 'Binary') {
+    New-ScheduledTaskAction `
+        -Execute          $resolvedBinary `
+        -Argument         $argStr `
+        -WorkingDirectory $resolvedConfigDir
+} else {
+    $cmdArg = "/c `"$cmdWrapper`" $argStr"
+    New-ScheduledTaskAction `
+        -Execute          'cmd.exe' `
+        -Argument         $cmdArg `
+        -WorkingDirectory $resolvedConfigDir
+}
 
 # ── 5. Trigger / settings ────────────────────────────────────────────────────
-$trigger  = New-ScheduledTaskTrigger -AtLogon -User $currentUser
+$trigger  = New-ScheduledTaskTrigger -AtStartup
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries `
     -DontStopIfGoingOnBatteries `
@@ -169,74 +172,31 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
             Write-Error "Task '$TaskName' already exists. Use -Force to overwrite."
         }
         Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-        # Wait for the task to fully stop to release any locks
         while ((Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue).State -eq 'Running') {
             Start-Sleep -Seconds 1
         }
     }
 
-    # Ensure config directory exists
     New-Item -ItemType Directory -Force -Path $resolvedConfigDir | Out-Null
 
-    # Write VBS launcher
-    $cmdToRun = if ($PSCmdlet.ParameterSetName -eq 'Binary') {
-        "`"$resolvedBinary`" $argStr"
-    } else {
-        "`"$cmdWrapper`" $argStr"
+    # Prompt for credentials — Get-Credential emits a Windows dialog.
+    # Password is passed to Register-ScheduledTask which stores it in
+    # Windows Credential Manager (DPAPI encrypted). We do NOT store it.
+    $cred = Get-Credential -UserName $currentUser -Message "Enter your Windows password for the 1mcp daemon task. The password will be stored securely by Task Scheduler."
+    if (-not $cred) {
+        Write-Error 'Credential prompt cancelled. Cannot register task without credentials.'
     }
-    $escapedCmd = $cmdToRun.Replace('"', '""')
-    
-    $vbsContent = @"
-Set fso = CreateObject("Scripting.FileSystemObject")
-configDir = "$resolvedConfigDir"
-pidFile = configDir & "\server.pid"
-ownerDir = configDir & "\runtime.owner"
+    $plainPassword = $cred.GetNetworkCredential().Password
 
-If fso.FileExists(pidFile) Then
-    On Error Resume Next
-    Set f = fso.OpenTextFile(pidFile, 1)
-    content = f.ReadAll
-    f.Close
-    
-    Set regEx = New RegExp
-    regEx.Pattern = """pid""\s*:\s*(\d+)"
-    Set matches = regEx.Execute(content)
-    If matches.Count > 0 Then
-        pid = matches(0).SubMatches(0)
-        Set wmi = GetObject("winmgmts:\\.\root\cimv2")
-        Set procs = wmi.ExecQuery("Select * from Win32_Process Where ProcessId = " & pid)
-        isDead = True
-        If procs.Count > 0 Then
-            For Each proc In procs
-                cmdLine = LCase(proc.CommandLine)
-                exePath = LCase(proc.ExecutablePath)
-                If InStr(cmdLine, "1mcp") > 0 Or InStr(exePath, "node") > 0 Then
-                    isDead = False
-                End If
-            Next
-        End If
-        If isDead Then
-            fso.DeleteFile pidFile, True
-            If fso.FolderExists(ownerDir) Then
-                fso.DeleteFolder ownerDir, True
-            End If
-        End If
-    End If
-    On Error GoTo 0
-End If
-
-CreateObject("Wscript.Shell").Run "cmd.exe /c $escapedCmd", 0, False
-"@
-
-    [System.IO.File]::WriteAllText($vbsPath, $vbsContent, [System.Text.Encoding]::UTF8)
-
-    $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType Interactive -RunLevel Limited
+    $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType Password -RunLevel Limited
     Register-ScheduledTask `
         -TaskName    $TaskName `
         -Action      $action `
         -Trigger     $trigger `
         -Settings    $settings `
         -Principal   $principal `
+        -User        $currentUser `
+        -Password    $plainPassword `
         -Description '1MCP aggregated MCP runtime (managed by install-windows-task.ps1)' `
         -Force:$Force | Out-Null
 
@@ -283,4 +243,8 @@ CreateObject("Wscript.Shell").Run "cmd.exe /c $escapedCmd", 0, False
     Write-Host "  State  : $state"
     Write-Host "  Status : 1mcp serve --status --config-dir `"$resolvedConfigDir`""
     Write-Host "  Remove : .\scripts\install-windows-task.ps1 -Uninstall [-TaskName '$TaskName']"
+    Write-Host "  Note   : If you change your Windows password, re-run this script to update the stored task credentials."
 }
+
+# ponytail: removed ~60 lines of VBS launcher (Session 0 has no visible window).
+# ponytail: switched InteractiveToken -> Password (InteractiveToken cannot work with AtStartup).

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -1,5 +1,4 @@
-#Requires -Version 5.1
-<#
+﻿<#
 .SYNOPSIS
   Register or remove 1mcp serve as a Windows Task Scheduler daemon.
 
@@ -25,7 +24,7 @@
   Absolute path to the 1mcp configuration directory.
   The task account is granted Modify access on this directory so it can
   write server.pid and log files.
-  Default: C:\ProgramData\1mcp
+  Default: $env:APPDATA\1mcp
 
 .PARAMETER Port
   Port for 1mcp to listen on. Default: 3050.
@@ -63,6 +62,7 @@
   # Remove the task
   .\scripts\install-windows-task.ps1 -Uninstall
 #>
+#Requires -Version 5.1
 [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Binary')]
 param(
     [Parameter(ParameterSetName = 'Binary', Mandatory = $true)]
@@ -90,7 +90,7 @@ if ($PSCmdlet.ParameterSetName -eq 'Binary') {
     if (-not (Test-Path $BinaryPath -PathType Leaf)) {
         Write-Error "Binary not found: $BinaryPath"
     }
-    $resolvedBinary = (Resolve-Path $BinaryPath).Path
+    if ($WhatIfPreference) { $resolvedBinary = $BinaryPath } else { $resolvedBinary = (Resolve-Path $BinaryPath).Path }
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'Npm') {
@@ -132,6 +132,11 @@ if ($Uninstall) {
 }
 
 # ── 4. Build task action ──────────────────────────────────────────────────────
+# Reject shell metacharacters in HostAddress to prevent cmd.exe injection in npm mode.
+if ($HostAddress -match '[&<>|@^(){};"`]') {
+    Write-Error "HostAddress contains forbidden characters: '$HostAddress'. Only IPv4/IPv6 addresses and hostnames are allowed."
+}
+
 $argStr = "serve --transport http --host $HostAddress --port $Port --config-dir `"$resolvedConfigDir`""
 
 # ponytail: AtStartup + Password = Session 0, no console window visible — no VBS launcher needed.
@@ -141,7 +146,7 @@ $action = if ($PSCmdlet.ParameterSetName -eq 'Binary') {
         -Argument         $argStr `
         -WorkingDirectory $resolvedConfigDir
 } else {
-    $cmdArg = "/c `"$cmdWrapper`" $argStr"
+    $cmdArg = '/s /c ""{0}" {1}"' -f $cmdWrapper, $argStr
     New-ScheduledTaskAction `
         -Execute          'cmd.exe' `
         -Argument         $cmdArg `
@@ -172,12 +177,15 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
             Write-Error "Task '$TaskName' already exists. Use -Force to overwrite."
         }
         Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-        while ((Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue).State -eq 'Running') {
+        $stopDeadline = (Get-Date).AddSeconds(30)
+        while ((Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue).State -eq 'Running' -and (Get-Date) -lt $stopDeadline) {
             Start-Sleep -Seconds 1
+        }
+        if ((Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue).State -eq 'Running') {
+            Write-Error "Task '$TaskName' did not stop within 30 s. Cannot replace a running task."
         }
     }
 
-    New-Item -ItemType Directory -Force -Path $resolvedConfigDir | Out-Null
 
     # Prompt for credentials — Get-Credential emits a Windows dialog.
     # Password is passed to Register-ScheduledTask which stores it in
@@ -187,6 +195,17 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
         Write-Error 'Credential prompt cancelled. Cannot register task without credentials.'
     }
     $plainPassword = $cred.GetNetworkCredential().Password
+
+    New-Item -ItemType Directory -Force -Path $resolvedConfigDir | Out-Null
+
+    # Grant Modify access on config directory BEFORE registering the task
+    # so the task account can immediately write server.pid and logs.
+    $icaclsArgs = @($resolvedConfigDir, '/grant', "$($currentUser):(OI)(CI)M")
+    & icacls $icaclsArgs | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "icacls failed with exit code $LASTEXITCODE. Could not grant permissions on '$resolvedConfigDir'."
+    }
+    Write-Host "Granted Modify access on '$resolvedConfigDir' to '$currentUser'."
 
     # ponytail: -User + -Password implicitly sets LogonType=Password and RunLevel=Limited.
     Register-ScheduledTask `
@@ -199,13 +218,6 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
         -Description '1MCP aggregated MCP runtime (managed by install-windows-task.ps1)' `
         -Force:$Force | Out-Null
 
-    # ── 7. Grant Modify access on config directory ────────────────────────────
-    $icaclsArgs = @($resolvedConfigDir, '/grant', "$($currentUser):(OI)(CI)M")
-    & icacls $icaclsArgs | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "icacls failed with exit code $LASTEXITCODE. Could not grant permissions on '$resolvedConfigDir'."
-    }
-    Write-Host "Granted Modify access on '$resolvedConfigDir' to '$currentUser'."
 
     # ── 8. Initial start + health check ──────────────────────────────────────
     Write-Host "Starting '$TaskName' for initial verification..."
@@ -219,7 +231,8 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
     $healthUrl = "http://${probeHost}:${Port}/health/ready"
     $healthy = $false
 
-    for ($attempt = 0; $attempt -lt 30; $attempt++) {
+    $healthDeadline = (Get-Date).AddSeconds(30)
+    while ((Get-Date) -lt $healthDeadline) {
         try {
             $resp = Invoke-WebRequest -UseBasicParsing -Uri $healthUrl -TimeoutSec 2 -ErrorAction Stop
             if ($resp.StatusCode -eq 200) {

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -188,13 +188,12 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
     }
     $plainPassword = $cred.GetNetworkCredential().Password
 
-    $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType Password -RunLevel Limited
+    # ponytail: -User + -Password implicitly sets LogonType=Password and RunLevel=Limited.
     Register-ScheduledTask `
         -TaskName    $TaskName `
         -Action      $action `
         -Trigger     $trigger `
         -Settings    $settings `
-        -Principal   $principal `
         -User        $currentUser `
         -Password    $plainPassword `
         -Description '1MCP aggregated MCP runtime (managed by install-windows-task.ps1)' `

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -78,27 +78,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# ── 1. Elevation check ────────────────────────────────────────────────────────
-$currentPrincipal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
-$isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-if (-not $isAdmin) {
-    Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
-}
-
-# ── 2. Uninstall path ─────────────────────────────────────────────────────────
-if ($Uninstall) {
-    $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-    if (-not $existing) {
-        Write-Host "Task '$TaskName' not found — nothing to remove."
-        exit 0
-    }
-    Stop-ScheduledTask  -TaskName $TaskName -ErrorAction SilentlyContinue
-    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
-    Write-Host "Removed scheduled task '$TaskName'."
-    exit 0
-}
-
-# ── 3. Parameter validation ───────────────────────────────────────────────────
+# ── 1. Parameter validation ───────────────────────────────────────────────────
 if ($PSCmdlet.ParameterSetName -eq 'Binary') {
     if (-not (Test-Path $BinaryPath -PathType Leaf)) {
         Write-Error "Binary not found: $BinaryPath"
@@ -110,8 +90,30 @@ if ($PSCmdlet.ParameterSetName -eq 'Npm') {
     $cmdWrapper = (Get-Command '1mcp.cmd' -ErrorAction Stop).Source
 }
 
+# ── 2. Uninstall path ─────────────────────────────────────────────────────────
+if ($Uninstall) {
+    $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if (-not $existing) {
+        Write-Host "Task '$TaskName' not found — nothing to remove."
+        exit 0
+    }
+    
+    $isAdmin = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent().IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if (-not $isAdmin -and -not $WhatIfPreference) {
+        Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
+    }
+
+    if ($PSCmdlet.ShouldProcess($TaskName, 'Unregister-ScheduledTask')) {
+        Stop-ScheduledTask  -TaskName $TaskName -ErrorAction SilentlyContinue
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+        Write-Host "Removed scheduled task '$TaskName'."
+    }
+    exit 0
+}
+
+# ── 3. Path resolution ────────────────────────────────────────────────────────
 New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
-$resolvedConfigDir = (Resolve-Path $ConfigDir).Path
+$resolvedConfigDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ConfigDir)
 
 # ── 4. Build task action ──────────────────────────────────────────────────────
 $argStr = "serve --transport http --host $HostAddress --port $Port --config-dir `"$resolvedConfigDir`""
@@ -124,11 +126,11 @@ $action = if ($PSCmdlet.ParameterSetName -eq 'Binary') {
 } else {
     New-ScheduledTaskAction `
         -Execute          'cmd.exe' `
-        -Argument         "/c `"$cmdWrapper`" $argStr" `
+        -Argument         "/s /c `"`"$cmdWrapper`" $argStr`"" `
         -WorkingDirectory $resolvedConfigDir
 }
 
-# ── 5. Trigger / settings / principal ────────────────────────────────────────
+# ── 5. Trigger / settings ────────────────────────────────────────────────────
 $trigger  = New-ScheduledTaskTrigger -AtStartup
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries `
@@ -138,20 +140,23 @@ $settings = New-ScheduledTaskSettingsSet `
     -RestartInterval (New-TimeSpan -Minutes 2) `
     -StartWhenAvailable `
     -MultipleInstances IgnoreNew
-$principal = New-ScheduledTaskPrincipal -LogonType Password -RunLevel Limited
 
 # ── 6. Credential prompt + registration ──────────────────────────────────────
-Write-Host "Enter the Windows account credentials for task '$TaskName'."
-Write-Host "(The account must have the 'Log on as a service' or 'Log on as a batch job' right.)"
-$cred = Get-Credential -Message "Account for scheduled task '$TaskName'"
-
 if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
+    $isAdmin = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent().IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if (-not $isAdmin) {
+        Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
+    }
+
+    Write-Host "Enter the Windows account credentials for task '$TaskName'."
+    Write-Host "(The account must have the 'Log on as a service' or 'Log on as a batch job' right.)"
+    $cred = Get-Credential -Message "Account for scheduled task '$TaskName'"
+
     Register-ScheduledTask `
         -TaskName    $TaskName `
         -Action      $action `
         -Trigger     $trigger `
         -Settings    $settings `
-        -Principal   $principal `
         -User        $cred.UserName `
         -Password    $cred.GetNetworkCredential().Password `
         -Description '1MCP aggregated MCP runtime (managed by install-windows-task.ps1)' `
@@ -160,24 +165,39 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
     # ── 7. Grant Modify access on config directory ────────────────────────────
     # The task account needs Modify (not just Write) so it can create subdirs,
     # rename temp PID files atomically, and write log files.
-    icacls $resolvedConfigDir /grant "$($cred.UserName):(OI)(CI)M" | Out-Null
+    $icaclsArgs = @($resolvedConfigDir, '/grant', "$($cred.UserName):(OI)(CI)M")
+    & icacls $icaclsArgs | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "icacls failed with exit code $LASTEXITCODE. Could not grant permissions on '$resolvedConfigDir'."
+    }
     Write-Host "Granted Modify access on '$resolvedConfigDir' to '$($cred.UserName)'."
 
     # ── 8. Initial start + health check ──────────────────────────────────────
     Write-Host "Starting '$TaskName' for initial verification..."
     Start-ScheduledTask -TaskName $TaskName
-    Start-Sleep -Seconds 5
 
     $state = (Get-ScheduledTask -TaskName $TaskName).State
     Write-Host "Task state: $state"
 
-    try {
-        $resp = Invoke-WebRequest `
-            -UseBasicParsing "http://${HostAddress}:${Port}/health/ready" `
-            -TimeoutSec 10
-        Write-Host "Health check: HTTP $($resp.StatusCode)"
-    } catch {
-        Write-Warning "Health endpoint did not respond within 10 s (daemon may still be starting)."
+    $probeHost = if ($HostAddress -in @('0.0.0.0', '::', '*')) { '127.0.0.1' } else { $HostAddress }
+    $healthUrl = "http://${probeHost}:${Port}/health/ready"
+    $healthy = $false
+
+    for ($attempt = 0; $attempt -lt 30; $attempt++) {
+        try {
+            $resp = Invoke-WebRequest -UseBasicParsing -Uri $healthUrl -TimeoutSec 2 -ErrorAction Stop
+            if ($resp.StatusCode -eq 200) {
+                Write-Host "Health check: HTTP $($resp.StatusCode)"
+                $healthy = $true
+                break
+            }
+        } catch {
+            Start-Sleep -Seconds 1
+        }
+    }
+
+    if (-not $healthy) {
+        Write-Warning "Health endpoint did not respond within 30 s (daemon may still be starting)."
         Write-Warning "Verify: 1mcp serve --status --config-dir `"$resolvedConfigDir`""
     }
 

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -1,0 +1,189 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Register or remove 1mcp serve as a Windows Task Scheduler daemon.
+
+.DESCRIPTION
+  Idempotent: re-running the script re-registers the task with -Force.
+  Requires an elevated (Administrator) PowerShell session.
+
+  The task runs as a specific Windows user account (LogonType Password).
+  Credentials are prompted interactively via Get-Credential — no passwords
+  are embedded in the script or the task definition.
+
+.PARAMETER BinaryPath
+  Absolute path to the 1mcp standalone binary (.exe).
+  Mutually exclusive with -UseNpm.
+
+.PARAMETER UseNpm
+  Locate and use the 1mcp.cmd npm wrapper found on PATH instead of a
+  standalone binary.
+  Mutually exclusive with -BinaryPath.
+
+.PARAMETER ConfigDir
+  Absolute path to the 1mcp configuration directory.
+  The task account is granted Modify access on this directory so it can
+  write server.pid and log files.
+  Default: C:\ProgramData\1mcp
+
+.PARAMETER Port
+  Port for 1mcp to listen on. Default: 3050.
+
+.PARAMETER HostAddress
+  Host address for 1mcp to bind to. Default: 127.0.0.1.
+
+.PARAMETER TaskName
+  Windows Task Scheduler task name. Default: 1mcp-daemon.
+
+.PARAMETER Uninstall
+  Stop and remove the task instead of registering it.
+
+.EXAMPLE
+  # Standalone binary
+  .\scripts\install-windows-task.ps1 -BinaryPath 'C:\Program Files\1mcp\1mcp.exe'
+
+.EXAMPLE
+  # npm installation
+  .\scripts\install-windows-task.ps1 -UseNpm
+
+.EXAMPLE
+  # Custom config directory and port
+  .\scripts\install-windows-task.ps1 -BinaryPath 'C:\1mcp\1mcp.exe' `
+      -ConfigDir 'C:\ProgramData\myorg\1mcp' -Port 3051
+
+.EXAMPLE
+  # Preview changes without applying them
+  .\scripts\install-windows-task.ps1 -BinaryPath 'C:\1mcp\1mcp.exe' -WhatIf
+
+.EXAMPLE
+  # Remove the task
+  .\scripts\install-windows-task.ps1 -Uninstall
+#>
+[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Binary')]
+param(
+    [Parameter(ParameterSetName = 'Binary', Mandatory = $true)]
+    [string]$BinaryPath,
+
+    [Parameter(ParameterSetName = 'Npm', Mandatory = $true)]
+    [switch]$UseNpm,
+
+    [string]$ConfigDir   = 'C:\ProgramData\1mcp',
+    [int]$Port           = 3050,
+    [string]$HostAddress = '127.0.0.1',
+    [string]$TaskName    = '1mcp-daemon',
+
+    [Parameter(ParameterSetName = 'Uninstall', Mandatory = $true)]
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ── 1. Elevation check ────────────────────────────────────────────────────────
+$currentPrincipal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+$isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
+}
+
+# ── 2. Uninstall path ─────────────────────────────────────────────────────────
+if ($Uninstall) {
+    $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if (-not $existing) {
+        Write-Host "Task '$TaskName' not found — nothing to remove."
+        exit 0
+    }
+    Stop-ScheduledTask  -TaskName $TaskName -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "Removed scheduled task '$TaskName'."
+    exit 0
+}
+
+# ── 3. Parameter validation ───────────────────────────────────────────────────
+if ($PSCmdlet.ParameterSetName -eq 'Binary') {
+    if (-not (Test-Path $BinaryPath -PathType Leaf)) {
+        Write-Error "Binary not found: $BinaryPath"
+    }
+    $resolvedBinary = (Resolve-Path $BinaryPath).Path
+}
+
+if ($PSCmdlet.ParameterSetName -eq 'Npm') {
+    $cmdWrapper = (Get-Command '1mcp.cmd' -ErrorAction Stop).Source
+}
+
+New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
+$resolvedConfigDir = (Resolve-Path $ConfigDir).Path
+
+# ── 4. Build task action ──────────────────────────────────────────────────────
+$argStr = "serve --transport http --host $HostAddress --port $Port --config-dir `"$resolvedConfigDir`""
+
+$action = if ($PSCmdlet.ParameterSetName -eq 'Binary') {
+    New-ScheduledTaskAction `
+        -Execute          $resolvedBinary `
+        -Argument         $argStr `
+        -WorkingDirectory $resolvedConfigDir
+} else {
+    New-ScheduledTaskAction `
+        -Execute          'cmd.exe' `
+        -Argument         "/c `"$cmdWrapper`" $argStr" `
+        -WorkingDirectory $resolvedConfigDir
+}
+
+# ── 5. Trigger / settings / principal ────────────────────────────────────────
+$trigger  = New-ScheduledTaskTrigger -AtStartup
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -ExecutionTimeLimit (New-TimeSpan -Seconds 0) `
+    -RestartCount 5 `
+    -RestartInterval (New-TimeSpan -Minutes 2) `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew
+$principal = New-ScheduledTaskPrincipal -LogonType Password -RunLevel Limited
+
+# ── 6. Credential prompt + registration ──────────────────────────────────────
+Write-Host "Enter the Windows account credentials for task '$TaskName'."
+Write-Host "(The account must have the 'Log on as a service' or 'Log on as a batch job' right.)"
+$cred = Get-Credential -Message "Account for scheduled task '$TaskName'"
+
+if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
+    Register-ScheduledTask `
+        -TaskName    $TaskName `
+        -Action      $action `
+        -Trigger     $trigger `
+        -Settings    $settings `
+        -Principal   $principal `
+        -User        $cred.UserName `
+        -Password    $cred.GetNetworkCredential().Password `
+        -Description '1MCP aggregated MCP runtime (managed by install-windows-task.ps1)' `
+        -Force | Out-Null
+
+    # ── 7. Grant Modify access on config directory ────────────────────────────
+    # The task account needs Modify (not just Write) so it can create subdirs,
+    # rename temp PID files atomically, and write log files.
+    icacls $resolvedConfigDir /grant "$($cred.UserName):(OI)(CI)M" | Out-Null
+    Write-Host "Granted Modify access on '$resolvedConfigDir' to '$($cred.UserName)'."
+
+    # ── 8. Initial start + health check ──────────────────────────────────────
+    Write-Host "Starting '$TaskName' for initial verification..."
+    Start-ScheduledTask -TaskName $TaskName
+    Start-Sleep -Seconds 5
+
+    $state = (Get-ScheduledTask -TaskName $TaskName).State
+    Write-Host "Task state: $state"
+
+    try {
+        $resp = Invoke-WebRequest `
+            -UseBasicParsing "http://${HostAddress}:${Port}/health/ready" `
+            -TimeoutSec 10
+        Write-Host "Health check: HTTP $($resp.StatusCode)"
+    } catch {
+        Write-Warning "Health endpoint did not respond within 10 s (daemon may still be starting)."
+        Write-Warning "Verify: 1mcp serve --status --config-dir `"$resolvedConfigDir`""
+    }
+
+    Write-Host ''
+    Write-Host "Task '$TaskName' registered successfully."
+    Write-Host "  State  : $state"
+    Write-Host "  Status : 1mcp serve --status --config-dir `"$resolvedConfigDir`""
+    Write-Host "  Remove : .\scripts\install-windows-task.ps1 -Uninstall [-TaskName '$TaskName']"
+}

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -69,7 +69,7 @@ param(
     [Parameter(ParameterSetName = 'Npm', Mandatory = $true)]
     [switch]$UseNpm,
 
-    [string]$ConfigDir   = 'C:\ProgramData\1mcp',
+    [string]$ConfigDir   = "$env:APPDATA\1mcp",
     [ValidateRange(1, 65535)]
     [int]$Port           = 3050,
     [string]$HostAddress = '127.0.0.1',
@@ -106,7 +106,11 @@ if ($PSCmdlet.ParameterSetName -eq 'Npm') {
     }
 }
 
-# ── 2. Uninstall path ─────────────────────────────────────────────────────────
+# ── 2. Path resolution ────────────────────────────────────────────────────────
+$resolvedConfigDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ConfigDir)
+$vbsPath = Join-Path $resolvedConfigDir '1mcp-start.vbs'
+
+# ── 3. Uninstall path ─────────────────────────────────────────────────────────
 if ($Uninstall) {
     $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     if (-not $existing) {
@@ -123,31 +127,25 @@ if ($Uninstall) {
         Stop-ScheduledTask  -TaskName $TaskName -ErrorAction SilentlyContinue
         Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
         Write-Host "Removed scheduled task '$TaskName'."
+
+        # Clean up launcher script if present
+        if (Test-Path $vbsPath -PathType Leaf) {
+            Remove-Item $vbsPath -Force
+        }
     }
     exit 0
 }
 
-# ── 3. Path resolution ────────────────────────────────────────────────────────
-New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
-$resolvedConfigDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ConfigDir)
-
 # ── 4. Build task action ──────────────────────────────────────────────────────
 $argStr = "serve --transport http --host $HostAddress --port $Port --config-dir `"$resolvedConfigDir`""
 
-$action = if ($PSCmdlet.ParameterSetName -eq 'Binary') {
-    New-ScheduledTaskAction `
-        -Execute          $resolvedBinary `
-        -Argument         $argStr `
-        -WorkingDirectory $resolvedConfigDir
-} else {
-    New-ScheduledTaskAction `
-        -Execute          'cmd.exe' `
-        -Argument         "/s /c `"`"$cmdWrapper`" $argStr`"" `
-        -WorkingDirectory $resolvedConfigDir
-}
+$action = New-ScheduledTaskAction `
+    -Execute          'wscript.exe' `
+    -Argument         "//B `"$vbsPath`"" `
+    -WorkingDirectory $resolvedConfigDir
 
 # ── 5. Trigger / settings ────────────────────────────────────────────────────
-$trigger  = New-ScheduledTaskTrigger -AtStartup
+$trigger  = New-ScheduledTaskTrigger -AtLogon
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries `
     -DontStopIfGoingOnBatteries `
@@ -157,16 +155,14 @@ $settings = New-ScheduledTaskSettingsSet `
     -StartWhenAvailable `
     -MultipleInstances IgnoreNew
 
-# ── 6. Credential prompt + registration ──────────────────────────────────────
+# ── 6. Task registration ──────────────────────────────────────────────────────
 if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
     $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-not $isAdmin) {
         Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
     }
 
-    Write-Host "Enter the Windows account credentials for task '$TaskName'."
-    Write-Host "(The account must have the 'Log on as a service' or 'Log on as a batch job' right.)"
-    $cred = Get-Credential -Message "Account for scheduled task '$TaskName'"
+    $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
 
     $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     if ($existingTask) {
@@ -180,25 +176,78 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
         }
     }
 
+    # Ensure config directory exists
+    New-Item -ItemType Directory -Force -Path $resolvedConfigDir | Out-Null
+
+    # Write VBS launcher
+    $cmdToRun = if ($PSCmdlet.ParameterSetName -eq 'Binary') {
+        "`"$resolvedBinary`" $argStr"
+    } else {
+        "`"$cmdWrapper`" $argStr"
+    }
+    $escapedCmd = $cmdToRun.Replace('"', '""')
+    
+    $vbsContent = @"
+Set fso = CreateObject("Scripting.FileSystemObject")
+configDir = "$resolvedConfigDir"
+pidFile = configDir & "\server.pid"
+ownerDir = configDir & "\runtime.owner"
+
+If fso.FileExists(pidFile) Then
+    On Error Resume Next
+    Set f = fso.OpenTextFile(pidFile, 1)
+    content = f.ReadAll
+    f.Close
+    
+    Set regEx = New RegExp
+    regEx.Pattern = """pid""\s*:\s*(\d+)"
+    Set matches = regEx.Execute(content)
+    If matches.Count > 0 Then
+        pid = matches(0).SubMatches(0)
+        Set wmi = GetObject("winmgmts:\\.\root\cimv2")
+        Set procs = wmi.ExecQuery("Select * from Win32_Process Where ProcessId = " & pid)
+        isDead = True
+        If procs.Count > 0 Then
+            For Each proc In procs
+                cmdLine = LCase(proc.CommandLine)
+                exePath = LCase(proc.ExecutablePath)
+                If InStr(cmdLine, "1mcp") > 0 Or InStr(exePath, "node") > 0 Then
+                    isDead = False
+                End If
+            Next
+        End If
+        If isDead Then
+            fso.DeleteFile pidFile, True
+            If fso.FolderExists(ownerDir) Then
+                fso.DeleteFolder ownerDir, True
+            End If
+        End If
+    End If
+    On Error GoTo 0
+End If
+
+CreateObject("Wscript.Shell").Run "cmd.exe /c $escapedCmd", 0, False
+"@
+
+    [System.IO.File]::WriteAllText($vbsPath, $vbsContent, [System.Text.Encoding]::UTF8)
+
+    $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType Interactive -RunLevel Limited
     Register-ScheduledTask `
         -TaskName    $TaskName `
         -Action      $action `
         -Trigger     $trigger `
         -Settings    $settings `
-        -User        $cred.UserName `
-        -Password    $cred.GetNetworkCredential().Password `
+        -Principal   $principal `
         -Description '1MCP aggregated MCP runtime (managed by install-windows-task.ps1)' `
         -Force:$Force | Out-Null
 
     # ── 7. Grant Modify access on config directory ────────────────────────────
-    # The task account needs Modify (not just Write) so it can create subdirs,
-    # rename temp PID files atomically, and write log files.
-    $icaclsArgs = @($resolvedConfigDir, '/grant', "$($cred.UserName):(OI)(CI)M")
+    $icaclsArgs = @($resolvedConfigDir, '/grant', "$($currentUser):(OI)(CI)M")
     & icacls $icaclsArgs | Out-Null
     if ($LASTEXITCODE -ne 0) {
         Write-Error "icacls failed with exit code $LASTEXITCODE. Could not grant permissions on '$resolvedConfigDir'."
     }
-    Write-Host "Granted Modify access on '$resolvedConfigDir' to '$($cred.UserName)'."
+    Write-Host "Granted Modify access on '$resolvedConfigDir' to '$currentUser'."
 
     # ── 8. Initial start + health check ──────────────────────────────────────
     Write-Host "Starting '$TaskName' for initial verification..."

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -114,7 +114,7 @@ if ($Uninstall) {
         exit 0
     }
     
-    $isAdmin = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent().IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-not $isAdmin -and -not $WhatIfPreference) {
         Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
     }
@@ -159,7 +159,7 @@ $settings = New-ScheduledTaskSettingsSet `
 
 # ── 6. Credential prompt + registration ──────────────────────────────────────
 if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
-    $isAdmin = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent().IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-not $isAdmin) {
         Write-Error 'This script must run from an elevated (Administrator) PowerShell session.'
     }

--- a/scripts/install-windows-task.ps1
+++ b/scripts/install-windows-task.ps1
@@ -4,7 +4,6 @@
   Register or remove 1mcp serve as a Windows Task Scheduler daemon.
 
 .DESCRIPTION
-  Idempotent: re-running the script re-registers the task with -Force.
   Requires an elevated (Administrator) PowerShell session.
 
   The task runs as a specific Windows user account (LogonType Password).
@@ -38,6 +37,9 @@
 .PARAMETER Uninstall
   Stop and remove the task instead of registering it.
 
+.PARAMETER Force
+  Overwrite an existing task with the same name if it already exists.
+
 .EXAMPLE
   # Standalone binary
   .\scripts\install-windows-task.ps1 -BinaryPath 'C:\Program Files\1mcp\1mcp.exe'
@@ -68,12 +70,15 @@ param(
     [switch]$UseNpm,
 
     [string]$ConfigDir   = 'C:\ProgramData\1mcp',
+    [ValidateRange(1, 65535)]
     [int]$Port           = 3050,
     [string]$HostAddress = '127.0.0.1',
     [string]$TaskName    = '1mcp-daemon',
 
     [Parameter(ParameterSetName = 'Uninstall', Mandatory = $true)]
-    [switch]$Uninstall
+    [switch]$Uninstall,
+
+    [switch]$Force
 )
 
 $ErrorActionPreference = 'Stop'
@@ -87,7 +92,11 @@ if ($PSCmdlet.ParameterSetName -eq 'Binary') {
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'Npm') {
-    $cmdWrapper = (Get-Command '1mcp.cmd' -ErrorAction Stop).Source
+    try {
+        $cmdWrapper = (Get-Command '1mcp.cmd' -ErrorAction Stop).Source
+    } catch [System.Management.Automation.CommandNotFoundException] {
+        Write-Error "1mcp.cmd not found in PATH. Ensure the package is installed globally (e.g., 'npm install -g @1mcp/agent') or use -BinaryPath instead."
+    }
 }
 
 # ── 2. Uninstall path ─────────────────────────────────────────────────────────
@@ -152,6 +161,18 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
     Write-Host "(The account must have the 'Log on as a service' or 'Log on as a batch job' right.)"
     $cred = Get-Credential -Message "Account for scheduled task '$TaskName'"
 
+    $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($existingTask) {
+        if (-not $Force) {
+            Write-Error "Task '$TaskName' already exists. Use -Force to overwrite."
+        }
+        Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        # Wait for the task to fully stop to release any locks
+        while ((Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue).State -eq 'Running') {
+            Start-Sleep -Seconds 1
+        }
+    }
+
     Register-ScheduledTask `
         -TaskName    $TaskName `
         -Action      $action `
@@ -160,7 +181,7 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
         -User        $cred.UserName `
         -Password    $cred.GetNetworkCredential().Password `
         -Description '1MCP aggregated MCP runtime (managed by install-windows-task.ps1)' `
-        -Force | Out-Null
+        -Force:$Force | Out-Null
 
     # ── 7. Grant Modify access on config directory ────────────────────────────
     # The task account needs Modify (not just Write) so it can create subdirs,
@@ -180,6 +201,7 @@ if ($PSCmdlet.ShouldProcess($TaskName, 'Register-ScheduledTask')) {
     Write-Host "Task state: $state"
 
     $probeHost = if ($HostAddress -in @('0.0.0.0', '::', '*')) { '127.0.0.1' } else { $HostAddress }
+    if ($probeHost -match ':') { $probeHost = "[$probeHost]" }
     $healthUrl = "http://${probeHost}:${Port}/health/ready"
     $healthy = $false
 

--- a/scripts/test-install-windows-task.ps1
+++ b/scripts/test-install-windows-task.ps1
@@ -129,8 +129,8 @@ Assert-Pass '6. -WhatIf: no task is registered and no credentials prompt' {
     if ($proc.ExitCode -ne 0) {
         throw "Script exited with code $($proc.ExitCode). Error output: $errOutput"
     }
-    if (-not ($outOutput -match "What if:")) {
-        throw "Expected output to contain 'What if:', but got: $outOutput"
+    if (-not ($outOutput -match 'What ?[iI]f:')) {
+        throw "Expected output to contain 'What if:' (or localized equivalent), but got: $outOutput"
     }
     
     $stillAbsent = -not (Get-ScheduledTask -TaskName $fakeName -ErrorAction SilentlyContinue)

--- a/scripts/test-install-windows-task.ps1
+++ b/scripts/test-install-windows-task.ps1
@@ -28,18 +28,6 @@ function Assert-Pass {
     }
 }
 
-function Assert-Fail {
-    param([string]$Label, [scriptblock]$Test)
-    try {
-        & $Test
-        Write-Host "FAIL: $Label — expected an error but none was thrown"
-        $script:failures++
-    } catch {
-        $firstLine = $_.Exception.Message.Split([char]10)[0]
-        Write-Host "PASS: $Label (threw as expected: $firstLine)"
-    }
-}
-
 Write-Host "Testing $ScriptPath"
 Write-Host ("─" * 60)
 
@@ -70,7 +58,7 @@ Assert-Pass '3. Get-Help: synopsis present' {
 
 # ── Test 4: -BinaryPath that does not exist triggers Write-Error ──────────────
 # Spawn a child process so Write-Error / exit propagate cleanly.
-Assert-Pass '4. -BinaryPath nonexistent: exits non-zero' {
+Assert-Pass '4. -BinaryPath nonexistent: exits non-zero and prints correct error' {
     $fakePath = 'C:\nonexistent-path\1mcp.exe'
     $proc = Start-Process powershell.exe `
         -ArgumentList @(
@@ -79,9 +67,17 @@ Assert-Pass '4. -BinaryPath nonexistent: exits non-zero' {
             '-File', $ScriptPath,
             '-BinaryPath', $fakePath
         ) `
+        -RedirectStandardError "test-err.log" -RedirectStandardOutput "test-out.log" `
         -PassThru -Wait -NoNewWindow
+
+    $errOutput = Get-Content "test-err.log" -ErrorAction SilentlyContinue | Out-String
+    Remove-Item "test-err.log", "test-out.log" -ErrorAction SilentlyContinue
+
     if ($proc.ExitCode -eq 0) {
         throw "Expected non-zero exit code for missing binary, got 0"
+    }
+    if (-not ($errOutput -match "Binary not found")) {
+        throw "Expected 'Binary not found' in output, but got: $errOutput"
     }
 }
 
@@ -105,17 +101,34 @@ Assert-Pass '5. -Uninstall nonexistent task: clean exit (code 0)' {
 # ── Test 6: -WhatIf leaves no task registered ─────────────────────────────────
 # With -WhatIf, ShouldProcess returns false so Register-ScheduledTask is skipped.
 # We use an existing binary (powershell.exe) so param validation passes.
-Assert-Pass '6. -WhatIf: no task is registered' {
+Assert-Pass '6. -WhatIf: no task is registered and no credentials prompt' {
     $fakeName = "1mcp-whatif-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
     $ps = (Get-Command powershell.exe).Source
-    try {
-        # -WhatIf short-circuits ShouldProcess; Get-Credential may still be reached
-        # in a non-interactive session and throw — that is acceptable for this test.
-        & $ScriptPath -BinaryPath $ps -TaskName $fakeName -WhatIf `
-            -ErrorAction SilentlyContinue 2>$null
-    } catch {
-        # Credential prompt in non-interactive session — ignore
+    
+    # We run in a child process to capture output and verify WhatIf message
+    $proc = Start-Process powershell.exe `
+        -ArgumentList @(
+            '-NoProfile', '-NonInteractive',
+            '-ExecutionPolicy', 'Bypass',
+            '-File', $ScriptPath,
+            '-BinaryPath', $ps,
+            '-TaskName', $fakeName,
+            '-WhatIf'
+        ) `
+        -RedirectStandardOutput "test-out.log" -RedirectStandardError "test-err.log" `
+        -PassThru -Wait -NoNewWindow
+    
+    $outOutput = Get-Content "test-out.log" -ErrorAction SilentlyContinue | Out-String
+    $errOutput = Get-Content "test-err.log" -ErrorAction SilentlyContinue | Out-String
+    Remove-Item "test-err.log", "test-out.log" -ErrorAction SilentlyContinue
+
+    if ($proc.ExitCode -ne 0) {
+        throw "Script exited with code $($proc.ExitCode). Error output: $errOutput"
     }
+    if (-not ($outOutput -match "What if:")) {
+        throw "Expected output to contain 'What if:', but got: $outOutput"
+    }
+    
     $stillAbsent = -not (Get-ScheduledTask -TaskName $fakeName -ErrorAction SilentlyContinue)
     if (-not $stillAbsent) {
         Unregister-ScheduledTask -TaskName $fakeName -Confirm:$false -ErrorAction SilentlyContinue

--- a/scripts/test-install-windows-task.ps1
+++ b/scripts/test-install-windows-task.ps1
@@ -1,4 +1,4 @@
-# Test suite for install-windows-task.ps1
+﻿# Test suite for install-windows-task.ps1
 # Usage: .\scripts\test-install-windows-task.ps1 [[-ScriptPath] <path>]
 #
 # Does NOT require Administrator privileges.
@@ -51,8 +51,8 @@ Assert-Pass '2. Syntax: 0 parse errors' {
 # ── Test 3: Get-Help returns a non-empty synopsis ─────────────────────────────
 Assert-Pass '3. Get-Help: synopsis present' {
     $help = Get-Help $ScriptPath -ErrorAction Stop
-    if (-not $help.Synopsis -or $help.Synopsis.Trim() -eq '') {
-        throw 'Synopsis is empty'
+    if (-not $help.Synopsis -or $help.Synopsis.Trim() -ne 'Register or remove 1mcp serve as a Windows Task Scheduler daemon.') {
+        throw "Synopsis mismatch: expected 'Register or remove 1mcp serve as a Windows Task Scheduler daemon.', got: '$($help.Synopsis)'"
     }
 }
 
@@ -125,11 +125,19 @@ Assert-Pass '6. -WhatIf: no task registered, mentions Password logon, no cred pr
     if ($proc.ExitCode -ne 0) {
         throw "Script exited with code $($proc.ExitCode). Error output: $errOutput"
     }
-    if (-not ($outOutput -match 'What ?[iI]f:')) {
+    if (-not ($outOutput -match 'Register-ScheduledTask')) {
         throw "Expected output to contain 'What if:' (or localized equivalent), but got: $outOutput"
     }
 
-    $stillAbsent = -not (Get-ScheduledTask -TaskName $fakeName -ErrorAction SilentlyContinue)
+    $taskLookup = $null
+    try {
+        $taskLookup = Get-ScheduledTask -TaskName $fakeName -ErrorAction Stop
+    } catch {
+        if ($_.FullyQualifiedErrorId -notmatch 'CmdletizationQuery_NotFound_TaskName') {
+            throw "Unexpected error checking task '$fakeName': $_"
+        }
+    }
+    $stillAbsent = -not $taskLookup
     if (-not $stillAbsent) {
         Unregister-ScheduledTask -TaskName $fakeName -Confirm:$false -ErrorAction SilentlyContinue
         throw "Task '$fakeName' was registered despite -WhatIf"

--- a/scripts/test-install-windows-task.ps1
+++ b/scripts/test-install-windows-task.ps1
@@ -57,7 +57,6 @@ Assert-Pass '3. Get-Help: synopsis present' {
 }
 
 # ── Test 4: -BinaryPath that does not exist triggers Write-Error ──────────────
-# Spawn a child process so Write-Error / exit propagate cleanly.
 Assert-Pass '4. -BinaryPath nonexistent: exits non-zero and prints correct error' {
     $fakePath = 'C:\nonexistent-path\1mcp.exe'
     $tempErr = [System.IO.Path]::GetTempFileName()
@@ -100,16 +99,13 @@ Assert-Pass '5. -Uninstall nonexistent task: clean exit (code 0)' {
     }
 }
 
-# ── Test 6: -WhatIf leaves no task registered ─────────────────────────────────
-# With -WhatIf, ShouldProcess returns false so Register-ScheduledTask is skipped.
-# We use an existing binary (powershell.exe) so param validation passes.
-Assert-Pass '6. -WhatIf: no task is registered and no credentials prompt' {
+# ── Test 6: -WhatIf leaves no task and mentions LogonType Password ────────────
+Assert-Pass '6. -WhatIf: no task registered, mentions Password logon, no cred prompt' {
     $fakeName = "1mcp-whatif-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
     $ps = (Get-Command powershell.exe).Source
-    
+
     $tempErr = [System.IO.Path]::GetTempFileName()
     $tempOut = [System.IO.Path]::GetTempFileName()
-    # We run in a child process to capture output and verify WhatIf message
     $proc = Start-Process powershell.exe `
         -ArgumentList @(
             '-NoProfile', '-NonInteractive',
@@ -121,7 +117,7 @@ Assert-Pass '6. -WhatIf: no task is registered and no credentials prompt' {
         ) `
         -RedirectStandardOutput $tempOut -RedirectStandardError $tempErr `
         -PassThru -Wait -NoNewWindow
-    
+
     $outOutput = Get-Content $tempOut -ErrorAction SilentlyContinue | Out-String
     $errOutput = Get-Content $tempErr -ErrorAction SilentlyContinue | Out-String
     Remove-Item $tempErr, $tempOut -ErrorAction SilentlyContinue
@@ -132,7 +128,7 @@ Assert-Pass '6. -WhatIf: no task is registered and no credentials prompt' {
     if (-not ($outOutput -match 'What ?[iI]f:')) {
         throw "Expected output to contain 'What if:' (or localized equivalent), but got: $outOutput"
     }
-    
+
     $stillAbsent = -not (Get-ScheduledTask -TaskName $fakeName -ErrorAction SilentlyContinue)
     if (-not $stillAbsent) {
         Unregister-ScheduledTask -TaskName $fakeName -Confirm:$false -ErrorAction SilentlyContinue

--- a/scripts/test-install-windows-task.ps1
+++ b/scripts/test-install-windows-task.ps1
@@ -1,0 +1,134 @@
+# Test suite for install-windows-task.ps1
+# Usage: .\scripts\test-install-windows-task.ps1 [[-ScriptPath] <path>]
+#
+# Does NOT require Administrator privileges.
+# Does NOT register any actual Task Scheduler task.
+# Follows the same plain-PowerShell pattern as test-binary-windows.ps1.
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$ScriptPath = ''
+)
+
+if (-not $ScriptPath) {
+    $ScriptPath = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) 'install-windows-task.ps1'
+}
+
+$ErrorActionPreference = 'Stop'
+$failures = 0
+
+function Assert-Pass {
+    param([string]$Label, [scriptblock]$Test)
+    try {
+        & $Test
+        Write-Host "PASS: $Label"
+    } catch {
+        Write-Host "FAIL: $Label — $_"
+        $script:failures++
+    }
+}
+
+function Assert-Fail {
+    param([string]$Label, [scriptblock]$Test)
+    try {
+        & $Test
+        Write-Host "FAIL: $Label — expected an error but none was thrown"
+        $script:failures++
+    } catch {
+        $firstLine = $_.Exception.Message.Split([char]10)[0]
+        Write-Host "PASS: $Label (threw as expected: $firstLine)"
+    }
+}
+
+Write-Host "Testing $ScriptPath"
+Write-Host ("─" * 60)
+
+# ── Test 1: Script file exists ────────────────────────────────────────────────
+Assert-Pass '1. Script file exists' {
+    if (-not (Test-Path $ScriptPath -PathType Leaf)) {
+        throw "Not found: $ScriptPath"
+    }
+}
+
+# ── Test 2: PowerShell syntax is valid (0 parse errors) ──────────────────────
+Assert-Pass '2. Syntax: 0 parse errors' {
+    $parseErrors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile(
+        (Resolve-Path $ScriptPath).Path, [ref]$null, [ref]$parseErrors) | Out-Null
+    if ($parseErrors.Count -gt 0) {
+        throw ($parseErrors | Format-List | Out-String)
+    }
+}
+
+# ── Test 3: Get-Help returns a non-empty synopsis ─────────────────────────────
+Assert-Pass '3. Get-Help: synopsis present' {
+    $help = Get-Help $ScriptPath -ErrorAction Stop
+    if (-not $help.Synopsis -or $help.Synopsis.Trim() -eq '') {
+        throw 'Synopsis is empty'
+    }
+}
+
+# ── Test 4: -BinaryPath that does not exist triggers Write-Error ──────────────
+# Spawn a child process so Write-Error / exit propagate cleanly.
+Assert-Pass '4. -BinaryPath nonexistent: exits non-zero' {
+    $fakePath = 'C:\nonexistent-path\1mcp.exe'
+    $proc = Start-Process powershell.exe `
+        -ArgumentList @(
+            '-NoProfile', '-NonInteractive',
+            '-ExecutionPolicy', 'Bypass',
+            '-File', $ScriptPath,
+            '-BinaryPath', $fakePath
+        ) `
+        -PassThru -Wait -NoNewWindow
+    if ($proc.ExitCode -eq 0) {
+        throw "Expected non-zero exit code for missing binary, got 0"
+    }
+}
+
+# ── Test 5: -Uninstall with a nonexistent task name exits 0 ──────────────────
+Assert-Pass '5. -Uninstall nonexistent task: clean exit (code 0)' {
+    $fakeName = "1mcp-test-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
+    $proc = Start-Process powershell.exe `
+        -ArgumentList @(
+            '-NoProfile', '-NonInteractive',
+            '-ExecutionPolicy', 'Bypass',
+            '-File', $ScriptPath,
+            '-Uninstall',
+            '-TaskName', $fakeName
+        ) `
+        -PassThru -Wait -NoNewWindow
+    if ($proc.ExitCode -ne 0) {
+        throw "Exit code was $($proc.ExitCode), expected 0"
+    }
+}
+
+# ── Test 6: -WhatIf leaves no task registered ─────────────────────────────────
+# With -WhatIf, ShouldProcess returns false so Register-ScheduledTask is skipped.
+# We use an existing binary (powershell.exe) so param validation passes.
+Assert-Pass '6. -WhatIf: no task is registered' {
+    $fakeName = "1mcp-whatif-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
+    $ps = (Get-Command powershell.exe).Source
+    try {
+        # -WhatIf short-circuits ShouldProcess; Get-Credential may still be reached
+        # in a non-interactive session and throw — that is acceptable for this test.
+        & $ScriptPath -BinaryPath $ps -TaskName $fakeName -WhatIf `
+            -ErrorAction SilentlyContinue 2>$null
+    } catch {
+        # Credential prompt in non-interactive session — ignore
+    }
+    $stillAbsent = -not (Get-ScheduledTask -TaskName $fakeName -ErrorAction SilentlyContinue)
+    if (-not $stillAbsent) {
+        Unregister-ScheduledTask -TaskName $fakeName -Confirm:$false -ErrorAction SilentlyContinue
+        throw "Task '$fakeName' was registered despite -WhatIf"
+    }
+}
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+Write-Host ("─" * 60)
+if ($failures -eq 0) {
+    Write-Host "All tests passed."
+    exit 0
+} else {
+    Write-Host "$failures test(s) failed."
+    exit 1
+}

--- a/scripts/test-install-windows-task.ps1
+++ b/scripts/test-install-windows-task.ps1
@@ -60,6 +60,8 @@ Assert-Pass '3. Get-Help: synopsis present' {
 # Spawn a child process so Write-Error / exit propagate cleanly.
 Assert-Pass '4. -BinaryPath nonexistent: exits non-zero and prints correct error' {
     $fakePath = 'C:\nonexistent-path\1mcp.exe'
+    $tempErr = [System.IO.Path]::GetTempFileName()
+    $tempOut = [System.IO.Path]::GetTempFileName()
     $proc = Start-Process powershell.exe `
         -ArgumentList @(
             '-NoProfile', '-NonInteractive',
@@ -67,11 +69,11 @@ Assert-Pass '4. -BinaryPath nonexistent: exits non-zero and prints correct error
             '-File', $ScriptPath,
             '-BinaryPath', $fakePath
         ) `
-        -RedirectStandardError "test-err.log" -RedirectStandardOutput "test-out.log" `
+        -RedirectStandardError $tempErr -RedirectStandardOutput $tempOut `
         -PassThru -Wait -NoNewWindow
 
-    $errOutput = Get-Content "test-err.log" -ErrorAction SilentlyContinue | Out-String
-    Remove-Item "test-err.log", "test-out.log" -ErrorAction SilentlyContinue
+    $errOutput = Get-Content $tempErr -ErrorAction SilentlyContinue | Out-String
+    Remove-Item $tempErr, $tempOut -ErrorAction SilentlyContinue
 
     if ($proc.ExitCode -eq 0) {
         throw "Expected non-zero exit code for missing binary, got 0"
@@ -105,6 +107,8 @@ Assert-Pass '6. -WhatIf: no task is registered and no credentials prompt' {
     $fakeName = "1mcp-whatif-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
     $ps = (Get-Command powershell.exe).Source
     
+    $tempErr = [System.IO.Path]::GetTempFileName()
+    $tempOut = [System.IO.Path]::GetTempFileName()
     # We run in a child process to capture output and verify WhatIf message
     $proc = Start-Process powershell.exe `
         -ArgumentList @(
@@ -115,12 +119,12 @@ Assert-Pass '6. -WhatIf: no task is registered and no credentials prompt' {
             '-TaskName', $fakeName,
             '-WhatIf'
         ) `
-        -RedirectStandardOutput "test-out.log" -RedirectStandardError "test-err.log" `
+        -RedirectStandardOutput $tempOut -RedirectStandardError $tempErr `
         -PassThru -Wait -NoNewWindow
     
-    $outOutput = Get-Content "test-out.log" -ErrorAction SilentlyContinue | Out-String
-    $errOutput = Get-Content "test-err.log" -ErrorAction SilentlyContinue | Out-String
-    Remove-Item "test-err.log", "test-out.log" -ErrorAction SilentlyContinue
+    $outOutput = Get-Content $tempOut -ErrorAction SilentlyContinue | Out-String
+    $errOutput = Get-Content $tempErr -ErrorAction SilentlyContinue | Out-String
+    Remove-Item $tempErr, $tempOut -ErrorAction SilentlyContinue
 
     if ($proc.ExitCode -ne 0) {
         throw "Script exited with code $($proc.ExitCode). Error output: $errOutput"

--- a/scripts/test-install-windows-task.ps1
+++ b/scripts/test-install-windows-task.ps1
@@ -66,7 +66,7 @@ Assert-Pass '4. -BinaryPath nonexistent: exits non-zero and prints correct error
         -ArgumentList @(
             '-NoProfile', '-NonInteractive',
             '-ExecutionPolicy', 'Bypass',
-            '-File', $ScriptPath,
+            '-File', ('"{0}"' -f $ScriptPath),
             '-BinaryPath', $fakePath
         ) `
         -RedirectStandardError $tempErr -RedirectStandardOutput $tempOut `
@@ -90,7 +90,7 @@ Assert-Pass '5. -Uninstall nonexistent task: clean exit (code 0)' {
         -ArgumentList @(
             '-NoProfile', '-NonInteractive',
             '-ExecutionPolicy', 'Bypass',
-            '-File', $ScriptPath,
+            '-File', ('"{0}"' -f $ScriptPath),
             '-Uninstall',
             '-TaskName', $fakeName
         ) `
@@ -114,8 +114,8 @@ Assert-Pass '6. -WhatIf: no task is registered and no credentials prompt' {
         -ArgumentList @(
             '-NoProfile', '-NonInteractive',
             '-ExecutionPolicy', 'Bypass',
-            '-File', $ScriptPath,
-            '-BinaryPath', $ps,
+            '-File', ('"{0}"' -f $ScriptPath),
+            '-BinaryPath', ('"{0}"' -f $ps),
             '-TaskName', $fakeName,
             '-WhatIf'
         ) `


### PR DESCRIPTION
## Summary

Adds `scripts/install-windows-task.ps1` — a parameterised, idempotent PowerShell 5.1 helper that registers `1mcp serve` as a Windows Task Scheduler daemon.

Closes the **"Deferred: install helper script"** item in #450.
Problems 1–3 (SIGTERM reliability, isProcessAlive Session 0, %APPDATA% resolution) remain tracked in #450 for a separate PR.

## What's included

| File | Purpose |
|------|---------|
| `scripts/install-windows-task.ps1` | Install / uninstall script |
| `scripts/test-install-windows-task.ps1` | Test suite (syntax, help, error paths, -WhatIf) |

## Checklist
- [x] PowerShell 5.1 compatible (no PS7-only syntax)
- [x] No embedded passwords — `Get-Credential` only
- [x] `RunLevel Limited`, `LogonType Password`
- [x] Idempotent via `Register-ScheduledTask -Force`
- [x] `ShouldProcess` / `-WhatIf` support
- [x] Aligned with deployment contract in #449
- [x] Zero TypeScript changes
- [x] `pnpm lint && pnpm typecheck` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows setup script for running the service as a Task Scheduler daemon.
  * Supports installation, removal, standalone binaries, npm-based execution, custom ports, hosts, task names, and configuration directories.
  * Includes startup configuration, restart behavior, permission setup, health checks, and preview mode.

* **Tests**
  * Added automated validation for installation, uninstallation, syntax, help output, error handling, and preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->