### PR TITLE
feat: configure per-server tool metadata

### DIFF
--- a/docs/.vitepress/utils/configSchemaGen.ts
+++ b/docs/.vitepress/utils/configSchemaGen.ts
@@ -58,7 +58,7 @@ export async function writeSchemaFile(schema: Record<string, unknown>, outputPat
     await mkdir(dirname(outputPath), { recursive: true });
 
     // Write schema with proper formatting
-    await writeFile(outputPath, JSON.stringify(schema, null, 2), 'utf-8');
+    await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`, 'utf-8');
   } catch (error) {
     const message = `Failed to write schema file to '${outputPath}': ${error instanceof Error ? error.message : String(error)}`;
     process.stderr.write(`[schema-gen] ${message}\n`);

--- a/docs/en/reference/mcp-servers.md
+++ b/docs/en/reference/mcp-servers.md
@@ -156,6 +156,7 @@ This is a dictionary of all the backend MCP servers the agent will manage.
 - `timeout` (number, optional): **Deprecated** fallback timeout in milliseconds. Used when specific timeouts are not set. New configurations should use `connectionTimeout` and `requestTimeout`.
 - `enabled` (boolean, optional): Set to `false` to disable the server. Defaults to `true`.
 - `disabledTools` (array of strings, optional): Hide selected tools from this server without disabling the entire server.
+- `toolDescriptionOverrides` (object, optional): Replace upstream tool descriptions by logical server-local tool name.
 
 **HTTP Transport Properties:**
 
@@ -250,7 +251,7 @@ This is a dictionary of all the backend MCP servers the agent will manage.
 }
 ```
 
-### Disabling Individual Tools
+### Configuring Individual Tools
 
 Use `disabledTools` when a server should stay enabled but selected tools should be hidden:
 
@@ -260,13 +261,18 @@ Use `disabledTools` when a server should stay enabled but selected tools should 
     "filesystem": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
-      "disabledTools": ["write_file"]
+      "disabledTools": ["write_file"],
+      "toolDescriptionOverrides": {
+        "read_file": "Read a file from the approved workspace root"
+      }
     }
   }
 }
 ```
 
 Disabled tools are per-server only. Use logical server-local names such as `write_file`; runtime filtering also recognizes qualified names like `filesystem_1mcp_write_file`, but logical names are easier to maintain.
+
+`toolDescriptionOverrides` changes the description exposed through full `tools/list`, lazy tool discovery and schema inspection, REST capability views, and Admin. It does not mutate the upstream server or change the tool input schema, annotations, or execution route. Remove a key, or use **Reset** in Admin, to inherit the upstream description again. Empty names and blank descriptions are rejected.
 
 Manage this field with [`mcp tools`](/commands/mcp/tools):
 
@@ -278,7 +284,11 @@ npx -y @1mcp/agent mcp tools list filesystem --disabled
 
 The `mcp tools` list, enable, and disable subcommands update `mcp.json`. A running `1mcp serve` instance picks up the change through config hot reload.
 
-If the same server name exists in both `mcpTemplates` and `mcpServers`, the template entry is authoritative. Tool enable/disable commands update `mcpTemplates.<name>.disabledTools` and leave any stale `mcpServers.<name>.disabledTools` value unchanged.
+Admin uses the same `disabledTools` and `toolDescriptionOverrides` fields. The editor shows the observed upstream inventory, effective descriptions, per-tool token estimates, search/filter controls, and visible-row bulk actions. Entries retained in configuration after a tool disappears remain visible as unresolved so they can be repaired or removed. Preview reports enabled/disabled counts and the approximate token change; applying a zero-enabled result requires explicit confirmation. These metadata changes propagate to connected clients without restarting the outbound server.
+
+For a Template Server, Admin shows the union observed across active instances and marks tools seen in only some instances. The selection and description rules are stored on the template definition and inherited by future instances; `disabledTools` is therefore a denylist, so newly introduced tool names remain enabled unless explicitly disabled.
+
+If the same server name exists in both `mcpTemplates` and `mcpServers`, the template entry is authoritative. Tool enable/disable commands update `mcpTemplates.<name>.disabledTools` and leave any stale `mcpServers.<name>.disabledTools` value unchanged. Direct config edits and Admin remain interoperable because both persist the same fields.
 
 ---
 

--- a/docs/public/schemas/v1.0.0/mcp-config.json
+++ b/docs/public/schemas/v1.0.0/mcp-config.json
@@ -153,6 +153,18 @@
             "description": "Literal replacement for upstream server instructions; an empty string intentionally suppresses them",
             "type": "string"
           },
+          "toolDescriptionOverrides": {
+            "description": "Override upstream tool descriptions by logical tool name; blank descriptions are not supported",
+            "type": "object",
+            "propertyNames": {
+              "type": "string",
+              "minLength": 1
+            },
+            "additionalProperties": {
+              "type": "string",
+              "minLength": 1
+          }
+          },
           "timeout": {
             "description": "Deprecated: Use connectionTimeout and requestTimeout instead. Fallback timeout in milliseconds",
             "type": "number"
@@ -369,6 +381,18 @@
           "instructionOverride": {
             "description": "Literal replacement for upstream server instructions inherited by rendered instances; an empty string intentionally suppresses them",
             "type": "string"
+          },
+          "toolDescriptionOverrides": {
+            "description": "Override upstream tool descriptions by logical tool name; blank descriptions are not supported",
+            "type": "object",
+            "propertyNames": {
+              "type": "string",
+              "minLength": 1
+            },
+            "additionalProperties": {
+              "type": "string",
+              "minLength": 1
+          }
           },
           "timeout": {
             "description": "Deprecated: Use connectionTimeout and requestTimeout instead. Fallback timeout in milliseconds",

--- a/docs/public/schemas/v1.0.0/mcp-config.json
+++ b/docs/public/schemas/v1.0.0/mcp-config.json
@@ -158,12 +158,14 @@
             "type": "object",
             "propertyNames": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "pattern": "\\S"
             },
             "additionalProperties": {
               "type": "string",
-              "minLength": 1
-          }
+              "minLength": 1,
+              "pattern": "\\S"
+            }
           },
           "timeout": {
             "description": "Deprecated: Use connectionTimeout and requestTimeout instead. Fallback timeout in milliseconds",
@@ -387,12 +389,14 @@
             "type": "object",
             "propertyNames": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "pattern": "\\S"
             },
             "additionalProperties": {
               "type": "string",
-              "minLength": 1
-          }
+              "minLength": 1,
+              "pattern": "\\S"
+            }
           },
           "timeout": {
             "description": "Deprecated: Use connectionTimeout and requestTimeout instead. Fallback timeout in milliseconds",

--- a/docs/zh/reference/mcp-servers.md
+++ b/docs/zh/reference/mcp-servers.md
@@ -135,6 +135,7 @@ npx -y @1mcp/agent --config-dir ./project-config
 - `timeout` (数字, 可选): **已弃用** 的回退超时时间（毫秒）。当未设置特定超时时使用。新配置应使用 `connectionTimeout` 和 `requestTimeout`。
 - `enabled` (布尔值, 可选): 设置为 `false` 以禁用服务器。默认为 `true`。
 - `disabledTools` (字符串数组, 可选): 隐藏此服务器中的指定工具，而不禁用整个服务器。
+- `toolDescriptionOverrides` (对象, 可选): 按服务器本地逻辑工具名替换上游工具描述。
 
 **HTTP 传输属性：**
 
@@ -229,7 +230,7 @@ npx -y @1mcp/agent --config-dir ./project-config
 }
 ```
 
-### 禁用单个工具
+### 配置单个工具
 
 当服务器应保持启用，但其中某些工具需要隐藏时，使用 `disabledTools`：
 
@@ -239,13 +240,18 @@ npx -y @1mcp/agent --config-dir ./project-config
     "filesystem": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
-      "disabledTools": ["write_file"]
+      "disabledTools": ["write_file"],
+      "toolDescriptionOverrides": {
+        "read_file": "从已批准的工作区根目录读取文件"
+      }
     }
   }
 }
 ```
 
 禁用工具只按服务器生效，不是全局设置。请使用逻辑上的服务器本地名称，例如 `write_file`；运行时过滤也能识别 `filesystem_1mcp_write_file` 这样的限定名称，但逻辑名称更容易维护。
+
+`toolDescriptionOverrides` 会更新完整 `tools/list`、懒加载工具发现与 Schema 查看、REST 能力视图以及 Admin 中展示的描述。它不会修改上游服务器，也不会改变工具输入 Schema、annotations 或执行路由。删除对应键，或在 Admin 中使用 **重置**，即可重新继承上游描述。空工具名和空白描述会被拒绝。
 
 可以使用 [`mcp tools`](/zh/commands/mcp/tools) 管理此字段：
 
@@ -257,7 +263,11 @@ npx -y @1mcp/agent mcp tools list filesystem --disabled
 
 `mcp tools` 的 list、enable 和 disable 子命令会更新 `mcp.json`。正在运行的 `1mcp serve` 实例会通过配置热重载观察到变化。
 
-如果同名服务器同时存在于 `mcpTemplates` 和 `mcpServers` 中，模板条目是权威配置。工具启用/禁用命令会更新 `mcpTemplates.<name>.disabledTools`，并保留任何旧的 `mcpServers.<name>.disabledTools` 值不变。
+Admin 使用相同的 `disabledTools` 和 `toolDescriptionOverrides` 字段。编辑器会展示观测到的上游工具清单、有效描述、逐工具 token 估算、搜索/筛选以及仅作用于可见行的批量操作。工具从上游消失后，配置中保留的条目仍会以“未解析”状态显示，便于修复或删除。预览会显示启用/禁用数量和近似 token 变化；若结果为零个启用工具，应用前必须显式确认。这些元数据变更会通知已连接客户端，无需重启出站服务器。
+
+对于 Template Server，Admin 展示所有活跃实例观测到的工具并集，并标记只在部分实例中出现的工具。选择和描述规则存储在模板定义上，未来实例会继承这些规则；因此 `disabledTools` 是拒绝列表，新出现且未被明确禁用的工具默认保持启用。
+
+如果同名服务器同时存在于 `mcpTemplates` 和 `mcpServers` 中，模板条目是权威配置。工具启用/禁用命令会更新 `mcpTemplates.<name>.disabledTools`，并保留任何旧的 `mcpServers.<name>.disabledTools` 值不变。直接编辑配置与 Admin 可以互操作，因为两者持久化的是相同字段。
 
 ---
 

--- a/src/config/configLoader.validation-app-config.test.ts
+++ b/src/config/configLoader.validation-app-config.test.ts
@@ -175,6 +175,28 @@ describe('ConfigLoader', () => {
 
       expect(result.disabledTools).toEqual(['write_file', 'delete_file']);
     });
+
+    it('should validate non-empty tool description overrides', () => {
+      const result = loader.validateServerConfig('described-server', {
+        command: 'echo',
+        toolDescriptionOverrides: {
+          read_file: 'Read a file from the workspace',
+        },
+      });
+
+      expect(result.toolDescriptionOverrides).toEqual({
+        read_file: 'Read a file from the workspace',
+      });
+    });
+
+    it('should reject whitespace-only tool description overrides', () => {
+      expect(() =>
+        loader.validateServerConfig('described-server', {
+          command: 'echo',
+          toolDescriptionOverrides: { read_file: '   ' },
+        }),
+      ).toThrow(/Invalid configuration for server 'described-server'/);
+    });
   });
 
   describe('getTransportConfig', () => {

--- a/src/config/configuredServerTargets.ts
+++ b/src/config/configuredServerTargets.ts
@@ -1,0 +1,9 @@
+import { McpConfigManager } from '@src/config/mcpConfigManager.js';
+import type { MCPServerParams } from '@src/core/types/index.js';
+
+export function getConfiguredServerTargets(): Record<string, MCPServerParams> {
+  const manager = McpConfigManager.getInstance();
+  return typeof manager.getConfiguredServerTargets === 'function'
+    ? manager.getConfiguredServerTargets()
+    : manager.getTransportConfig();
+}

--- a/src/config/mcpConfigManager.test.ts
+++ b/src/config/mcpConfigManager.test.ts
@@ -298,6 +298,36 @@ describe('McpConfigManager', () => {
       );
     });
 
+    it('exposes template-first configured targets with inherited defaults', () => {
+      (fs.readFileSync as unknown as MockInstance).mockReturnValueOnce(
+        JSON.stringify({
+          serverDefaults: { requestTimeout: 9000 },
+          mcpServers: { shared: { type: 'stdio', command: 'static' } },
+          mcpTemplates: {
+            shared: {
+              type: 'stdio',
+              command: 'template',
+              disabledTools: ['write'],
+              toolDescriptionOverrides: { read: 'Read safely' },
+            },
+          },
+        }),
+      );
+
+      const instance = McpConfigManager.getInstance(testConfigPath);
+
+      expect(instance.getTransportConfig()).toEqual({});
+      expect(instance.getConfiguredServerTargets()).toEqual({
+        shared: {
+          type: 'stdio',
+          command: 'template',
+          requestTimeout: 9000,
+          disabledTools: ['write'],
+          toolDescriptionOverrides: { read: 'Read safely' },
+        },
+      });
+    });
+
     it('should not emit a transport config change when reload fails to parse', () => {
       (fs.existsSync as unknown as MockInstance).mockImplementation((p: string) => {
         if (String(p).endsWith('config.toml')) return false;

--- a/src/config/mcpConfigManager.ts
+++ b/src/config/mcpConfigManager.ts
@@ -4,8 +4,14 @@ import path from 'path';
 
 import ConfigContext from '@src/config/configContext.js';
 import { ConfigLoader } from '@src/config/configLoader.js';
+import { mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
-import { ApplicationConfig, GlobalTransportConfig, MCPServerParams } from '@src/core/types/index.js';
+import {
+  ApplicationConfig,
+  GlobalTransportConfig,
+  mcpServerConfigSchema,
+  MCPServerParams,
+} from '@src/core/types/index.js';
 import logger, { debugIf } from '@src/logger/logger.js';
 
 /**
@@ -22,6 +28,7 @@ export class McpConfigManager extends EventEmitter {
   private static instance: McpConfigManager;
   private configWatcher: fs.FSWatcher | null = null;
   private transportConfig: Record<string, MCPServerParams> = {};
+  private templateConfig: Record<string, MCPServerParams> = {};
   private globalConfig: GlobalTransportConfig = {};
   private appConfig: ApplicationConfig = {};
   private configFilePath: string;
@@ -80,6 +87,15 @@ export class McpConfigManager extends EventEmitter {
       this.globalConfig = loadedConfig.globalConfig;
       this.appConfig = loadedConfig.appConfig;
       this.transportConfig = loadedConfig.validatedServers;
+      const declaredConfig = mcpServerConfigSchema.safeParse(loadedConfig.processedConfig);
+      this.templateConfig = declaredConfig.success
+        ? Object.fromEntries(
+            Object.entries(declaredConfig.data.mcpTemplates ?? {}).map(([name, config]) => [
+              name,
+              mergeGlobalAndServerConfig(this.globalConfig, config),
+            ]),
+          )
+        : {};
       const substitutionStatus = features.envSubstitution ? 'with' : 'without';
       logger.info(`Configuration loaded successfully ${substitutionStatus} environment variable substitution`);
       return true;
@@ -88,6 +104,7 @@ export class McpConfigManager extends EventEmitter {
       this.globalConfig = {};
       this.appConfig = {};
       this.transportConfig = {};
+      this.templateConfig = {};
       return false;
     }
   }
@@ -246,6 +263,11 @@ export class McpConfigManager extends EventEmitter {
    */
   public getTransportConfig(): Record<string, MCPServerParams> {
     return { ...this.transportConfig };
+  }
+
+  /** Static and declared template targets, with templates authoritative on name conflicts. */
+  public getConfiguredServerTargets(): Record<string, MCPServerParams> {
+    return { ...this.transportConfig, ...this.templateConfig };
   }
 
   /**

--- a/src/core/capabilities/capabilityAggregator.test.ts
+++ b/src/core/capabilities/capabilityAggregator.test.ts
@@ -8,6 +8,7 @@ import { ClientStatus, OutboundConnections } from '@src/core/types/index.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CapabilityAggregator } from './capabilityAggregator.js';
+import { readLastConfiguredToolSnapshot } from './configuredToolSnapshot.js';
 
 // Mock InternalCapabilitiesProvider
 vi.mock('@src/core/capabilities/internalCapabilitiesProvider.js', () => ({
@@ -110,7 +111,8 @@ describe('CapabilityAggregator', () => {
       const slowListTools = vi
         .fn()
         .mockRejectedValueOnce(new Error('Request timed out'))
-        .mockResolvedValueOnce({ tools: [recoveredTool] });
+        .mockResolvedValueOnce({ tools: [recoveredTool] })
+        .mockRejectedValueOnce(new Error('Request timed out again'));
 
       const createConnection = (name: string, listTools: Client['listTools']) => {
         const client = createMockClient({
@@ -141,7 +143,10 @@ describe('CapabilityAggregator', () => {
 
       const recovered = await aggregator.refreshCapabilities();
       expect(recovered.tools.map((tool) => tool.name).sort()).toEqual(['healthy-tool', 'recovered-tool']);
-      expect(slowListTools).toHaveBeenCalledTimes(2);
+
+      await aggregator.refreshCapabilities();
+      expect(readLastConfiguredToolSnapshot('slow-server').map((tool) => tool.name)).toEqual(['recovered-tool']);
+      expect(slowListTools).toHaveBeenCalledTimes(3);
     });
 
     it('should return no changes when no servers are connected', async () => {
@@ -191,6 +196,36 @@ describe('CapabilityAggregator', () => {
       expect(changes.current.resources).toHaveLength(1);
       expect(changes.current.prompts).toHaveLength(1);
       expect(changes.current.readyServers).toContain('test-server');
+    });
+
+    it('should detect effective tool description changes', async () => {
+      const mockClient = {
+        listTools: vi.fn().mockResolvedValue({ tools: [mockTool] }),
+        listResources: vi.fn().mockResolvedValue({ resources: [] }),
+        listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+        getServerCapabilities: vi.fn().mockReturnValue({ tools: true }),
+        transport: { start: vi.fn(), send: vi.fn(), close: vi.fn() },
+      } as any;
+      mockConnections.set('test-server', {
+        name: 'test-server',
+        client: mockClient,
+        status: ClientStatus.Connected,
+        transport: { start: vi.fn(), send: vi.fn(), close: vi.fn() },
+      } as any);
+
+      await aggregator.updateCapabilities();
+      mockGetTransportConfig.mockReturnValue({
+        'test-server': {
+          type: 'stdio',
+          command: 'node',
+          toolDescriptionOverrides: { 'test-tool': 'Operator description' },
+        },
+      });
+
+      const changes = await aggregator.updateCapabilities();
+
+      expect(changes.toolsChanged).toBe(true);
+      expect(changes.current.tools).toMatchObject([{ name: 'test-tool', description: 'Operator description' }]);
     });
 
     it('should handle client method failures gracefully', async () => {

--- a/src/core/capabilities/capabilityAggregator.ts
+++ b/src/core/capabilities/capabilityAggregator.ts
@@ -10,9 +10,16 @@ import {
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { McpConfigManager } from '@src/config/mcpConfigManager.js';
+import { getConfiguredServerTargets } from '@src/config/configuredServerTargets.js';
+import {
+  clearConfiguredToolSnapshot,
+  collectConfiguredToolPages,
+  publishCompleteConfiguredToolTargetSnapshots,
+  publishConfiguredToolSnapshot,
+} from '@src/core/capabilities/configuredToolSnapshot.js';
 import { InternalCapabilitiesProvider } from '@src/core/capabilities/internalCapabilitiesProvider.js';
 import { filterDisabledTools } from '@src/core/server/disabledTools.js';
+import { applyEffectiveToolDescription } from '@src/core/server/toolDescriptionOverrides.js';
 import { ClientStatus, OutboundConnections } from '@src/core/types/index.js';
 import type { EnhancedTransport } from '@src/core/types/transport.js';
 import logger, { debugIf } from '@src/logger/logger.js';
@@ -144,7 +151,7 @@ export class CapabilityAggregator extends EventEmitter {
     const allTools: Tool[] = [];
     const allResources: Resource[] = [];
     const allPrompts: Prompt[] = [];
-    const serverConfigs = McpConfigManager.getInstance().getTransportConfig();
+    const serverConfigs = getConfiguredServerTargets();
 
     // Add 1mcp tools first
     try {
@@ -194,9 +201,16 @@ export class CapabilityAggregator extends EventEmitter {
         if (results[0]?.status === 'fulfilled') {
           const toolsResult = results[0].value as ListToolsResult;
           if (toolsResult.tools) {
+            publishConfiguredToolSnapshot(connection, toolsResult.tools, toolsResult.nextCursor === undefined);
             const logicalServerName = connection.name || serverName;
-            allTools.push(...filterDisabledTools(toolsResult.tools, serverConfigs, logicalServerName));
+            allTools.push(
+              ...filterDisabledTools(toolsResult.tools, serverConfigs, logicalServerName).map((tool) =>
+                applyEffectiveToolDescription(tool, serverConfigs[logicalServerName], logicalServerName),
+              ),
+            );
           }
+        } else {
+          clearConfiguredToolSnapshot(connection);
         }
 
         // Process resources (second if available)
@@ -229,6 +243,8 @@ export class CapabilityAggregator extends EventEmitter {
       }
     }
 
+    publishCompleteConfiguredToolTargetSnapshots(this.outboundConns);
+
     return {
       tools: this.deduplicateTools(allTools),
       resources: this.deduplicateResources(allResources),
@@ -247,10 +263,12 @@ export class CapabilityAggregator extends EventEmitter {
     transport: EnhancedTransport,
   ): Promise<ListToolsResult> {
     try {
-      return await client.listTools(undefined, { timeout: getRequestTimeout(transport) });
+      return await collectConfiguredToolPages((cursor) =>
+        client.listTools(cursor === undefined ? undefined : { cursor }, { timeout: getRequestTimeout(transport) }),
+      );
     } catch (error) {
       logger.warn(`Failed to list tools from ${serverName}`, { error: String(error) });
-      return { tools: [] };
+      throw error;
     }
   }
 
@@ -291,8 +309,8 @@ export class CapabilityAggregator extends EventEmitter {
    */
   private detectChanges(previous: AggregatedCapabilities, current: AggregatedCapabilities): CapabilityChanges {
     const toolsChanged = !this.arraysEqual(
-      previous.tools.map((t) => t.name).sort(),
-      current.tools.map((t) => t.name).sort(),
+      previous.tools.map((tool) => `${tool.name}\0${tool.description ?? ''}`).sort(),
+      current.tools.map((tool) => `${tool.name}\0${tool.description ?? ''}`).sort(),
     );
 
     const resourcesChanged = !this.arraysEqual(

--- a/src/core/capabilities/capabilityCatalog.test.ts
+++ b/src/core/capabilities/capabilityCatalog.test.ts
@@ -72,6 +72,15 @@ describe('CapabilityCatalog', () => {
           type: 'stdio',
           command: 'node',
           disabledTools: ['write_file'],
+          toolDescriptionOverrides: {
+            read_file: 'Read a workspace file safely',
+            write_file: 'Hidden override',
+          },
+        } as any,
+        'template-server': {
+          type: 'stdio',
+          command: 'node',
+          toolDescriptionOverrides: { template_tool: 'Describe a rendered project' },
         } as any,
       }),
       templateHashProvider,
@@ -95,6 +104,29 @@ describe('CapabilityCatalog', () => {
       'template-server:rendered123',
     ]);
     expect(result.servers).toEqual(['filesystem', 'template-server']);
+  });
+
+  it('uses effective descriptions consistently for listing and full-schema inspection', async () => {
+    const upstreamSchema: Tool = {
+      name: 'read_file',
+      description: 'Upstream description',
+      inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+      outputSchema: { type: 'object', properties: { content: { type: 'string' } } },
+      annotations: { readOnlyHint: true },
+    };
+    const catalog = createCatalog(undefined, {
+      loadSchema: vi.fn(async () => upstreamSchema),
+    });
+
+    const listed = await catalog.listVisibleTools({});
+    const described = await catalog.describeVisibleTool({ server: 'filesystem', toolName: 'read_file' });
+
+    expect(listed.tools.find((tool) => tool.name === 'read_file')?.description).toBe('Read a workspace file safely');
+    expect(listed.tools.find((tool) => tool.name === 'template_tool')?.description).toBe('Describe a rendered project');
+    expect(described.schema).toEqual({
+      ...upstreamSchema,
+      description: 'Read a workspace file safely',
+    });
   });
 
   it('maps external capability items for non-tool kinds', async () => {

--- a/src/core/capabilities/capabilityCatalog.ts
+++ b/src/core/capabilities/capabilityCatalog.ts
@@ -2,6 +2,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 
 import { ConnectionResolver, type TemplateHashProvider } from '@src/core/server/connectionResolver.js';
 import { getDisabledToolError, isToolDisabled } from '@src/core/server/disabledTools.js';
+import { applyEffectiveToolDescription } from '@src/core/server/toolDescriptionOverrides.js';
 import {
   ClientStatus,
   type MCPServerParams,
@@ -218,7 +219,12 @@ export class CapabilityCatalog {
     const { route } = access;
     const cached = this.deps.schemaCache.getIfCached(route.connectionKey, route.toolName);
     if (cached) {
-      return { schema: cached, fromCache: true, route, refresh };
+      return {
+        schema: applyEffectiveToolDescription(cached, this.deps.getServerConfigs()[route.server], route.server),
+        fromCache: true,
+        route,
+        refresh,
+      };
     }
 
     if (!this.deps.loadSchema) {
@@ -235,7 +241,12 @@ export class CapabilityCatalog {
 
     try {
       const tool = await this.deps.schemaCache.getOrLoad(route.connectionKey, route.toolName, this.deps.loadSchema);
-      return { schema: tool, fromCache: false, route, refresh };
+      return {
+        schema: applyEffectiveToolDescription(tool, this.deps.getServerConfigs()[route.server], route.server),
+        fromCache: false,
+        route,
+        refresh,
+      };
     } catch (error) {
       logger.error(`Failed to load tool schema from upstream server: ${route.server}:${route.toolName}`, { error });
       return {
@@ -366,11 +377,15 @@ export class CapabilityCatalog {
         .getAllTools()
         .filter((tool) => !isToolDisabled(serverConfigs, tool.server, tool.name))
         .map((tool) => ({
-          tool: {
-            name: tool.name,
-            description: tool.description,
-            inputSchema: tool.inputSchema ?? { type: 'object' },
-          },
+          tool: applyEffectiveToolDescription(
+            {
+              name: tool.name,
+              description: tool.description,
+              inputSchema: tool.inputSchema ?? { type: 'object' },
+            },
+            serverConfigs[tool.server],
+            tool.server,
+          ),
           server: tool.server,
           connectionKey: tool.connectionKey,
           tags: tool.tags,

--- a/src/core/capabilities/capabilityPagination.ts
+++ b/src/core/capabilities/capabilityPagination.ts
@@ -10,6 +10,8 @@ import {
 import type { OutboundConnection, OutboundConnections } from '@src/core/types/index.js';
 import { MCPError } from '@src/utils/core/errorTypes.js';
 
+import { clearConfiguredToolSnapshot } from './configuredToolSnapshot.js';
+
 /** MCP result metadata key used to describe a partial aggregate walk. */
 export const CAPABILITY_PAGINATION_META_KEY = 'app.1mcp/capability-pagination';
 
@@ -118,6 +120,7 @@ export function registerCapabilityPaginationNotifications(
     await Promise.all(Array.from(state!.forwarders.values(), (handler) => handler(notification)));
   };
   setNotificationHandler(ToolListChangedNotificationSchema, async (notification) => {
+    clearConfiguredToolSnapshot(connection);
     for (const registeredConnections of state!.connections) {
       advanceCapabilityPaginationGeneration(registeredConnections, 'tools');
     }

--- a/src/core/capabilities/configuredToolSnapshot.test.ts
+++ b/src/core/capabilities/configuredToolSnapshot.test.ts
@@ -1,0 +1,99 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { ClientStatus, type OutboundConnection, type OutboundConnections } from '@src/core/types/index.js';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  clearLastConfiguredToolSnapshot,
+  collectConfiguredToolPages,
+  publishCompleteConfiguredToolTargetSnapshots,
+  publishConfiguredToolPage,
+  publishConfiguredToolSnapshot,
+  readConfiguredToolSnapshot,
+  readLastConfiguredToolSnapshot,
+} from './configuredToolSnapshot.js';
+
+function connection(name: string): OutboundConnection {
+  return {
+    name,
+    status: ClientStatus.Connected,
+    client: {},
+    transport: {},
+  } as unknown as OutboundConnection;
+}
+
+describe('configured tool snapshots', () => {
+  it('evicts a durable target snapshot only when its definition is removed', () => {
+    const outbound = connection('removed-target');
+    publishConfiguredToolSnapshot(outbound, [{ name: 'old', inputSchema: { type: 'object' } }]);
+    publishCompleteConfiguredToolTargetSnapshots(new Map([['removed-target', outbound]]));
+
+    clearLastConfiguredToolSnapshot('removed-target');
+
+    expect(readLastConfiguredToolSnapshot('removed-target')).toEqual([]);
+  });
+
+  it('publishes only after an ordered protocol page sequence is complete', () => {
+    const outbound = connection('paged-target');
+
+    publishConfiguredToolPage(outbound, [{ name: 'first', inputSchema: { type: 'object' } }], undefined, 'page-2');
+    expect(readConfiguredToolSnapshot(outbound)).toBeUndefined();
+    publishConfiguredToolPage(outbound, [{ name: 'second', inputSchema: { type: 'object' } }], 'page-2', undefined);
+
+    expect(readConfiguredToolSnapshot(outbound)?.map((tool) => tool.name)).toEqual(['first', 'second']);
+  });
+
+  it('collects every upstream page for runtime discovery', async () => {
+    const listPage = vi.fn(async (cursor: string | undefined) =>
+      cursor === undefined
+        ? { tools: [{ name: 'first', inputSchema: { type: 'object' as const } }], nextCursor: 'page-2' }
+        : { tools: [{ name: 'second', inputSchema: { type: 'object' as const } }] },
+    );
+
+    const result = await collectConfiguredToolPages(listPage);
+
+    expect(result.tools.map((tool) => tool.name)).toEqual(['first', 'second']);
+    expect(listPage).toHaveBeenNthCalledWith(2, 'page-2');
+  });
+
+  it('promotes a complete per-instance union to the bounded target fallback', () => {
+    const first = connection('snapshot-target');
+    const second = connection('snapshot-target');
+    const connections: OutboundConnections = new Map([
+      ['snapshot-target:first', first],
+      ['snapshot-target:second', second],
+    ]);
+    const firstTools: Tool[] = [{ name: 'search', inputSchema: { type: 'object' } }];
+    const secondTools: Tool[] = [{ name: 'read', inputSchema: { type: 'object' } }];
+
+    publishConfiguredToolSnapshot(first, firstTools);
+    publishConfiguredToolSnapshot(second, secondTools);
+    publishCompleteConfiguredToolTargetSnapshots(connections);
+
+    connections.clear();
+    expect(
+      readLastConfiguredToolSnapshot('snapshot-target')
+        .map((tool) => tool.name)
+        .sort(),
+    ).toEqual(['read', 'search']);
+  });
+
+  it('does not replace the last complete target fallback with a partial observation', () => {
+    const complete = connection('partial-snapshot-target');
+    publishConfiguredToolSnapshot(complete, [{ name: 'known', inputSchema: { type: 'object' } }]);
+    publishCompleteConfiguredToolTargetSnapshots(new Map([['complete', complete]]));
+
+    const observed = connection('partial-snapshot-target');
+    const unknown = connection('partial-snapshot-target');
+    publishConfiguredToolSnapshot(observed, [{ name: 'partial', inputSchema: { type: 'object' } }]);
+    publishCompleteConfiguredToolTargetSnapshots(
+      new Map([
+        ['observed', observed],
+        ['unknown', unknown],
+      ]),
+    );
+
+    expect(readLastConfiguredToolSnapshot('partial-snapshot-target').map((tool) => tool.name)).toEqual(['known']);
+  });
+});

--- a/src/core/capabilities/configuredToolSnapshot.test.ts
+++ b/src/core/capabilities/configuredToolSnapshot.test.ts
@@ -44,6 +44,16 @@ describe('configured tool snapshots', () => {
     expect(readConfiguredToolSnapshot(outbound)?.map((tool) => tool.name)).toEqual(['first', 'second']);
   });
 
+  it('rejects a cyclic protocol page sequence without retaining partial state', () => {
+    const outbound = connection('cyclic-target');
+
+    publishConfiguredToolPage(outbound, [{ name: 'first', inputSchema: { type: 'object' } }], undefined, 'page-2');
+    publishConfiguredToolPage(outbound, [{ name: 'second', inputSchema: { type: 'object' } }], 'page-2', 'page-2');
+    publishConfiguredToolPage(outbound, [{ name: 'third', inputSchema: { type: 'object' } }], 'page-2', undefined);
+
+    expect(readConfiguredToolSnapshot(outbound)).toBeUndefined();
+  });
+
   it('collects every upstream page for runtime discovery', async () => {
     const listPage = vi.fn(async (cursor: string | undefined) =>
       cursor === undefined

--- a/src/core/capabilities/configuredToolSnapshot.ts
+++ b/src/core/capabilities/configuredToolSnapshot.ts
@@ -1,0 +1,111 @@
+import type { ListToolsResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { ClientStatus, type OutboundConnection, type OutboundConnections } from '@src/core/types/index.js';
+
+const snapshots = new WeakMap<OutboundConnection, Tool[]>();
+const pendingPages = new WeakMap<OutboundConnection, { nextCursor: string; tools: Tool[] }>();
+const lastCompleteTargetSnapshots = new Map<string, Tool[]>();
+const MAX_TOOL_PAGES = 1_000;
+
+export function publishConfiguredToolSnapshot(
+  connection: OutboundConnection,
+  tools: readonly Tool[],
+  complete = true,
+): void {
+  if (!complete) {
+    snapshots.delete(connection);
+    return;
+  }
+  const snapshot = tools.map((tool) => ({ ...tool }));
+  snapshots.set(connection, snapshot);
+}
+
+export function publishConfiguredToolPage(
+  connection: OutboundConnection,
+  tools: readonly Tool[],
+  cursor: string | undefined,
+  nextCursor: string | undefined,
+): void {
+  const previous = cursor === undefined ? undefined : pendingPages.get(connection);
+  if (cursor !== undefined && previous?.nextCursor !== cursor) {
+    pendingPages.delete(connection);
+    return;
+  }
+
+  const accumulated = [...(previous?.tools ?? []), ...tools];
+  if (nextCursor === undefined) {
+    pendingPages.delete(connection);
+    publishConfiguredToolSnapshot(connection, accumulated);
+  } else {
+    pendingPages.set(connection, { nextCursor, tools: accumulated });
+    snapshots.delete(connection);
+  }
+}
+
+export async function collectConfiguredToolPages(
+  listPage: (cursor: string | undefined) => Promise<ListToolsResult>,
+): Promise<ListToolsResult> {
+  const tools: Tool[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_TOOL_PAGES; page += 1) {
+    const result = await listPage(cursor);
+    tools.push(...(result.tools ?? []));
+    if (result.nextCursor === undefined) return { ...result, tools };
+    if (seenCursors.has(result.nextCursor)) throw new Error('Tool pagination returned a repeated cursor');
+    seenCursors.add(result.nextCursor);
+    cursor = result.nextCursor;
+  }
+
+  throw new Error(`Tool pagination exceeded ${MAX_TOOL_PAGES} pages`);
+}
+
+export function readConfiguredToolSnapshot(connection: OutboundConnection): readonly Tool[] | undefined {
+  return snapshots.get(connection);
+}
+
+export function clearConfiguredToolSnapshot(connection: OutboundConnection): void {
+  snapshots.delete(connection);
+  pendingPages.delete(connection);
+}
+
+export function readLastConfiguredToolSnapshot(targetName: string): readonly Tool[] {
+  return lastCompleteTargetSnapshots.get(targetName) ?? [];
+}
+
+export function clearLastConfiguredToolSnapshot(targetName: string): void {
+  lastCompleteTargetSnapshots.delete(targetName);
+}
+
+export function publishLastConfiguredToolSnapshot(targetName: string, tools: readonly Tool[]): void {
+  lastCompleteTargetSnapshots.set(
+    targetName,
+    tools.map((tool) => ({ ...tool })),
+  );
+}
+
+export function publishCompleteConfiguredToolTargetSnapshots(connections: OutboundConnections): void {
+  const connectionsByTarget = new Map<string, OutboundConnection[]>();
+
+  for (const connection of connections.values()) {
+    if (connection.status !== ClientStatus.Connected) continue;
+    const existing = connectionsByTarget.get(connection.name);
+    if (existing) existing.push(connection);
+    else connectionsByTarget.set(connection.name, [connection]);
+  }
+
+  for (const [targetName, targetConnections] of connectionsByTarget) {
+    const targetTools = new Map<string, Tool>();
+    let complete = true;
+    for (const connection of targetConnections) {
+      const connectionTools = snapshots.get(connection);
+      if (!connectionTools) {
+        complete = false;
+        break;
+      }
+      for (const tool of connectionTools) targetTools.set(tool.name, tool);
+    }
+    if (complete) publishLastConfiguredToolSnapshot(targetName, Array.from(targetTools.values()));
+  }
+}

--- a/src/core/capabilities/configuredToolSnapshot.ts
+++ b/src/core/capabilities/configuredToolSnapshot.ts
@@ -3,7 +3,10 @@ import type { ListToolsResult, Tool } from '@modelcontextprotocol/sdk/types.js';
 import { ClientStatus, type OutboundConnection, type OutboundConnections } from '@src/core/types/index.js';
 
 const snapshots = new WeakMap<OutboundConnection, Tool[]>();
-const pendingPages = new WeakMap<OutboundConnection, { nextCursor: string; tools: Tool[] }>();
+const pendingPages = new WeakMap<
+  OutboundConnection,
+  { nextCursor: string; tools: Tool[]; seenCursors: Set<string>; pageCount: number }
+>();
 const lastCompleteTargetSnapshots = new Map<string, Tool[]>();
 const MAX_TOOL_PAGES = 1_000;
 
@@ -27,8 +30,14 @@ export function publishConfiguredToolPage(
   nextCursor: string | undefined,
 ): void {
   const previous = cursor === undefined ? undefined : pendingPages.get(connection);
-  if (cursor !== undefined && previous?.nextCursor !== cursor) {
+  if (
+    cursor !== undefined &&
+    (previous?.nextCursor !== cursor ||
+      previous.seenCursors.has(nextCursor ?? '') ||
+      previous.pageCount >= MAX_TOOL_PAGES)
+  ) {
     pendingPages.delete(connection);
+    snapshots.delete(connection);
     return;
   }
 
@@ -37,7 +46,12 @@ export function publishConfiguredToolPage(
     pendingPages.delete(connection);
     publishConfiguredToolSnapshot(connection, accumulated);
   } else {
-    pendingPages.set(connection, { nextCursor, tools: accumulated });
+    pendingPages.set(connection, {
+      nextCursor,
+      tools: accumulated,
+      seenCursors: new Set([...(previous?.seenCursors ?? []), nextCursor]),
+      pageCount: (previous?.pageCount ?? 0) + 1,
+    });
     snapshots.delete(connection);
   }
 }

--- a/src/core/capabilities/lazyLoadingOrchestrator.test.ts
+++ b/src/core/capabilities/lazyLoadingOrchestrator.test.ts
@@ -8,6 +8,7 @@ import { ClientStatus, OutboundConnections } from '@src/core/types/index.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { capabilityVisibilityFromServerNames } from './capabilityVisibility.js';
+import { readConfiguredToolSnapshot, readLastConfiguredToolSnapshot } from './configuredToolSnapshot.js';
 import { LazyLoadingOrchestrator } from './lazyLoadingOrchestrator.js';
 
 describe('LazyLoadingOrchestrator', () => {
@@ -216,6 +217,22 @@ describe('LazyLoadingOrchestrator', () => {
       await orchestrator.refreshCapabilities();
       expect(orchestrator.getToolRegistry().size()).toBe(2);
       expect(slowListTools).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps the last complete target snapshot but clears a failed connection snapshot', async () => {
+      mockOutboundConnections.delete('database');
+      const connection = mockOutboundConnections.get('filesystem')!;
+      orchestrator = new LazyLoadingOrchestrator(mockOutboundConnections, mockAgentConfig);
+
+      await orchestrator.initialize();
+      expect(readConfiguredToolSnapshot(connection)?.map((tool) => tool.name)).toContain('read_file');
+      expect(readLastConfiguredToolSnapshot('filesystem').map((tool) => tool.name)).toContain('read_file');
+
+      mockClient.listTools.mockRejectedValueOnce(new Error('discovery failed'));
+      await orchestrator.refreshCapabilities();
+
+      expect(readConfiguredToolSnapshot(connection)).toBeUndefined();
+      expect(readLastConfiguredToolSnapshot('filesystem').map((tool) => tool.name)).toContain('read_file');
     });
 
     it('should initialize successfully in metatool mode', async () => {

--- a/src/core/capabilities/lazyLoadingOrchestrator.ts
+++ b/src/core/capabilities/lazyLoadingOrchestrator.ts
@@ -16,6 +16,7 @@ import { AsyncLoadingOrchestratorEvent } from './asyncLoadingOrchestratorEvent.j
 import { AggregatedCapabilities, CapabilityAggregator } from './capabilityAggregator.js';
 import { type CapabilityVisibility, getCapabilityVisibleServerNames } from './capabilityVisibility.js';
 import {
+  clearConfiguredToolSnapshot,
   collectConfiguredToolPages,
   publishCompleteConfiguredToolTargetSnapshots,
   publishConfiguredToolSnapshot,
@@ -202,6 +203,7 @@ export class LazyLoadingOrchestrator extends EventEmitter {
           );
         }
       } catch (error) {
+        clearConfiguredToolSnapshot(connection);
         const errorMessage = error instanceof Error ? error.message : String(error);
         errorIf(() => ({
           message: 'Failed to list tools from server during registry build',

--- a/src/core/capabilities/lazyLoadingOrchestrator.ts
+++ b/src/core/capabilities/lazyLoadingOrchestrator.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 
-import { McpConfigManager } from '@src/config/mcpConfigManager.js';
+import { getConfiguredServerTargets } from '@src/config/configuredServerTargets.js';
 import { MCP_URI_SEPARATOR } from '@src/constants.js';
 import { AgentConfigManager } from '@src/core/server/agentConfig.js';
 import { ConnectionResolver, TemplateHashProvider } from '@src/core/server/connectionResolver.js';
@@ -15,6 +15,11 @@ import { AsyncLoadingOrchestrator } from './asyncLoadingOrchestrator.js';
 import { AsyncLoadingOrchestratorEvent } from './asyncLoadingOrchestratorEvent.js';
 import { AggregatedCapabilities, CapabilityAggregator } from './capabilityAggregator.js';
 import { type CapabilityVisibility, getCapabilityVisibleServerNames } from './capabilityVisibility.js';
+import {
+  collectConfiguredToolPages,
+  publishCompleteConfiguredToolTargetSnapshots,
+  publishConfiguredToolSnapshot,
+} from './configuredToolSnapshot.js';
 import { MetaToolProvider } from './metaToolProvider.js';
 import { SchemaCache, SchemaCacheConfig } from './schemaCache.js';
 import { ToolRegistry } from './toolRegistry.js';
@@ -163,7 +168,7 @@ export class LazyLoadingOrchestrator extends EventEmitter {
     // Build tools map for registry by fetching tools directly from each connection
     const registryTools: Array<{ tool: Tool; server: string; connectionKey: string; tags: string[] }> = [];
     const failedServers: Array<{ server: string; error: string }> = [];
-    const serverConfigs = McpConfigManager.getInstance().getTransportConfig();
+    const serverConfigs = getConfiguredServerTargets();
 
     for (const [serverName, connection] of this.outboundConnections.entries()) {
       if (!connection.client || connection.status !== ClientStatus.Connected) {
@@ -172,9 +177,12 @@ export class LazyLoadingOrchestrator extends EventEmitter {
 
       try {
         // Get tools directly from this server's client
-        const toolsResult = await connection.client.listTools(undefined, {
-          timeout: getRequestTimeout(connection.transport),
-        });
+        const toolsResult = await collectConfiguredToolPages((cursor) =>
+          connection.client.listTools(cursor === undefined ? undefined : { cursor }, {
+            timeout: getRequestTimeout(connection.transport),
+          }),
+        );
+        publishConfiguredToolSnapshot(connection, toolsResult.tools ?? []);
         const effectiveServerName = connection.name || serverName;
         const serverTools = filterDisabledTools(toolsResult.tools || [], serverConfigs, effectiveServerName);
 
@@ -202,6 +210,8 @@ export class LazyLoadingOrchestrator extends EventEmitter {
         failedServers.push({ server: serverName, error: errorMessage });
       }
     }
+
+    publishCompleteConfiguredToolTargetSnapshots(this.outboundConnections);
 
     // Warn if significant failures
     if (failedServers.length > 0) {

--- a/src/core/capabilities/metaToolProvider.ts
+++ b/src/core/capabilities/metaToolProvider.ts
@@ -1,6 +1,6 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 
-import { McpConfigManager } from '@src/config/mcpConfigManager.js';
+import { getConfiguredServerTargets } from '@src/config/configuredServerTargets.js';
 import { TemplateHashProvider } from '@src/core/server/connectionResolver.js';
 import { OutboundConnections } from '@src/core/types/index.js';
 import logger, { errorIf } from '@src/logger/logger.js';
@@ -111,7 +111,7 @@ export class MetaToolProvider {
       loadSchema,
       defaultVisibility,
       templateHashProvider,
-      getServerConfigs: () => McpConfigManager.getInstance().getTransportConfig(),
+      getServerConfigs: getConfiguredServerTargets,
     });
   }
 
@@ -127,7 +127,7 @@ export class MetaToolProvider {
       loadSchema: this.loadSchema,
       defaultVisibility: visibility,
       templateHashProvider: this.templateHashProvider,
-      getServerConfigs: () => McpConfigManager.getInstance().getTransportConfig(),
+      getServerConfigs: getConfiguredServerTargets,
     });
   }
 

--- a/src/core/configChangeHandler.restart-logic.test.ts
+++ b/src/core/configChangeHandler.restart-logic.test.ts
@@ -145,6 +145,9 @@ describe('ConfigChangeHandler', () => {
 
         const { ServerManager } = await import('@src/core/server/serverManager.js');
         expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
+        expect(ServerManager.current.restartServer).not.toHaveBeenCalled();
+        expect(ServerManager.current.stopServer).not.toHaveBeenCalled();
+        expect(ServerManager.current.startServer).not.toHaveBeenCalled();
         expect(ServerManager.current.updateServerMetadata).toHaveBeenCalled();
         expect(notify).toHaveBeenCalledOnce();
       },

--- a/src/core/configChangeHandler.restart-logic.test.ts
+++ b/src/core/configChangeHandler.restart-logic.test.ts
@@ -119,6 +119,37 @@ describe('ConfigChangeHandler', () => {
       expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
     });
 
+    it.each(['disabledTools', 'toolDescriptionOverrides'])(
+      'should not restart for %s metadata changes',
+      async (field) => {
+        const notify = vi
+          .spyOn(configChangeHandler as any, 'sendListChangedNotifications')
+          .mockResolvedValue(undefined);
+        const changes = [
+          {
+            serverName: 'test-server',
+            type: ConfigChangeType.MODIFIED,
+            fieldsChanged: [field],
+          },
+        ];
+        mockConfigManager.getTransportConfig = vi.fn(() => ({
+          'test-server': {
+            command: 'node',
+            args: ['server.js'],
+            [field]: field === 'disabledTools' ? ['write_file'] : { read_file: 'Read safely' },
+          },
+        }));
+
+        const changeHandler = (mockConfigManager.on as any).mock.calls[0][1];
+        await changeHandler(changes);
+
+        const { ServerManager } = await import('@src/core/server/serverManager.js');
+        expect(ServerManager.current.loadMcpServer).not.toHaveBeenCalled();
+        expect(ServerManager.current.updateServerMetadata).toHaveBeenCalled();
+        expect(notify).toHaveBeenCalledOnce();
+      },
+    );
+
     it('should return true for mixed field changes (including tags)', async () => {
       const changes = [
         {

--- a/src/core/configChangeHandler.test.ts
+++ b/src/core/configChangeHandler.test.ts
@@ -1,4 +1,8 @@
 import { ConfigChangeType, ConfigManager } from '@src/config/configManager.js';
+import {
+  publishLastConfiguredToolSnapshot,
+  readLastConfiguredToolSnapshot,
+} from '@src/core/capabilities/configuredToolSnapshot.js';
 import { ConfigChangeHandler } from '@src/core/configChangeHandler.js';
 import logger from '@src/logger/logger.js';
 
@@ -181,6 +185,19 @@ describe('ConfigChangeHandler', () => {
 
       const { ServerManager } = await import('@src/core/server/serverManager.js');
       expect(ServerManager.current.unloadMcpServer).toHaveBeenCalledWith('removed-server');
+    });
+
+    it('clears the retained tool snapshot when unloading a removed server fails', async () => {
+      publishLastConfiguredToolSnapshot('removed-server', [{ name: 'stale', inputSchema: { type: 'object' } }]);
+      const { ServerManager } = await import('@src/core/server/serverManager.js');
+      (ServerManager.current.unloadMcpServer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Unload failed'),
+      );
+      const changeHandler = (mockConfigManager.on as any).mock.calls[0][1];
+
+      await changeHandler([{ serverName: 'removed-server', type: ConfigChangeType.REMOVED }]);
+
+      expect(readLastConfiguredToolSnapshot('removed-server')).toEqual([]);
     });
   });
 

--- a/src/core/configChangeHandler.test.ts
+++ b/src/core/configChangeHandler.test.ts
@@ -86,14 +86,19 @@ describe('ConfigChangeHandler', () => {
         templateServers,
         errors: [],
       }));
+      const { ServerManager } = await import('@src/core/server/serverManager.js');
+      vi.mocked(ServerManager.current.getTemplateServerManager().rebuildTemplateIndex).mockReturnValue({
+        toolMetadataChanged: true,
+      });
+      const notify = vi.spyOn(configChangeHandler as any, 'sendListChangedNotifications').mockResolvedValue(undefined);
       const changeHandler = (mockConfigManager.on as any).mock.calls[0][1];
 
       await changeHandler([]);
 
-      const { ServerManager } = await import('@src/core/server/serverManager.js');
       expect(ServerManager.current.getTemplateServerManager().rebuildTemplateIndex).toHaveBeenCalledWith({
         mcpTemplates: templateServers,
       });
+      expect(notify).toHaveBeenCalledOnce();
     });
 
     it('preserves running template instances when declared config validation fails', async () => {

--- a/src/core/configChangeHandler.ts
+++ b/src/core/configChangeHandler.ts
@@ -1,4 +1,5 @@
 import { CONFIG_EVENTS, ConfigChange, ConfigChangeType, ConfigManager } from '@src/config/configManager.js';
+import { clearLastConfiguredToolSnapshot } from '@src/core/capabilities/configuredToolSnapshot.js';
 import { ServerManager } from '@src/core/server/serverManager.js';
 import { MCPServerParams } from '@src/core/types/index.js';
 import logger, { debugIf } from '@src/logger/logger.js';
@@ -62,9 +63,12 @@ export class ConfigChangeHandler {
    * Handle configuration changes with business logic
    */
   private async handleConfigChanges(changes: ConfigChange[]): Promise<void> {
-    this.reconcileDeclaredTemplates();
+    const templateToolMetadataChanged = this.reconcileDeclaredTemplates();
     this.refreshRuntimeInstructionConfiguration();
     if (changes.length === 0) {
+      if (templateToolMetadataChanged) {
+        await this.sendListChangedNotifications();
+      }
       return;
     }
 
@@ -86,6 +90,9 @@ export class ConfigChangeHandler {
 
     // Notify clients if capabilities changed
     await this.notifyClientsIfNeeded(appliedChanges, newConfig);
+    if (templateToolMetadataChanged && appliedChanges.length === 0) {
+      await this.sendListChangedNotifications();
+    }
   }
 
   private refreshRuntimeInstructionConfiguration(): void {
@@ -94,17 +101,20 @@ export class ConfigChangeHandler {
     aggregator?.setRuntimeInstructionConfiguration(this.configManager.getRuntimeInstructionConfiguration());
   }
 
-  private reconcileDeclaredTemplates(): void {
-    if (typeof this.configManager.loadDeclaredServerConfigs !== 'function') return;
+  private reconcileDeclaredTemplates(): boolean {
+    if (typeof this.configManager.loadDeclaredServerConfigs !== 'function') return false;
     const serverManager = this.tryGetServerManager();
-    if (typeof serverManager?.getTemplateServerManager !== 'function') return;
+    if (typeof serverManager?.getTemplateServerManager !== 'function') return false;
 
     const { templateServers, errors } = this.configManager.loadDeclaredServerConfigs();
     if (errors.length > 0) {
       logger.warn('Skipping template reconciliation because the declared configuration is invalid', { errors });
-      return;
+      return false;
     }
-    serverManager.getTemplateServerManager().rebuildTemplateIndex({ mcpTemplates: templateServers });
+    return (
+      serverManager.getTemplateServerManager().rebuildTemplateIndex({ mcpTemplates: templateServers })
+        ?.toolMetadataChanged ?? false
+    );
   }
 
   /**
@@ -133,6 +143,7 @@ export class ConfigChangeHandler {
 
       case ConfigChangeType.REMOVED:
         await this.handleServerRemoved(change.serverName);
+        clearLastConfiguredToolSnapshot(change.serverName);
         return true;
 
       case ConfigChangeType.MODIFIED: {
@@ -230,9 +241,8 @@ export class ConfigChangeHandler {
       return true; // Conservative approach - restart if we don't know what changed
     }
 
-    // Tags and instruction overrides are runtime metadata and do not change the backend process.
-    const backendFields = fieldsChanged.filter((field) => field !== 'tags' && field !== 'instructionOverride');
-    return backendFields.length > 0;
+    const metadataOnlyFields = new Set(['tags', 'instructionOverride', 'disabledTools', 'toolDescriptionOverrides']);
+    return fieldsChanged.some((field) => !metadataOnlyFields.has(field));
   }
 
   /**

--- a/src/core/configChangeHandler.ts
+++ b/src/core/configChangeHandler.ts
@@ -142,9 +142,12 @@ export class ConfigChangeHandler {
       }
 
       case ConfigChangeType.REMOVED:
-        await this.handleServerRemoved(change.serverName);
-        clearLastConfiguredToolSnapshot(change.serverName);
-        return true;
+        try {
+          await this.handleServerRemoved(change.serverName);
+          return true;
+        } finally {
+          clearLastConfiguredToolSnapshot(change.serverName);
+        }
 
       case ConfigChangeType.MODIFIED: {
         const config = newConfig[change.serverName];

--- a/src/core/protocol/capabilityPaginationHandlers.test.ts
+++ b/src/core/protocol/capabilityPaginationHandlers.test.ts
@@ -213,6 +213,35 @@ describe('capability pagination protocol handlers', () => {
     expect(alphaList).toHaveBeenNthCalledWith(2, { cursor: 'alpha-next' }, expect.anything());
   });
 
+  it('rejects a tool cursor after a configured description override changes', async () => {
+    const listTools = vi
+      .fn()
+      .mockResolvedValueOnce({
+        tools: [{ name: 'search', description: 'Search upstream', inputSchema: { type: 'object' } }],
+        nextCursor: 'alpha-next',
+      })
+      .mockResolvedValueOnce({ tools: [] });
+    const connections = new Map([['alpha', connection('alpha', { listTools })]]) as OutboundConnections;
+    registerToolHandlers(connections, {
+      enablePagination: true,
+      status: ServerStatus.Connected,
+      server: { setRequestHandler: vi.fn((schema, handler) => handlers.set(schema, handler)) },
+    } as never);
+    const handler = handlers.get(ListToolsRequestSchema);
+    if (!handler) throw new Error('tools/list handler was not registered');
+    const first = (await handler({ params: {} })) as { nextCursor?: string };
+
+    mockGetTransportConfig.mockReturnValue({
+      alpha: { type: 'stdio', command: 'node', toolDescriptionOverrides: { search: 'Search safely' } },
+    });
+
+    await expect(handler({ params: { cursor: first.nextCursor } })).rejects.toMatchObject({
+      code: ErrorCode.InvalidParams,
+      data: { reason: 'stale_generation' },
+    });
+    expect(listTools).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['malformed text', 'not-a-cursor!'],
     ['legacy cursor', Buffer.from('alpha:upstream-cursor').toString('base64')],

--- a/src/core/protocol/capabilityPaginationHandlers.test.ts
+++ b/src/core/protocol/capabilityPaginationHandlers.test.ts
@@ -10,19 +10,19 @@ import {
   ResourceListChangedNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 
-import type { OutboundConnection, OutboundConnections } from '@src/core/types/index.js';
-import { ClientStatus, ServerStatus } from '@src/core/types/index.js';
 import {
   registerCapabilityPaginationNotifications,
   unregisterCapabilityPaginationForwarder,
 } from '@src/core/capabilities/capabilityPagination.js';
+import type { OutboundConnection, OutboundConnections } from '@src/core/types/index.js';
+import { ClientStatus, ServerStatus } from '@src/core/types/index.js';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { registerResourceHandlers } from './resourceRequestHandlers.js';
-import { registerPromptHandlers } from './promptRequestHandlers.js';
-import { registerToolHandlers } from './toolRequestHandlers.js';
 import { setupClientToServerNotifications } from './notificationHandlers.js';
+import { registerPromptHandlers } from './promptRequestHandlers.js';
+import { registerResourceHandlers } from './resourceRequestHandlers.js';
+import { registerToolHandlers } from './toolRequestHandlers.js';
 
 const mockGetTransportConfig = vi.fn(() => ({}));
 const mockGetAvailableTools = vi.fn(() => [
@@ -171,7 +171,10 @@ describe('capability pagination protocol handlers', () => {
   it('walks upstream tool pages and includes internal tools exactly once', async () => {
     const alphaList = vi
       .fn()
-      .mockResolvedValueOnce({ tools: [{ name: 'alpha-1', inputSchema: { type: 'object' } }], nextCursor: 'alpha-next' })
+      .mockResolvedValueOnce({
+        tools: [{ name: 'alpha-1', inputSchema: { type: 'object' } }],
+        nextCursor: 'alpha-next',
+      })
       .mockResolvedValueOnce({ tools: [{ name: 'alpha-2', inputSchema: { type: 'object' } }] });
     const zetaList = vi.fn().mockResolvedValue({
       tools: [{ name: 'zeta-1', inputSchema: { type: 'object' } }],
@@ -180,16 +183,13 @@ describe('capability pagination protocol handlers', () => {
       ['zeta-key', connection('zeta', { listTools: zetaList })],
       ['alpha-key', connection('alpha', { listTools: alphaList })],
     ]);
-    registerToolHandlers(
-      connections,
-      {
-        enablePagination: true,
-        status: ServerStatus.Connected,
-        server: {
-          setRequestHandler: vi.fn((schema, handler) => handlers.set(schema, handler)),
-        },
-      } as never,
-    );
+    registerToolHandlers(connections, {
+      enablePagination: true,
+      status: ServerStatus.Connected,
+      server: {
+        setRequestHandler: vi.fn((schema, handler) => handlers.set(schema, handler)),
+      },
+    } as never);
     const handler = handlers.get(ListToolsRequestSchema);
     if (!handler) throw new Error('tools/list handler was not registered');
 
@@ -230,6 +230,7 @@ describe('capability pagination protocol handlers', () => {
     const handler = handlers.get(ListToolsRequestSchema);
     if (!handler) throw new Error('tools/list handler was not registered');
     const first = (await handler({ params: {} })) as { nextCursor?: string };
+    listTools.mockClear();
 
     mockGetTransportConfig.mockReturnValue({
       alpha: { type: 'stdio', command: 'node', toolDescriptionOverrides: { search: 'Search safely' } },
@@ -260,9 +261,7 @@ describe('capability pagination protocol handlers', () => {
   it('rejects a cursor used for a different capability kind', async () => {
     const listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'alpha-tool', inputSchema: { type: 'object' } }] });
     const listResources = vi.fn().mockResolvedValue({ resources: [{ uri: 'alpha-resource', name: 'alpha-resource' }] });
-    const connections = new Map([
-      ['alpha', connection('alpha', { listTools, listResources })],
-    ]) as OutboundConnections;
+    const connections = new Map([['alpha', connection('alpha', { listTools, listResources })]]) as OutboundConnections;
 
     registerToolHandlers(connections, {
       enablePagination: true,
@@ -513,11 +512,7 @@ describe('capability pagination protocol handlers', () => {
 
     const result = (await handler({ params: {} })) as { tools: Array<{ name: string }>; nextCursor?: string };
 
-    expect(result.tools.map((tool) => tool.name)).toEqual([
-      '1mcp_1mcp_runtime_status',
-      'tool_list',
-      'tool_schema',
-    ]);
+    expect(result.tools.map((tool) => tool.name)).toEqual(['1mcp_1mcp_runtime_status', 'tool_list', 'tool_schema']);
     expect(result.nextCursor).toBeUndefined();
     await expect(handler({ params: { cursor: 'legacy!' } })).rejects.toMatchObject({
       code: ErrorCode.InvalidParams,

--- a/src/core/protocol/requestHandlerUtils.ts
+++ b/src/core/protocol/requestHandlerUtils.ts
@@ -1,4 +1,4 @@
-import { McpConfigManager } from '@src/config/mcpConfigManager.js';
+import { getConfiguredServerTargets } from '@src/config/configuredServerTargets.js';
 import { CapabilityCatalog } from '@src/core/capabilities/capabilityCatalog.js';
 import { type CapabilityVisibility, createCapabilityVisibility } from '@src/core/capabilities/capabilityVisibility.js';
 import { SchemaCache } from '@src/core/capabilities/schemaCache.js';
@@ -18,7 +18,7 @@ export function getRequestSession(inboundConn: InboundConnection): string | unde
 
 export async function createCapabilityCatalogFromConnections(
   connections: OutboundConnections,
-  getServerConfigs: () => Record<string, MCPServerParams> = () => McpConfigManager.getInstance().getTransportConfig(),
+  getServerConfigs: () => Record<string, MCPServerParams> = getConfiguredServerTargets,
 ): Promise<CapabilityCatalog> {
   const toolsByServer = new Map<string, Awaited<ReturnType<OutboundConnection['client']['listTools']>>['tools']>();
   const tagsByServer = new Map<string, string[]>();
@@ -58,7 +58,7 @@ export async function createCapabilityCatalogFromConnections(
 /** Create the runtime Capability Catalog used by protocol capability walks. */
 export function createProtocolCapabilityCatalog(
   connections: OutboundConnections,
-  getServerConfigs: () => Record<string, MCPServerParams> = () => McpConfigManager.getInstance().getTransportConfig(),
+  getServerConfigs: () => Record<string, MCPServerParams> = getConfiguredServerTargets,
 ): CapabilityCatalog {
   return new CapabilityCatalog({
     getToolRegistry: ToolRegistry.empty,

--- a/src/core/protocol/requestHandlers-disabledTools.test.ts
+++ b/src/core/protocol/requestHandlers-disabledTools.test.ts
@@ -135,6 +135,31 @@ describe('requestHandlers disabled tools enforcement', () => {
     expect(result.tools.map((tool: { name: string }) => tool.name)).toEqual(['filesystem/read_file']);
   });
 
+  it('uses effective descriptions in non-lazy listTools responses', async () => {
+    mockGetTransportConfig.mockReturnValue({
+      filesystem: {
+        type: 'stdio',
+        command: 'node',
+        toolDescriptionOverrides: {
+          read_file: 'Read a workspace file safely',
+        },
+      },
+    });
+
+    registerRequestHandlers(outboundConnections, {
+      server: mockServer,
+      enablePagination: true,
+    } as any);
+
+    const handler = getRegisteredHandler(ListToolsRequestSchema);
+    const result = await handler({ params: {} });
+
+    expect(result.tools.find((tool: { name: string }) => tool.name === 'filesystem/read_file')).toMatchObject({
+      description: 'Read a workspace file safely',
+      inputSchema: { type: 'object' },
+    });
+  });
+
   it('re-reads disabled tools config for listTools after config reload', async () => {
     mockGetTransportConfig.mockReturnValueOnce({
       filesystem: {

--- a/src/core/protocol/toolRequestHandlers.ts
+++ b/src/core/protocol/toolRequestHandlers.ts
@@ -6,11 +6,16 @@ import {
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { McpConfigManager } from '@src/config/mcpConfigManager.js';
+import { getConfiguredServerTargets } from '@src/config/configuredServerTargets.js';
 import { MCP_URI_SEPARATOR } from '@src/constants.js';
+import {
+  publishCompleteConfiguredToolTargetSnapshots,
+  publishConfiguredToolPage,
+} from '@src/core/capabilities/configuredToolSnapshot.js';
 import { InternalCapabilitiesProvider } from '@src/core/capabilities/internalCapabilitiesProvider.js';
 import { LazyLoadingOrchestrator } from '@src/core/capabilities/lazyLoadingOrchestrator.js';
 import { getDisabledToolError } from '@src/core/server/disabledTools.js';
+import { applyEffectiveToolDescription } from '@src/core/server/toolDescriptionOverrides.js';
 import { InboundConnection, OutboundConnections } from '@src/core/types/index.js';
 import type { MCPServerParams } from '@src/core/types/transport.js';
 import logger, { infoIf } from '@src/logger/logger.js';
@@ -33,7 +38,7 @@ export function registerToolHandlers(
 ): void {
   const sessionId = getRequestSession(inboundConn);
   const lazyLoadingEnabled = lazyLoadingOrchestrator?.isEnabled();
-  const getServerConfigs = (): Record<string, MCPServerParams> => McpConfigManager.getInstance().getTransportConfig();
+  const getServerConfigs = (): Record<string, MCPServerParams> => getConfiguredServerTargets();
   const catalog = createProtocolCapabilityCatalog(outboundConns, getServerConfigs);
 
   inboundConn.server.setRequestHandler(
@@ -108,13 +113,17 @@ export function registerToolHandlers(
             { cursor },
             { timeout: getRequestTimeout(outboundConn.transport) },
           );
+          publishConfiguredToolPage(outboundConn, upstream.tools ?? [], cursor, upstream.nextCursor);
+          if (upstream.nextCursor === undefined) {
+            publishCompleteConfiguredToolTargetSnapshots(outboundConns);
+          }
           return {
             items: upstream.tools ?? [],
             nextCursor: upstream.nextCursor,
           };
         },
         mapItem: (tool, serverName) => ({
-          ...tool,
+          ...applyEffectiveToolDescription(tool, serverConfigs[serverName], serverName),
           name: buildUri(serverName, tool.name, MCP_URI_SEPARATOR),
           inputSchema: tool.inputSchema ?? { type: 'object' },
         }),
@@ -208,12 +217,26 @@ export function registerToolHandlers(
 function createToolPaginationFacts(
   internalTools: Tool[],
   serverConfigs: Record<string, MCPServerParams>,
-): { disabledTools: Record<string, string[]>; internalTools: string[] } {
+): {
+  disabledTools: Record<string, string[]>;
+  toolDescriptionOverrides: Record<string, Record<string, string>>;
+  internalTools: string[];
+} {
   return {
     disabledTools: Object.fromEntries(
       Object.entries(serverConfigs)
         .filter(([, config]) => config.disabledTools?.length)
         .map(([name, config]) => [name, [...(config.disabledTools ?? [])].sort()]),
+    ),
+    toolDescriptionOverrides: Object.fromEntries(
+      Object.entries(serverConfigs)
+        .filter(([, config]) => Object.keys(config.toolDescriptionOverrides ?? {}).length > 0)
+        .map(([name, config]) => [
+          name,
+          Object.fromEntries(
+            Object.entries(config.toolDescriptionOverrides ?? {}).sort(([left], [right]) => left.localeCompare(right)),
+          ),
+        ]),
     ),
     internalTools: internalTools.map((tool) => tool.name).sort(),
   };

--- a/src/core/server/clientInstancePool.ts
+++ b/src/core/server/clientInstancePool.ts
@@ -3,7 +3,7 @@ import {
   createTemplateInstanceId,
   resolveTemplateInstanceId,
   serializePoolIdentity,
-  templateRenderedHash,
+  templateRuntimeHash,
 } from '@src/core/server/templateIdentity.js';
 import type { AuthProviderTransport } from '@src/core/types/client.js';
 import type { MCPServerParams } from '@src/core/types/transport.js';
@@ -71,7 +71,7 @@ export class ClientInstancePool {
     // Render template with context data
     const renderer = new HandlebarsTemplateRenderer();
     const renderedConfig = renderer.renderTemplate(templateConfig, context);
-    const renderedHash = templateRenderedHash(renderedConfig);
+    const renderedHash = templateRuntimeHash(renderedConfig);
 
     // Debug logging to verify template rendering
     debugIf(() => ({

--- a/src/core/server/disabledTools.ts
+++ b/src/core/server/disabledTools.ts
@@ -7,7 +7,7 @@ function normalizeToolName(toolName: string): string {
   return toolName.trim();
 }
 
-function getRawToolName(logicalServerName: string, toolName: string): string {
+export function getLogicalToolName(logicalServerName: string, toolName: string): string {
   const normalizedToolName = normalizeToolName(toolName);
   const qualifiedPrefix = `${logicalServerName}${MCP_URI_SEPARATOR}`;
 
@@ -25,7 +25,7 @@ function getComparableToolNames(logicalServerName: string, toolName: string): st
   }
 
   const names = new Set<string>([normalizedToolName]);
-  const rawToolName = getRawToolName(logicalServerName, normalizedToolName);
+  const rawToolName = getLogicalToolName(logicalServerName, normalizedToolName);
   if (rawToolName) {
     names.add(rawToolName);
     names.add(`${logicalServerName}${MCP_URI_SEPARATOR}${rawToolName}`);
@@ -35,7 +35,7 @@ function getComparableToolNames(logicalServerName: string, toolName: string): st
 }
 
 export function getDisabledToolMessage(logicalServerName: string, toolName: string): string {
-  const displayToolName = getRawToolName(logicalServerName, toolName);
+  const displayToolName = getLogicalToolName(logicalServerName, toolName);
   return `Tool is disabled: ${logicalServerName}:${displayToolName}. Use '1mcp mcp tools enable ${logicalServerName} ${displayToolName}' to re-enable it.`;
 }
 
@@ -58,6 +58,12 @@ export function getDisabledTools(serverConfig?: Pick<MCPServerParams, 'disabledT
   }
 
   return disabledTools;
+}
+
+export function normalizeDisabledToolsForServer(logicalServerName: string, toolNames: readonly string[]): string[] {
+  return Array.from(
+    new Set(toolNames.map((toolName) => getLogicalToolName(logicalServerName, toolName)).filter(Boolean)),
+  ).sort((left, right) => left.localeCompare(right));
 }
 
 export function getDisabledToolsForServer(
@@ -125,7 +131,9 @@ export function withToolDisabledState(
   );
 
   if (disabled && normalizedToolName) {
-    disabledTools.add(logicalServerName ? getRawToolName(logicalServerName, normalizedToolName) : normalizedToolName);
+    disabledTools.add(
+      logicalServerName ? getLogicalToolName(logicalServerName, normalizedToolName) : normalizedToolName,
+    );
   }
 
   const nextDisabledTools = Array.from(disabledTools).sort((left, right) => left.localeCompare(right));

--- a/src/core/server/templateIdentity.test.ts
+++ b/src/core/server/templateIdentity.test.ts
@@ -15,6 +15,7 @@ import {
   serializePoolIdentity,
   serializeTemplateIdentity,
   templateRenderedHash,
+  templateRuntimeHash,
 } from './templateIdentity.js';
 
 const FIRST_INSTANCE_ID = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
@@ -77,6 +78,18 @@ describe('templateIdentity', () => {
     const second = templateRenderedHash({ command: 'node', args: ['server.js'], instructionOverride: 'second' });
 
     expect(first).toBe(second);
+  });
+
+  it('keeps configured-tool metadata out of runtime instance identity', () => {
+    const base = { command: 'node', args: ['server.js'] };
+    expect(
+      templateRuntimeHash({
+        ...base,
+        disabledTools: ['write'],
+        toolDescriptionOverrides: { read: 'Read safely' },
+      }),
+    ).toBe(templateRuntimeHash(base));
+    expect(templateRenderedHash({ ...base, disabledTools: ['write'] })).not.toBe(templateRenderedHash(base));
   });
 
   it('creates lookup candidates in session, rendered, static order', () => {

--- a/src/core/server/templateIdentity.ts
+++ b/src/core/server/templateIdentity.ts
@@ -107,6 +107,18 @@ export function templateRenderedHash(renderedConfig: unknown): string {
   return createHash(stableStringify(runtimeConfig));
 }
 
+export function templateRuntimeHash(renderedConfig: unknown): string {
+  if (!renderedConfig || typeof renderedConfig !== 'object' || Array.isArray(renderedConfig)) {
+    return templateRenderedHash(renderedConfig);
+  }
+  const {
+    disabledTools: _disabledTools,
+    toolDescriptionOverrides: _toolDescriptionOverrides,
+    ...runtimeConfig
+  } = renderedConfig as Record<string, unknown>;
+  return templateRenderedHash(runtimeConfig);
+}
+
 export function resolveTemplateIdentityMode(options?: {
   perClient?: boolean;
   shareable?: boolean;

--- a/src/core/server/templateServerManager.test.ts
+++ b/src/core/server/templateServerManager.test.ts
@@ -411,6 +411,38 @@ describe('TemplateServerManager', () => {
       );
     });
 
+    it('keeps active instances when only configured-tool metadata changes', async () => {
+      const manager = templateServerManager as any;
+      manager.clientInstancePool.getTemplateInstances.mockReturnValue([
+        {
+          id: 'instance-id',
+          instanceKey: 'test-template:rendered',
+          templateName: 'test-template',
+          client: {},
+          clientIds: new Set(['client-a']),
+        },
+      ]);
+
+      templateServerManager.rebuildTemplateIndex({
+        mcpTemplates: { 'test-template': { command: 'node', args: ['server.js'], template: {} } },
+      });
+      const result = templateServerManager.rebuildTemplateIndex({
+        mcpTemplates: {
+          'test-template': {
+            command: 'node',
+            args: ['server.js'],
+            template: {},
+            disabledTools: ['write'],
+            toolDescriptionOverrides: { read: 'Read safely' },
+          },
+        },
+      });
+
+      expect(result.toolMetadataChanged).toBe(true);
+      await Promise.resolve();
+      expect(manager.clientInstancePool.removeInstance).not.toHaveBeenCalled();
+    });
+
     it('queues another retirement pass when configuration changes again during retirement', async () => {
       const manager = templateServerManager as any;
       let finishFirstRetirement!: () => void;

--- a/src/core/server/templateServerManager.ts
+++ b/src/core/server/templateServerManager.ts
@@ -1,6 +1,7 @@
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
 import { registerCapabilityPaginationNotifications } from '@src/core/capabilities/capabilityPagination.js';
+import { clearLastConfiguredToolSnapshot } from '@src/core/capabilities/configuredToolSnapshot.js';
 import { ClientManager } from '@src/core/client/clientManager.js';
 import { ClientTemplateTracker, TemplateFilteringService, TemplateIndex } from '@src/core/filtering/index.js';
 import { InstructionAggregator } from '@src/core/instructions/instructionAggregator.js';
@@ -12,6 +13,7 @@ import {
   resolveTemplateIdentityMode,
   serializeTemplateIdentity,
   templateRenderedHash,
+  templateRuntimeHash,
 } from '@src/core/server/templateIdentity.js';
 import {
   cleanupExpiredEphemeralClients,
@@ -32,6 +34,10 @@ export interface TemplateRebuildOptions {
   mcpTemplates?: Record<string, MCPServerParams>;
 }
 
+export interface TemplateRebuildResult {
+  toolMetadataChanged: boolean;
+}
+
 export type TemplateClientLifecycle = 'persistent' | 'ephemeral';
 
 /**
@@ -47,6 +53,7 @@ export class TemplateServerManager {
   private outboundConns?: OutboundConnections;
   private transports?: Record<string, Transport>;
   private templateConfigHashes = new Map<string, string>();
+  private templateToolMetadataHashes = new Map<string, string>();
   private templateRetirements = new Map<string, Promise<void>>();
 
   // Maps sessionId -> (templateName -> renderedHash) for routing shareable servers
@@ -484,25 +491,40 @@ export class TemplateServerManager {
   /**
    * Rebuild the template index
    */
-  public rebuildTemplateIndex(serverConfigData?: TemplateRebuildOptions): void {
+  public rebuildTemplateIndex(serverConfigData?: TemplateRebuildOptions): TemplateRebuildResult {
     const templates = serverConfigData?.mcpTemplates ?? {};
     const currentNames = new Set(Object.keys(templates));
+    let toolMetadataChanged = false;
     for (const existingName of this.templateConfigHashes.keys()) {
       if (!currentNames.has(existingName)) {
         void this.scheduleTemplateRetirement(existingName);
         this.templateConfigHashes.delete(existingName);
+        this.templateToolMetadataHashes.delete(existingName);
+        clearLastConfiguredToolSnapshot(existingName);
+        toolMetadataChanged = true;
       }
     }
     for (const [templateName, config] of Object.entries(templates)) {
-      const nextHash = templateRenderedHash(config);
+      const nextHash = templateRuntimeHash(config);
       const previousHash = this.templateConfigHashes.get(templateName);
       if (previousHash && previousHash !== nextHash) {
         void this.scheduleTemplateRetirement(templateName);
       }
       this.templateConfigHashes.set(templateName, nextHash);
+      const nextToolMetadataHash = templateRenderedHash({
+        disabledTools: [...(config.disabledTools ?? [])].sort(),
+        toolDescriptionOverrides: Object.fromEntries(
+          Object.entries(config.toolDescriptionOverrides ?? {}).sort(([left], [right]) => left.localeCompare(right)),
+        ),
+      });
+      if (this.templateToolMetadataHashes.get(templateName) !== nextToolMetadataHash) {
+        toolMetadataChanged = true;
+      }
+      this.templateToolMetadataHashes.set(templateName, nextToolMetadataHash);
     }
     this.templateIndex.buildIndex(templates);
     logger.info('Template index rebuilt');
+    return { toolMetadataChanged };
   }
 
   private scheduleTemplateRetirement(templateName: string): Promise<void> {

--- a/src/core/server/toolDescriptionOverrides.test.ts
+++ b/src/core/server/toolDescriptionOverrides.test.ts
@@ -1,0 +1,54 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyEffectiveToolDescription,
+  getEffectiveToolDescription,
+  withToolDescriptionOverride,
+} from './toolDescriptionOverrides.js';
+
+describe('tool description overrides', () => {
+  const config = {
+    type: 'stdio' as const,
+    command: 'node',
+    toolDescriptionOverrides: {
+      read_file: 'Read a workspace file safely',
+    },
+  };
+
+  it('resolves override-first descriptions by logical or qualified tool name', () => {
+    expect(getEffectiveToolDescription(config, 'filesystem', 'read_file', 'Upstream description')).toBe(
+      'Read a workspace file safely',
+    );
+    expect(getEffectiveToolDescription(config, 'filesystem', 'filesystem_1mcp_read_file', 'Upstream description')).toBe(
+      'Read a workspace file safely',
+    );
+    expect(getEffectiveToolDescription(config, 'filesystem', 'write_file', 'Write upstream')).toBe('Write upstream');
+  });
+
+  it('changes only the tool description', () => {
+    const upstream: Tool = {
+      name: 'read_file',
+      description: 'Upstream description',
+      inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+      outputSchema: { type: 'object', properties: { content: { type: 'string' } } },
+      annotations: { readOnlyHint: true },
+    };
+
+    expect(applyEffectiveToolDescription(upstream, config, 'filesystem')).toEqual({
+      ...upstream,
+      description: 'Read a workspace file safely',
+    });
+  });
+
+  it('removes blank overrides and omits the empty record', () => {
+    expect(withToolDescriptionOverride(config, 'read_file', '   ').toolDescriptionOverrides).toBeUndefined();
+    expect(withToolDescriptionOverride(config, 'write_file', ' Write a file ')).toMatchObject({
+      toolDescriptionOverrides: {
+        read_file: 'Read a workspace file safely',
+        write_file: 'Write a file',
+      },
+    });
+  });
+});

--- a/src/core/server/toolDescriptionOverrides.ts
+++ b/src/core/server/toolDescriptionOverrides.ts
@@ -1,0 +1,66 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { MCP_URI_SEPARATOR } from '@src/constants.js';
+import type { MCPServerParams } from '@src/core/types/index.js';
+
+function logicalToolName(serverName: string, toolName: string): string {
+  const normalized = toolName.trim();
+  const prefix = `${serverName}${MCP_URI_SEPARATOR}`;
+  return normalized.startsWith(prefix) ? normalized.slice(prefix.length).trim() : normalized;
+}
+
+export function getToolDescriptionOverrides(
+  serverConfig?: Pick<MCPServerParams, 'toolDescriptionOverrides'>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(serverConfig?.toolDescriptionOverrides ?? {})
+      .map(([name, description]) => [name.trim(), description.trim()] as const)
+      .filter(([name, description]) => name.length > 0 && description.length > 0),
+  );
+}
+
+export function getEffectiveToolDescription(
+  serverConfig: Pick<MCPServerParams, 'toolDescriptionOverrides'> | undefined,
+  serverName: string,
+  toolName: string,
+  upstreamDescription?: string,
+): string | undefined {
+  const overrides = getToolDescriptionOverrides(serverConfig);
+  const logicalName = logicalToolName(serverName, toolName);
+  return overrides[logicalName] ?? overrides[toolName.trim()] ?? upstreamDescription;
+}
+
+export function applyEffectiveToolDescription<T extends Pick<Tool, 'name'> & { description?: string }>(
+  tool: T,
+  serverConfig: Pick<MCPServerParams, 'toolDescriptionOverrides'> | undefined,
+  serverName: string,
+): T {
+  const description = getEffectiveToolDescription(serverConfig, serverName, tool.name, tool.description);
+  if (description === tool.description) return tool;
+  if (description === undefined) {
+    const { description: _description, ...withoutDescription } = tool;
+    return withoutDescription as T;
+  }
+  return { ...tool, description };
+}
+
+export function withToolDescriptionOverride(
+  serverConfig: MCPServerParams,
+  toolName: string,
+  description: string | undefined,
+  serverName?: string,
+): MCPServerParams {
+  const overrides = getToolDescriptionOverrides(serverConfig);
+  const name = serverName ? logicalToolName(serverName, toolName) : toolName.trim();
+  const normalizedDescription = description?.trim() ?? '';
+
+  if (name) {
+    if (normalizedDescription) overrides[name] = normalizedDescription;
+    else delete overrides[name];
+  }
+
+  const nextConfig = { ...serverConfig };
+  if (Object.keys(overrides).length === 0) delete nextConfig.toolDescriptionOverrides;
+  else nextConfig.toolDescriptionOverrides = overrides;
+  return nextConfig;
+}

--- a/src/core/types/transport.test.ts
+++ b/src/core/types/transport.test.ts
@@ -98,3 +98,13 @@ describe('instruction management configuration', () => {
     },
   );
 });
+
+describe('transportConfigSchema tool description overrides', () => {
+  it('rejects logical tool names with surrounding whitespace', () => {
+    expect(() =>
+      transportConfigSchema.parse({
+        toolDescriptionOverrides: { ' search ': 'first', search: 'second' },
+      }),
+    ).toThrow();
+  });
+});

--- a/src/core/types/transport.ts
+++ b/src/core/types/transport.ts
@@ -245,7 +245,13 @@ export const transportConfigSchema = z.object({
     .optional()
     .describe('Literal replacement for upstream instructions; an empty string intentionally suppresses them'),
   toolDescriptionOverrides: z
-    .record(z.string().regex(/\S/u).trim().min(1), z.string().regex(/\S/u).trim().min(1))
+    .record(
+      z
+        .string()
+        .min(1)
+        .refine((name) => name === name.trim()),
+      z.string().regex(/\S/u).trim().min(1),
+    )
     .optional()
     .describe('Override upstream tool descriptions by logical tool name; blank descriptions are not supported'),
   timeout: z

--- a/src/core/types/transport.ts
+++ b/src/core/types/transport.ts
@@ -245,7 +245,7 @@ export const transportConfigSchema = z.object({
     .optional()
     .describe('Literal replacement for upstream instructions; an empty string intentionally suppresses them'),
   toolDescriptionOverrides: z
-    .record(z.string().trim().min(1), z.string().trim().min(1))
+    .record(z.string().regex(/\S/u).trim().min(1), z.string().regex(/\S/u).trim().min(1))
     .optional()
     .describe('Override upstream tool descriptions by logical tool name; blank descriptions are not supported'),
   timeout: z

--- a/src/core/types/transport.ts
+++ b/src/core/types/transport.ts
@@ -84,6 +84,8 @@ export interface BaseTransportConfig {
   readonly disabledTools?: string[];
   /** Literal replacement for upstream server instructions. Empty intentionally suppresses them. */
   readonly instructionOverride?: string;
+  /** Replace upstream tool descriptions by logical tool name */
+  readonly toolDescriptionOverrides?: Record<string, string>;
   readonly tags?: string[];
   readonly oauth?: OAuthConfig;
 }
@@ -242,6 +244,10 @@ export const transportConfigSchema = z.object({
     .string()
     .optional()
     .describe('Literal replacement for upstream instructions; an empty string intentionally suppresses them'),
+  toolDescriptionOverrides: z
+    .record(z.string().trim().min(1), z.string().trim().min(1))
+    .optional()
+    .describe('Override upstream tool descriptions by logical tool name; blank descriptions are not supported'),
   timeout: z
     .number()
     .optional()

--- a/src/domains/admin/adminConfiguredServerService.test.ts
+++ b/src/domains/admin/adminConfiguredServerService.test.ts
@@ -12,6 +12,7 @@ import {
   type ConfiguredServerConnectivityChecker,
 } from './adminConfiguredServerService.js';
 import { type AdminOperationContext, AdminOperationService } from './adminOperationService.js';
+import type { ConfiguredToolInventory } from './configuredToolInventory.js';
 
 const mockAgentConfig = {
   get: vi.fn().mockImplementation((key: string) => {
@@ -401,6 +402,390 @@ describe('AdminConfiguredServerService', () => {
     });
     expect(JSON.stringify(result)).not.toMatch(/raw-url-token|raw-header-token|raw-client-secret/);
     expect(JSON.stringify(result)).not.toMatch(/zod|rawSchema|storageShape/i);
+  });
+
+  it('loads a Template Server with one shared configured-tool inventory and no raw disabled-tools field', async () => {
+    const toolInventory: ConfiguredToolInventory = {
+      targetName: 'project',
+      source: 'mcpTemplates',
+      targetEnabled: true,
+      freshness: 'live',
+      model: 'gpt-4o',
+      generation: 'generation-1',
+      activeInstanceCount: 2,
+      rows: [
+        {
+          name: 'search',
+          upstreamDescription: 'Search upstream',
+          effectiveDescription: 'Search the project',
+          descriptionOverride: 'Search the project',
+          descriptionOverridden: true,
+          enabled: false,
+          observed: true,
+          unresolved: false,
+          observedInstanceCount: 2,
+          activeInstanceCount: 2,
+          observedInSomeInstances: false,
+          approximateTokens: 42,
+        },
+      ],
+      counts: { observed: 1, enabled: 0, disabled: 1, unresolved: 0 },
+      approximateTokens: { enabled: 0, allObserved: 42, savings: 42 },
+    };
+    const readToolInventory = vi.fn(async () => toolInventory);
+    const service = createService({
+      readConfigDocument: () => ({
+        mcpTemplates: {
+          project: {
+            type: 'stdio',
+            command: 'node',
+            disabledTools: ['search'],
+            toolDescriptionOverrides: { search: 'Search the project' },
+          },
+        },
+      }),
+      readToolInventory,
+    });
+
+    const result = await service.getConfiguredServerDetail({
+      context: context(),
+      targetName: 'project',
+      model: 'gpt-4o',
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        server: { id: 'project', source: 'mcpTemplates' },
+        editContract: { target: { id: 'project', source: 'mcpTemplates' } },
+        toolInventory,
+      },
+    });
+    if (!result.ok) return;
+    expect(
+      result.result.editContract.fieldGroups
+        .flatMap((group) => group.fields)
+        .some((field) => field.fieldPath.includes('disabledTools')),
+    ).toBe(false);
+    expect(readToolInventory).toHaveBeenCalledWith({
+      targetName: 'project',
+      source: 'mcpTemplates',
+      config: expect.objectContaining({ command: 'node' }),
+      model: 'gpt-4o',
+    });
+  });
+
+  it('previews and applies selection and description edits against one capability generation', async () => {
+    writeConfig({
+      mcpServers: {
+        filesystem: {
+          type: 'stdio',
+          command: 'node',
+          disabledTools: ['search'],
+        },
+      },
+    });
+    const readToolInventory = vi.fn(async ({ config }: { config: Record<string, any> }) => {
+      const enabled = !(config.disabledTools ?? []).includes('search');
+      const description = config.toolDescriptionOverrides?.search ?? 'Search upstream';
+      return {
+        targetName: 'filesystem',
+        source: 'mcpServers' as const,
+        targetEnabled: true,
+        freshness: 'live' as const,
+        model: 'gpt-4o',
+        generation: 'generation-1',
+        activeInstanceCount: 1,
+        rows: [
+          {
+            name: 'search',
+            upstreamDescription: 'Search upstream',
+            effectiveDescription: description,
+            ...(config.toolDescriptionOverrides?.search
+              ? { descriptionOverride: config.toolDescriptionOverrides.search }
+              : {}),
+            descriptionOverridden: Boolean(config.toolDescriptionOverrides?.search),
+            enabled,
+            observed: true,
+            unresolved: false,
+            observedInstanceCount: 1,
+            activeInstanceCount: 1,
+            observedInSomeInstances: false,
+            approximateTokens: enabled ? 25 : 25,
+          },
+        ],
+        counts: { observed: 1, enabled: enabled ? 1 : 0, disabled: enabled ? 0 : 1, unresolved: 0 },
+        approximateTokens: { enabled: enabled ? 25 : 0, allObserved: 25, savings: enabled ? 0 : 25 },
+      } satisfies ConfiguredToolInventory;
+    });
+    const service = createService({ readToolInventory });
+    const edit = {
+      disabledTools: [],
+      toolDescriptionOverrides: { search: 'Search the workspace' },
+    };
+
+    const preview = await service.previewConfiguredServerEdit({
+      context: context(),
+      targetName: 'filesystem',
+      edit,
+      model: 'gpt-4o',
+    });
+
+    expect(preview).toMatchObject({
+      ok: true,
+      result: {
+        diff: expect.arrayContaining([
+          expect.objectContaining({ fieldPath: ['disabledTools'] }),
+          expect.objectContaining({ fieldPath: ['toolDescriptionOverrides'] }),
+        ]),
+        toolSelection: {
+          capabilityGeneration: 'generation-1',
+          model: 'gpt-4o',
+          counts: { observed: 1, enabled: 1, disabled: 0, unresolved: 0 },
+          approximateTokens: { before: 0, after: 25, savings: -25 },
+        },
+      },
+    });
+    if (!preview.ok) return;
+
+    const applied = await service.applyConfiguredServerEdit({
+      context: context({
+        idempotencyKey: 'apply-tools',
+        requestFingerprint: 'apply-tools:fingerprint',
+        confirmationFacts: { previewConfirmed: preview.result.previewFingerprint },
+      }),
+      targetName: 'filesystem',
+      edit,
+      model: 'gpt-4o',
+      previewFingerprint: preview.result.previewFingerprint,
+    });
+
+    expect(applied.ok).toBe(true);
+    expect(readConfig().mcpServers.filesystem).toMatchObject({
+      toolDescriptionOverrides: { search: 'Search the workspace' },
+    });
+    expect(readConfig().mcpServers.filesystem.disabledTools).toBeUndefined();
+  });
+
+  it('rejects apply when the observed capability generation changes after preview', async () => {
+    writeConfig({
+      mcpServers: { filesystem: { type: 'stdio', command: 'node' } },
+    });
+    let inventoryReadCount = 0;
+    const readToolInventory = vi.fn(
+      async ({ config }: { config: Record<string, any> }): Promise<ConfiguredToolInventory> => {
+        inventoryReadCount += 1;
+        const enabled = !(config.disabledTools ?? []).includes('search');
+        return {
+          targetName: 'filesystem',
+          source: 'mcpServers',
+          targetEnabled: true,
+          freshness: 'live',
+          model: 'gpt-4o',
+          generation: inventoryReadCount <= 2 ? 'generation-1' : 'generation-2',
+          activeInstanceCount: 1,
+          rows: [
+            {
+              name: 'search',
+              upstreamDescription: 'Search upstream',
+              effectiveDescription: 'Search upstream',
+              descriptionOverridden: false,
+              enabled,
+              observed: true,
+              unresolved: false,
+              observedInstanceCount: 1,
+              activeInstanceCount: 1,
+              observedInSomeInstances: false,
+              approximateTokens: 25,
+            },
+          ],
+          counts: { observed: 1, enabled: enabled ? 1 : 0, disabled: enabled ? 0 : 1, unresolved: 0 },
+          approximateTokens: { enabled: enabled ? 25 : 0, allObserved: 25, savings: enabled ? 0 : 25 },
+        };
+      },
+    );
+    const service = createService({ readToolInventory });
+    const edit = { toolDescriptionOverrides: { search: 'Search the workspace' } };
+    const preview = await service.previewConfiguredServerEdit({
+      context: context(),
+      targetName: 'filesystem',
+      edit,
+    });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+
+    await expect(
+      service.applyConfiguredServerEdit({
+        context: context({ confirmationFacts: { previewConfirmed: preview.result.previewFingerprint } }),
+        targetName: 'filesystem',
+        edit,
+        previewFingerprint: preview.result.previewFingerprint,
+      }),
+    ).rejects.toMatchObject({ code: 'configured_server_stale_preview' });
+    expect(readConfig().mcpServers.filesystem.toolDescriptionOverrides).toBeUndefined();
+  });
+
+  it('requires explicit confirmation before disabling the final enabled tool', async () => {
+    writeConfig({
+      mcpServers: { filesystem: { type: 'stdio', command: 'node' } },
+    });
+    const readToolInventory = vi.fn(
+      async ({ config }: { config: Record<string, any> }): Promise<ConfiguredToolInventory> => {
+        const enabled = !(config.disabledTools ?? []).includes('search');
+        return {
+          targetName: 'filesystem',
+          source: 'mcpServers',
+          targetEnabled: true,
+          freshness: 'live',
+          model: 'gpt-4o',
+          generation: 'generation-1',
+          activeInstanceCount: 1,
+          rows: [
+            {
+              name: 'search',
+              effectiveDescription: 'Search upstream',
+              descriptionOverridden: false,
+              enabled,
+              observed: true,
+              unresolved: false,
+              observedInstanceCount: 1,
+              activeInstanceCount: 1,
+              observedInSomeInstances: false,
+              approximateTokens: 25,
+            },
+            {
+              name: 'retained_override',
+              effectiveDescription: 'Retained configuration',
+              descriptionOverridden: true,
+              descriptionOverride: 'Retained configuration',
+              enabled: true,
+              observed: false,
+              unresolved: true,
+              observedInstanceCount: 0,
+              activeInstanceCount: 1,
+              observedInSomeInstances: false,
+              approximateTokens: 0,
+            },
+          ],
+          counts: { observed: 1, enabled: enabled ? 2 : 1, disabled: enabled ? 0 : 1, unresolved: 1 },
+          approximateTokens: { enabled: enabled ? 25 : 0, allObserved: 25, savings: enabled ? 0 : 25 },
+        };
+      },
+    );
+    const service = createService({ readToolInventory });
+    const edit = { disabledTools: ['search'] };
+    const preview = await service.previewConfiguredServerEdit({
+      context: context(),
+      targetName: 'filesystem',
+      edit,
+    });
+    expect(preview).toMatchObject({
+      ok: true,
+      result: { toolSelection: { counts: { enabled: 1 }, requiresZeroEnabledConfirmation: true } },
+    });
+    if (!preview.ok) return;
+
+    const result = await service.applyConfiguredServerEdit({
+      context: context({ confirmationFacts: { previewConfirmed: preview.result.previewFingerprint } }),
+      targetName: 'filesystem',
+      edit,
+      previewFingerprint: preview.result.previewFingerprint,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'mutation_confirmation_required',
+      confirmationRequirements: expect.arrayContaining([{ code: 'zeroEnabledToolsConfirmed', expected: true }]),
+    });
+    expect(readConfig().mcpServers.filesystem.disabledTools).toBeUndefined();
+  });
+
+  it('rejects tool edits for names outside the observed or retained inventory', async () => {
+    writeConfig({
+      mcpServers: { filesystem: { type: 'stdio', command: 'node' } },
+    });
+    const readToolInventory = vi.fn(async (): Promise<ConfiguredToolInventory> => ({
+      targetName: 'filesystem',
+      source: 'mcpServers',
+      targetEnabled: true,
+      freshness: 'live',
+      model: 'gpt-4o',
+      generation: 'generation-1',
+      activeInstanceCount: 1,
+      rows: [],
+      counts: { observed: 0, enabled: 0, disabled: 0, unresolved: 0 },
+      approximateTokens: { enabled: 0, allObserved: 0, savings: 0 },
+    }));
+    const service = createService({ readToolInventory });
+
+    const preview = await service.previewConfiguredServerEdit({
+      context: context(),
+      targetName: 'filesystem',
+      edit: { disabledTools: ['invented'] },
+    });
+
+    expect(preview).toMatchObject({
+      ok: true,
+      result: {
+        validation: {
+          status: 'invalid',
+          errors: [expect.objectContaining({ fieldPath: ['tools', 'invented'], code: 'unknown_configured_tool' })],
+        },
+      },
+    });
+  });
+
+  it('applies configured-tool edits to a Template Server definition', async () => {
+    writeConfig({
+      mcpTemplates: { project: { type: 'stdio', command: 'node' } },
+    });
+    const readToolInventory = vi.fn(
+      async ({ config }: { config: Record<string, any> }): Promise<ConfiguredToolInventory> => ({
+        targetName: 'project',
+        source: 'mcpTemplates',
+        targetEnabled: true,
+        freshness: 'live',
+        model: 'gpt-4o',
+        generation: 'generation-1',
+        activeInstanceCount: 1,
+        rows: [
+          {
+            name: 'search',
+            effectiveDescription: config.toolDescriptionOverrides?.search ?? 'Search upstream',
+            descriptionOverridden: Boolean(config.toolDescriptionOverrides?.search),
+            enabled: !(config.disabledTools ?? []).includes('search'),
+            observed: true,
+            unresolved: false,
+            observedInstanceCount: 1,
+            activeInstanceCount: 1,
+            observedInSomeInstances: false,
+            approximateTokens: 25,
+          },
+        ],
+        counts: { observed: 1, enabled: 1, disabled: 0, unresolved: 0 },
+        approximateTokens: { enabled: 25, allObserved: 25, savings: 0 },
+      }),
+    );
+    const service = createService({ readToolInventory });
+    const edit = { toolDescriptionOverrides: { search: 'Search this project' } };
+    const preview = await service.previewConfiguredServerEdit({
+      context: context(),
+      targetName: 'project',
+      edit,
+    });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+
+    const result = await service.applyConfiguredServerEdit({
+      context: context({ confirmationFacts: { previewConfirmed: preview.result.previewFingerprint } }),
+      targetName: 'project',
+      edit,
+      previewFingerprint: preview.result.previewFingerprint,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readConfig().mcpTemplates.project.toolDescriptionOverrides).toEqual({ search: 'Search this project' });
+    expect(readConfig().mcpServers).toEqual({});
   });
 
   it('keeps nested secret record values out of editable transport record fields', async () => {
@@ -4572,6 +4957,12 @@ describe('AdminConfiguredServerService', () => {
         mcpServers?: Record<string, any>;
         mcpTemplates?: Record<string, any>;
       } | null;
+      readToolInventory?: (input: {
+        targetName: string;
+        source: 'mcpServers' | 'mcpTemplates';
+        config: Record<string, any>;
+        model?: string;
+      }) => Promise<ConfiguredToolInventory>;
       checkConnectivity?: ConfiguredServerConnectivityChecker;
       mutationAvailability?: { available: boolean; reason?: 'writer_lock_unavailable' };
     } = {},

--- a/src/domains/admin/adminConfiguredServerService.test.ts
+++ b/src/domains/admin/adminConfiguredServerService.test.ts
@@ -511,7 +511,7 @@ describe('AdminConfiguredServerService', () => {
             observedInstanceCount: 1,
             activeInstanceCount: 1,
             observedInSomeInstances: false,
-            approximateTokens: enabled ? 25 : 25,
+            approximateTokens: 25,
           },
         ],
         counts: { observed: 1, enabled: enabled ? 1 : 0, disabled: enabled ? 0 : 1, unresolved: 0 },
@@ -567,14 +567,69 @@ describe('AdminConfiguredServerService', () => {
     expect(readConfig().mcpServers.filesystem.disabledTools).toBeUndefined();
   });
 
+  it('removes a qualified denylist alias when applying the logical enabled selection', async () => {
+    writeConfig({
+      mcpServers: {
+        filesystem: {
+          type: 'stdio',
+          command: 'node',
+          disabledTools: ['filesystem_1mcp_write_file'],
+        },
+      },
+    });
+    const readToolInventory = vi.fn(async ({ config }: { config: Record<string, any> }) => {
+      const enabled = !config.disabledTools?.some(
+        (name: string) => name === 'write_file' || name === 'filesystem_1mcp_write_file',
+      );
+      return {
+        targetName: 'filesystem',
+        source: 'mcpServers' as const,
+        targetEnabled: true,
+        freshness: 'live' as const,
+        model: 'gpt-4o',
+        generation: 'qualified-generation',
+        activeInstanceCount: 1,
+        rows: [
+          {
+            name: 'write_file',
+            enabled,
+            observed: true,
+            unresolved: false,
+            descriptionOverridden: false,
+            observedInstanceCount: 1,
+            activeInstanceCount: 1,
+            observedInSomeInstances: false,
+            approximateTokens: 20,
+          },
+        ],
+        counts: { observed: 1, enabled: enabled ? 1 : 0, disabled: enabled ? 0 : 1, unresolved: 0 },
+        approximateTokens: { enabled: enabled ? 20 : 0, allObserved: 20, savings: enabled ? 0 : 20 },
+      } satisfies ConfiguredToolInventory;
+    });
+    const service = createService({ readToolInventory });
+    const edit = { disabledTools: [] };
+    const preview = await service.previewConfiguredServerEdit({ context: context(), targetName: 'filesystem', edit });
+    expect(preview.ok).toBe(true);
+    if (!preview.ok) return;
+
+    const applied = await service.applyConfiguredServerEdit({
+      context: context({ confirmationFacts: { previewConfirmed: preview.result.previewFingerprint } }),
+      targetName: 'filesystem',
+      edit,
+      previewFingerprint: preview.result.previewFingerprint,
+    });
+
+    expect(applied.ok).toBe(true);
+    expect(readConfig().mcpServers.filesystem.disabledTools).toBeUndefined();
+  });
+
   it('rejects apply when the observed capability generation changes after preview', async () => {
     writeConfig({
       mcpServers: { filesystem: { type: 'stdio', command: 'node' } },
     });
-    let inventoryReadCount = 0;
+    let generation = 'generation-1';
     const readToolInventory = vi.fn(
       async ({ config }: { config: Record<string, any> }): Promise<ConfiguredToolInventory> => {
-        inventoryReadCount += 1;
         const enabled = !(config.disabledTools ?? []).includes('search');
         return {
           targetName: 'filesystem',
@@ -582,7 +637,7 @@ describe('AdminConfiguredServerService', () => {
           targetEnabled: true,
           freshness: 'live',
           model: 'gpt-4o',
-          generation: inventoryReadCount <= 2 ? 'generation-1' : 'generation-2',
+          generation,
           activeInstanceCount: 1,
           rows: [
             {
@@ -613,6 +668,7 @@ describe('AdminConfiguredServerService', () => {
     });
     expect(preview.ok).toBe(true);
     if (!preview.ok) return;
+    generation = 'generation-2';
 
     await expect(
       service.applyConfiguredServerEdit({

--- a/src/domains/admin/adminConfiguredServerService.test.ts
+++ b/src/domains/admin/adminConfiguredServerService.test.ts
@@ -2157,6 +2157,36 @@ describe('AdminConfiguredServerService', () => {
     });
   });
 
+  it('rejects whitespace-variant tool override keys without normalizing collisions', async () => {
+    writeConfig({
+      mcpServers: {
+        github: { type: 'http', url: 'https://api.example.com/mcp' },
+      },
+    });
+    const service = createService();
+
+    const result = await service.previewConfiguredServerEdit({
+      context: context({ target: { type: 'configured_server', id: 'github' } }),
+      targetName: 'github',
+      edit: { toolDescriptionOverrides: { ' search ': 'first', search: 'second' } },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        validation: {
+          status: 'invalid',
+          errors: expect.arrayContaining([
+            expect.objectContaining({
+              fieldPath: ['toolDescriptionOverrides'],
+              code: 'invalid_tool_description_overrides',
+            }),
+          ]),
+        },
+      },
+    });
+  });
+
   it('rejects raw values submitted as environment-reference secret replacements without echoing them', async () => {
     writeConfig({
       mcpServers: {

--- a/src/domains/admin/adminConfiguredServerService.ts
+++ b/src/domains/admin/adminConfiguredServerService.ts
@@ -980,7 +980,8 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
   async getConfiguredServerDetail(
     input: ConfiguredServerDetailInput,
   ): Promise<AdminOperationResult<ConfiguredServerDetailResult>> {
-    const source = input.targetSource ?? 'mcpServers';
+    const configuredState = this.readConfiguredServerState(input.targetName, input.targetSource);
+    const source = configuredState.source;
     const context = {
       ...input.context,
       target: { type: 'configured_server', id: `${source}:${input.targetName}` },
@@ -989,7 +990,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
       context,
       operationName: 'getConfiguredServerDetail',
       run: async () => {
-        const { currentConfig, serverDefaults } = this.readConfiguredServerState(input.targetName, source);
+        const { currentConfig, serverDefaults } = configuredState;
         const server = createConfiguredServerReadModel(
           input.targetName,
           mergeGlobalAndServerConfig(serverDefaults, currentConfig),
@@ -1019,12 +1020,13 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
   async previewConfiguredServerEdit(
     input: ConfiguredServerPreviewInput,
   ): Promise<AdminOperationResult<ConfiguredServerPreviewResult>> {
-    const source = input.targetSource ?? 'mcpServers';
+    const configuredState = this.readConfiguredServerState(input.targetName, input.targetSource);
+    const source = configuredState.source;
     const context = {
       ...input.context,
       target: { type: 'configured_server', id: `${source}:${input.targetName}` },
     };
-    const { currentConfig, serverDefaults } = this.readConfiguredServerState(input.targetName, source);
+    const { currentConfig, serverDefaults } = configuredState;
     return this.options.operationService.executeDryRun({
       context,
       operationName: 'previewConfiguredServerEdit',
@@ -1035,7 +1037,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
   async applyConfiguredServerEdit(
     input: ConfiguredServerApplyInput,
   ): Promise<AdminOperationResult<ConfiguredServerApplyResult>> {
-    const source = input.targetSource ?? 'mcpServers';
+    const source = this.resolveConfiguredServerSource(input.targetName, input.targetSource);
     const context = {
       ...input.context,
       target: { type: 'configured_server', id: `${source}:${input.targetName}` },
@@ -1232,18 +1234,28 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
 
   private readConfiguredServerState(
     targetName: string,
-    targetSource: ConfiguredServerTargetSource = 'mcpServers',
+    targetSource?: ConfiguredServerTargetSource,
   ): {
     currentConfig: MCPServerParams;
     serverDefaults: GlobalTransportConfig | undefined;
     source: ConfiguredToolTargetSource;
   } {
     const parsed = this.options.readConfigDocument();
-    const currentConfig = parsed?.[targetSource]?.[targetName];
+    const source = this.resolveConfiguredServerSource(targetName, targetSource, parsed);
+    const currentConfig = parsed?.[source]?.[targetName];
     if (!currentConfig) {
       throw new AdminConfiguredServerNotFoundError(targetName);
     }
-    return { currentConfig, serverDefaults: parsed?.serverDefaults, source: targetSource };
+    return { currentConfig, serverDefaults: parsed?.serverDefaults, source };
+  }
+
+  private resolveConfiguredServerSource(
+    targetName: string,
+    targetSource?: ConfiguredServerTargetSource,
+    document: ConfiguredServerConfigDocument | null = this.options.readConfigDocument(),
+  ): ConfiguredServerTargetSource {
+    if (targetSource) return targetSource;
+    return document?.mcpTemplates?.[targetName] ? 'mcpTemplates' : 'mcpServers';
   }
 
   private readConfiguredServerConfig(targetName: string): MCPServerParams {
@@ -1263,11 +1275,11 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
     source: ConfiguredToolTargetSource = 'mcpServers',
   ): Promise<ConfiguredServerPreviewResult> {
     const normalizedEdit = normalizeEditDraft(input.edit);
-    const sourceValidation = validateEditForSource(input.targetSource ?? 'mcpServers', normalizedEdit.edit);
+    const sourceValidation = validateEditForSource(source, normalizedEdit.edit);
     const currentReadModel = createConfiguredServerReadModel(
       input.targetName,
       mergeGlobalAndServerConfig(serverDefaults, currentConfig),
-      input.targetSource ?? 'mcpServers',
+      source,
     );
     const secretValidation = validateSecretEditCapabilities(normalizedEdit.edit, currentReadModel.secretInputs);
     const transportApplicabilityValidation = validateTransportFieldApplicability(currentConfig, normalizedEdit.edit);
@@ -1278,7 +1290,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
     const proposedReadModel = createConfiguredServerReadModel(
       proposedTargetName,
       mergeGlobalAndServerConfig(serverDefaults, proposedConfig),
-      input.targetSource ?? 'mcpServers',
+      source,
     );
     const proposedTransportType = configuredTransportType(proposedConfig);
     const serverValidation = validatePreviewServerConfig(proposedConfig);
@@ -1338,7 +1350,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
       proposedTargetName,
       previewFingerprint: previewFingerprint({
         targetName: input.targetName,
-        targetSource: input.targetSource ?? 'mcpServers',
+        targetSource: source,
         sourceFingerprint: fingerprintConfiguredServerTarget(currentConfig),
         globalConfigFingerprint: fingerprintConfiguredServerDefaults(serverDefaults),
         edit: normalizedEdit.edit,
@@ -1350,7 +1362,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
       }),
       validation,
       diff,
-      configChange: previewConfigChange(input.targetName, changed, input.targetSource ?? 'mcpServers'),
+      configChange: previewConfigChange(input.targetName, changed, source),
       connectivityCheck: await this.previewConnectivityCheck({
         targetName: proposedTargetName,
         serverConfig: proposedConfig,
@@ -1488,13 +1500,14 @@ function validateEditForSource(
   edit: ConfiguredServerEditDraft,
 ): ConfiguredServerPreviewValidation {
   if (source !== 'mcpTemplates') return { status: 'valid', errors: [] };
-  const unsupported = Object.keys(edit).filter((key) => key !== 'instructionOverride');
+  const supportedTemplateMetadata = new Set(['instructionOverride', 'disabledTools', 'toolDescriptionOverrides']);
+  const unsupported = Object.keys(edit).filter((key) => !supportedTemplateMetadata.has(key));
   return {
     status: unsupported.length === 0 ? 'valid' : 'invalid',
     errors: unsupported.map((key) => ({
       fieldPath: [key],
       code: 'template_edit_field_unsupported',
-      message: 'Template Server edits may only change the instruction override.',
+      message: 'Template Server edits may only change instruction and tool metadata.',
     })),
   };
 }

--- a/src/domains/admin/adminConfiguredServerService.ts
+++ b/src/domains/admin/adminConfiguredServerService.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import { mergeGlobalAndServerConfig } from '@src/config/mcpConfigMerge.js';
+import { normalizeDisabledToolsForServer } from '@src/core/server/disabledTools.js';
 import {
   GLOBAL_TRANSPORT_CONFIG_KEYS,
   type GlobalTransportConfig,
@@ -1060,7 +1061,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
           source,
         );
         const applicableEdit = filterApplicableSecretEdits(normalizedEdit.edit, currentReadModel.secretInputs);
-        const proposedConfig = applyEditDraft(currentConfig, applicableEdit, serverDefaults);
+        const proposedConfig = applyEditDraft(currentConfig, applicableEdit, serverDefaults, input.targetName);
         const proposedReadModel = createConfiguredServerReadModel(
           preview.proposedTargetName,
           mergeGlobalAndServerConfig(serverDefaults, proposedConfig),
@@ -1273,7 +1274,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
     const overrideValidation = validateTransportOverrideClears(currentConfig, normalizedEdit.edit);
     const applicableEdit = filterApplicableSecretEdits(normalizedEdit.edit, currentReadModel.secretInputs);
     const proposedTargetName = applicableEdit.id?.trim() || input.targetName;
-    const proposedConfig = applyEditDraft(currentConfig, applicableEdit, serverDefaults);
+    const proposedConfig = applyEditDraft(currentConfig, applicableEdit, serverDefaults, input.targetName);
     const proposedReadModel = createConfiguredServerReadModel(
       proposedTargetName,
       mergeGlobalAndServerConfig(serverDefaults, proposedConfig),
@@ -2169,6 +2170,7 @@ function applyEditDraft(
   currentConfig: MCPServerParams,
   edit: ConfiguredServerEditDraft,
   serverDefaults?: GlobalTransportConfig,
+  logicalServerName?: string,
 ): MCPServerParams {
   const nextConfig = cloneServerConfig(currentConfig);
 
@@ -2195,8 +2197,11 @@ function applyEditDraft(
   }
 
   if (Array.isArray(edit.disabledTools)) {
-    if (edit.disabledTools.length === 0) delete nextConfig.disabledTools;
-    else nextConfig.disabledTools = [...edit.disabledTools];
+    const disabledTools = logicalServerName
+      ? normalizeDisabledToolsForServer(logicalServerName, edit.disabledTools)
+      : edit.disabledTools;
+    if (disabledTools.length === 0) delete nextConfig.disabledTools;
+    else nextConfig.disabledTools = disabledTools;
   }
 
   if (edit.toolDescriptionOverrides) {
@@ -2741,7 +2746,9 @@ function createConfiguredToolSelectionPreview(
     targetEnabled: proposed.targetEnabled,
     effect: proposed.targetEnabled ? 'immediate' : 'deferred_until_target_enabled',
     requiresZeroEnabledConfirmation:
-      proposed.rows.length > 0 && proposed.rows.every((row) => !row.observed || !row.enabled),
+      changedTools.length > 0 &&
+      current.rows.some((row) => row.observed && row.enabled) &&
+      !proposed.rows.some((row) => row.observed && row.enabled),
   };
 }
 

--- a/src/domains/admin/adminConfiguredServerService.ts
+++ b/src/domains/admin/adminConfiguredServerService.ts
@@ -1660,11 +1660,13 @@ function normalizeEditDraft(value: unknown): {
       record.toolDescriptionOverrides &&
       typeof record.toolDescriptionOverrides === 'object' &&
       !Array.isArray(record.toolDescriptionOverrides) &&
-      Object.values(record.toolDescriptionOverrides).every((description) => typeof description === 'string')
+      Object.entries(record.toolDescriptionOverrides).every(
+        ([name, description]) => name.length > 0 && name === name.trim() && typeof description === 'string',
+      )
     ) {
       edit.toolDescriptionOverrides = Object.fromEntries(
         Object.entries(record.toolDescriptionOverrides as Record<string, string>)
-          .map(([name, description]) => [name.trim(), description.trim()] as const)
+          .map(([name, description]) => [name, description.trim()] as const)
           .filter(([name, description]) => name.length > 0 && description.length > 0)
           .sort(([left], [right]) => left.localeCompare(right)),
       );

--- a/src/domains/admin/adminConfiguredServerService.ts
+++ b/src/domains/admin/adminConfiguredServerService.ts
@@ -33,6 +33,7 @@ import type {
   AdminOperationResult,
   AdminOperationService,
 } from './adminOperationService.js';
+import type { ConfiguredToolInventory, ConfiguredToolTargetSource } from './configuredToolInventory.js';
 
 type ConfiguredServerSecretAction = 'preserve' | 'replace' | 'clear';
 type ConfiguredServerSecretReplacementKind = 'environmentReference' | 'inlineSecret';
@@ -51,6 +52,12 @@ interface AdminConfiguredServerServiceOptions {
   configChangeService: ConfigChangeService;
   readConfigDocument: () => ConfiguredServerConfigDocument | null;
   checkConnectivity?: ConfiguredServerConnectivityChecker;
+  readToolInventory?: (input: {
+    targetName: string;
+    source: ConfiguredToolTargetSource;
+    config: MCPServerParams;
+    model?: string;
+  }) => Promise<ConfiguredToolInventory>;
 }
 
 interface PreparedConfiguredServerCreate {
@@ -492,6 +499,7 @@ interface ConfiguredServerDetailInput {
   context: AdminOperationContext;
   targetName: string;
   targetSource?: ConfiguredServerTargetSource;
+  model?: string;
 }
 
 interface ConfiguredServerPreviewInput {
@@ -500,6 +508,7 @@ interface ConfiguredServerPreviewInput {
   targetSource?: ConfiguredServerTargetSource;
   edit: unknown;
   connectivityCheck?: 'auto' | 'manual';
+  model?: string;
 }
 
 interface ConfiguredServerApplyInput {
@@ -508,6 +517,7 @@ interface ConfiguredServerApplyInput {
   targetSource?: ConfiguredServerTargetSource;
   edit: unknown;
   previewFingerprint: string;
+  model?: string;
 }
 
 interface ConfiguredServerCreateContractInput {
@@ -545,6 +555,8 @@ export interface ConfiguredServerEditDraft {
   secrets?: ConfiguredServerSecretEditDraft[];
   clearTransportOverrides?: string[];
   instructionOverride?: InstructionOverrideMutation;
+  disabledTools?: string[];
+  toolDescriptionOverrides?: Record<string, string>;
 }
 
 export interface ConfiguredServerSecretInput {
@@ -618,7 +630,7 @@ export interface ConfiguredServerPreviewDiffEntry {
   oldValue: unknown;
   newValue: unknown;
   secretAction?: ConfiguredServerSecretAction;
-  riskFlags: Array<'rename' | 'connection_critical' | 'secret' | 'template_risk'>;
+  riskFlags: Array<'rename' | 'connection_critical' | 'secret' | 'template_risk' | 'tool_visibility' | 'tool_metadata'>;
 }
 
 export interface ConfiguredServerPreviewValidationError {
@@ -673,6 +685,18 @@ export interface ConfiguredServerPreviewResult {
   diff: ConfiguredServerPreviewDiffEntry[];
   configChange: ConfigChangeResult;
   connectivityCheck: ConfiguredServerConnectivityCheckResult;
+  toolSelection?: ConfiguredToolSelectionPreview;
+}
+
+export interface ConfiguredToolSelectionPreview {
+  capabilityGeneration: string;
+  model: string;
+  changedTools: string[];
+  counts: ConfiguredToolInventory['counts'];
+  approximateTokens: { before: number; after: number; savings: number };
+  targetEnabled: boolean;
+  effect: 'immediate' | 'deferred_until_target_enabled';
+  requiresZeroEnabledConfirmation: boolean;
 }
 
 export interface ConfiguredServerApplyResult {
@@ -790,6 +814,7 @@ export interface ConfiguredServerEditContract {
 export interface ConfiguredServerDetailResult {
   server: ConfiguredServerReadModel;
   editContract: ConfiguredServerEditContract;
+  toolInventory?: ConfiguredToolInventory;
 }
 
 export interface ConfiguredServerConfigDocument {
@@ -975,6 +1000,16 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
         return {
           server,
           editContract: createConfiguredServerEditContract(server, currentConfig, serverDefaults),
+          ...(this.options.readToolInventory
+            ? {
+                toolInventory: await this.options.readToolInventory({
+                  targetName: input.targetName,
+                  source,
+                  config: currentConfig,
+                  ...(input.model ? { model: input.model } : {}),
+                }),
+              }
+            : {}),
         };
       },
     });
@@ -992,7 +1027,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
     return this.options.operationService.executeDryRun({
       context,
       operationName: 'previewConfiguredServerEdit',
-      run: async () => this.previewConfiguredServerEditResult(input, currentConfig, serverDefaults),
+      run: async () => this.previewConfiguredServerEditResult(input, currentConfig, serverDefaults, false, source),
     });
   }
 
@@ -1016,6 +1051,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
           currentConfig,
           serverDefaults,
           true,
+          source,
         );
         const normalizedEdit = normalizeEditDraft(input.edit);
         const currentReadModel = createConfiguredServerReadModel(
@@ -1063,6 +1099,9 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
               : []),
             ...(secretChange ? [{ code: 'secretChangeConfirmed', expected: true }] : []),
             ...(connectionCritical ? [{ code: 'connectionCriticalConfirmed', expected: true }] : []),
+            ...(preview.toolSelection?.requiresZeroEnabledConfirmation
+              ? [{ code: 'zeroEnabledToolsConfirmed', expected: true }]
+              : []),
             ...(preview.connectivityCheck.status === 'failed'
               ? [{ code: 'connectivityFailureOverrideConfirmed', expected: true }]
               : []),
@@ -1196,18 +1235,19 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
   ): {
     currentConfig: MCPServerParams;
     serverDefaults: GlobalTransportConfig | undefined;
+    source: ConfiguredToolTargetSource;
   } {
     const parsed = this.options.readConfigDocument();
     const currentConfig = parsed?.[targetSource]?.[targetName];
     if (!currentConfig) {
       throw new AdminConfiguredServerNotFoundError(targetName);
     }
-    return { currentConfig, serverDefaults: parsed?.serverDefaults };
+    return { currentConfig, serverDefaults: parsed?.serverDefaults, source: targetSource };
   }
 
   private readConfiguredServerConfig(targetName: string): MCPServerParams {
     const parsed = this.options.readConfigDocument();
-    const currentConfig = parsed?.mcpServers?.[targetName];
+    const currentConfig = parsed?.mcpTemplates?.[targetName] ?? parsed?.mcpServers?.[targetName];
     if (!currentConfig) {
       throw new AdminConfiguredServerNotFoundError(targetName);
     }
@@ -1219,6 +1259,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
     currentConfig: MCPServerParams,
     serverDefaults: GlobalTransportConfig | undefined,
     requireCriticalConnectivity = false,
+    source: ConfiguredToolTargetSource = 'mcpServers',
   ): Promise<ConfiguredServerPreviewResult> {
     const normalizedEdit = normalizeEditDraft(input.edit);
     const sourceValidation = validateEditForSource(input.targetSource ?? 'mcpServers', normalizedEdit.edit);
@@ -1240,14 +1281,33 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
     );
     const proposedTransportType = configuredTransportType(proposedConfig);
     const serverValidation = validatePreviewServerConfig(proposedConfig);
+    const currentToolInventory = this.options.readToolInventory
+      ? await this.options.readToolInventory({
+          targetName: input.targetName,
+          source,
+          config: currentConfig,
+          ...(input.model ? { model: input.model } : {}),
+        })
+      : undefined;
+    const toolEditValidation = validateConfiguredToolEdit(applicableEdit, currentToolInventory);
     const validation = mergeValidation(
       mergeValidation(
         mergeValidation(mergeValidation(normalizedEdit.validation, secretValidation), transportApplicabilityValidation),
         overrideValidation,
       ),
-      mergeValidation(serverValidation, sourceValidation),
+      mergeValidation(mergeValidation(serverValidation, sourceValidation), toolEditValidation),
     );
     const diff = createPreviewDiff(currentReadModel, proposedReadModel, applicableEdit);
+    pushDiff(diff, ['disabledTools'], currentConfig.disabledTools ?? [], proposedConfig.disabledTools ?? [], [
+      'tool_visibility',
+    ]);
+    pushDiff(
+      diff,
+      ['toolDescriptionOverrides'],
+      currentConfig.toolDescriptionOverrides ?? {},
+      proposedConfig.toolDescriptionOverrides ?? {},
+      ['tool_metadata'],
+    );
     appendClearedOverrideDiff(diff, currentReadModel, proposedReadModel, applicableEdit);
     const changed = validation.status === 'valid' && diff.length > 0;
     const endpointChangedWithPreservedSecrets =
@@ -1258,6 +1318,19 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
         ),
         applicableEdit,
       );
+
+    const proposedToolInventory = this.options.readToolInventory
+      ? await this.options.readToolInventory({
+          targetName: proposedTargetName,
+          source,
+          config: proposedConfig,
+          ...(input.model ? { model: input.model } : {}),
+        })
+      : undefined;
+    const toolSelection =
+      currentToolInventory && proposedToolInventory
+        ? createConfiguredToolSelectionPreview(currentToolInventory, proposedToolInventory)
+        : undefined;
 
     return {
       targetName: input.targetName,
@@ -1272,6 +1345,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
         proposed: proposedReadModel,
         diff,
         validation,
+        toolSelection,
       }),
       validation,
       diff,
@@ -1287,6 +1361,7 @@ export class AdminConfiguredServerService implements AdminConfiguredServerOperat
           (requireCriticalConnectivity && diff.some((entry) => entry.riskFlags.includes('connection_critical'))),
         endpointChangedWithPreservedSecrets,
       }),
+      ...(toolSelection ? { toolSelection } : {}),
     };
   }
 
@@ -1472,6 +1547,7 @@ function sanitizeApplyConfirmationFacts(
   if (!facts) return undefined;
   const allowed = ['previewConfirmed', 'targetNameConfirmed', 'secretChangeConfirmed', 'connectionCriticalConfirmed'];
   allowed.push('connectivityFailureOverrideConfirmed');
+  allowed.push('zeroEnabledToolsConfirmed');
   const sanitized = Object.fromEntries(allowed.filter((key) => key in facts).map((key) => [key, facts[key]]));
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;
 }
@@ -1497,6 +1573,8 @@ function normalizeEditDraft(value: unknown): {
     'secrets',
     'clearTransportOverrides',
     'instructionOverride',
+    'disabledTools',
+    'toolDescriptionOverrides',
   ]);
 
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -1558,6 +1636,42 @@ function normalizeEditDraft(value: unknown): {
         fieldPath: ['tags'],
         code: 'invalid_tags',
         message: 'Tags must be a list of strings.',
+      });
+    }
+  }
+
+  if (record.disabledTools !== undefined) {
+    if (Array.isArray(record.disabledTools) && record.disabledTools.every((name) => typeof name === 'string')) {
+      edit.disabledTools = Array.from(
+        new Set(record.disabledTools.map((name) => name.trim()).filter((name) => name.length > 0)),
+      ).sort((left, right) => left.localeCompare(right));
+    } else {
+      errors.push({
+        fieldPath: ['disabledTools'],
+        code: 'invalid_disabled_tools',
+        message: 'Disabled tools must be a list of logical tool names.',
+      });
+    }
+  }
+
+  if (record.toolDescriptionOverrides !== undefined) {
+    if (
+      record.toolDescriptionOverrides &&
+      typeof record.toolDescriptionOverrides === 'object' &&
+      !Array.isArray(record.toolDescriptionOverrides) &&
+      Object.values(record.toolDescriptionOverrides).every((description) => typeof description === 'string')
+    ) {
+      edit.toolDescriptionOverrides = Object.fromEntries(
+        Object.entries(record.toolDescriptionOverrides as Record<string, string>)
+          .map(([name, description]) => [name.trim(), description.trim()] as const)
+          .filter(([name, description]) => name.length > 0 && description.length > 0)
+          .sort(([left], [right]) => left.localeCompare(right)),
+      );
+    } else {
+      errors.push({
+        fieldPath: ['toolDescriptionOverrides'],
+        code: 'invalid_tool_description_overrides',
+        message: 'Tool description overrides must map logical tool names to descriptions.',
       });
     }
   }
@@ -1654,6 +1768,23 @@ function normalizeTransportEditDraft(
   }
 
   return transport;
+}
+
+function validateConfiguredToolEdit(
+  edit: ConfiguredServerEditDraft,
+  inventory: ConfiguredToolInventory | undefined,
+): ConfiguredServerPreviewValidation {
+  if (!inventory) return { status: 'valid', errors: [] };
+  const allowedNames = new Set(inventory.rows.map((row) => row.name));
+  const requestedNames = new Set([...(edit.disabledTools ?? []), ...Object.keys(edit.toolDescriptionOverrides ?? {})]);
+  const errors = Array.from(requestedNames)
+    .filter((name) => !allowedNames.has(name))
+    .map((name) => ({
+      fieldPath: ['tools', name],
+      code: 'unknown_configured_tool',
+      message: 'Tool changes must refer to an observed tool or a retained unresolved entry.',
+    }));
+  return { status: errors.length === 0 ? 'valid' : 'invalid', errors };
 }
 
 function isSecretCapableRawTransportEdit(key: string, value: unknown): boolean {
@@ -2061,6 +2192,16 @@ function applyEditDraft(
     nextConfig.instructionOverride = edit.instructionOverride.value;
   } else if (edit.instructionOverride?.action === 'remove') {
     delete nextConfig.instructionOverride;
+  }
+
+  if (Array.isArray(edit.disabledTools)) {
+    if (edit.disabledTools.length === 0) delete nextConfig.disabledTools;
+    else nextConfig.disabledTools = [...edit.disabledTools];
+  }
+
+  if (edit.toolDescriptionOverrides) {
+    if (Object.keys(edit.toolDescriptionOverrides).length === 0) delete nextConfig.toolDescriptionOverrides;
+    else nextConfig.toolDescriptionOverrides = { ...edit.toolDescriptionOverrides };
   }
 
   if (edit.transport && typeof edit.transport === 'object') {
@@ -2548,6 +2689,7 @@ function previewFingerprint(input: {
   proposed: ConfiguredServerReadModel;
   diff: ConfiguredServerPreviewDiffEntry[];
   validation: ConfiguredServerPreviewValidation;
+  toolSelection?: ConfiguredToolSelectionPreview;
 }): string {
   return `preview_${createHash('sha256')
     .update(
@@ -2562,9 +2704,45 @@ function previewFingerprint(input: {
         proposed: input.proposed,
         diff: input.diff,
         validation: input.validation,
+        toolSelection: input.toolSelection,
       }),
     )
     .digest('hex')}`;
+}
+
+function createConfiguredToolSelectionPreview(
+  current: ConfiguredToolInventory,
+  proposed: ConfiguredToolInventory,
+): ConfiguredToolSelectionPreview {
+  const currentRows = new Map(current.rows.map((row) => [row.name, row]));
+  const proposedRows = new Map(proposed.rows.map((row) => [row.name, row]));
+  const changedTools = Array.from(new Set([...currentRows.keys(), ...proposedRows.keys()]))
+    .filter((name) => {
+      const before = currentRows.get(name);
+      const after = proposedRows.get(name);
+      return (
+        before?.enabled !== after?.enabled ||
+        before?.descriptionOverride !== after?.descriptionOverride ||
+        before?.effectiveDescription !== after?.effectiveDescription
+      );
+    })
+    .sort((left, right) => left.localeCompare(right));
+
+  return {
+    capabilityGeneration: current.generation,
+    model: proposed.model,
+    changedTools,
+    counts: proposed.counts,
+    approximateTokens: {
+      before: current.approximateTokens.enabled,
+      after: proposed.approximateTokens.enabled,
+      savings: current.approximateTokens.enabled - proposed.approximateTokens.enabled,
+    },
+    targetEnabled: proposed.targetEnabled,
+    effect: proposed.targetEnabled ? 'immediate' : 'deferred_until_target_enabled',
+    requiresZeroEnabledConfirmation:
+      proposed.rows.length > 0 && proposed.rows.every((row) => !row.observed || !row.enabled),
+  };
 }
 
 function redactEditDraftForFingerprint(edit: ConfiguredServerEditDraft): ConfiguredServerEditDraft {
@@ -2788,7 +2966,13 @@ function createConfiguredServerReadModel(
   const transport: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(serverConfig)) {
-    if (key === 'disabled' || key === 'tags' || key === 'instructionOverride') {
+    if (
+      key === 'disabled' ||
+      key === 'tags' ||
+      key === 'instructionOverride' ||
+      key === 'disabledTools' ||
+      key === 'toolDescriptionOverrides'
+    ) {
       continue;
     }
 
@@ -2877,7 +3061,6 @@ const TRANSPORT_FIELD_DEFINITIONS: TransportFieldDefinition[] = [
   { key: 'timeout', label: 'Deprecated Timeout', control: 'number' },
   { key: 'connectionTimeout', label: 'Connection Timeout', control: 'number' },
   { key: 'requestTimeout', label: 'Request Timeout', control: 'number' },
-  { key: 'disabledTools', label: 'Disabled Tools', control: 'string-list', defaultValue: [] },
   { key: 'template', label: 'Template', control: 'record', defaultValue: {} },
   {
     key: 'url',

--- a/src/domains/admin/adminDomain.ts
+++ b/src/domains/admin/adminDomain.ts
@@ -26,6 +26,7 @@ import {
 import { type AdminOAuthOperations, AdminOAuthService } from './adminOAuthService.js';
 import { AdminOperationService } from './adminOperationService.js';
 import { type AdminPresetOperations, AdminPresetService } from './adminPresetService.js';
+import type { ConfiguredToolInventory, ConfiguredToolTargetSource } from './configuredToolInventory.js';
 import type { AdminMutationAvailability } from './runtimeScopeAdminLock.js';
 
 export interface AdminDomainOptions {
@@ -36,6 +37,12 @@ export interface AdminDomainOptions {
   getConfigPath?: () => string;
   readConfigDocument: () => ConfiguredServerConfigDocument | null;
   checkConnectivity?: ConfiguredServerConnectivityChecker;
+  readToolInventory?: (input: {
+    targetName: string;
+    source: ConfiguredToolTargetSource;
+    config: MCPServerParams;
+    model?: string;
+  }) => Promise<ConfiguredToolInventory>;
   mutationAvailability?: AdminMutationAvailability;
   now?: () => Date;
   createOperationId?: () => string;
@@ -77,6 +84,7 @@ export function createAdminDomain(options: AdminDomainOptions): AdminDomain {
     configChangeService: options.configChangeService,
     readConfigDocument: options.readConfigDocument,
     ...(options.checkConnectivity ? { checkConnectivity: options.checkConnectivity } : {}),
+    ...(options.readToolInventory ? { readToolInventory: options.readToolInventory } : {}),
   });
   const instructionTemplateService =
     options.getConfigPath && options.previewInstructions

--- a/src/domains/admin/configuredToolInventory.test.ts
+++ b/src/domains/admin/configuredToolInventory.test.ts
@@ -96,6 +96,28 @@ describe('Configured Tool Inventory', () => {
     expect(disabledInventory.counts.observed).toBe(0);
   });
 
+  it('coalesces qualified disabled names into their observed logical row', async () => {
+    const connections: OutboundConnections = new Map([
+      [
+        'filesystem',
+        connection('filesystem', [{ name: 'write_file', description: 'Write', inputSchema: { type: 'object' } }]),
+      ],
+    ]);
+
+    const inventory = await createConfiguredToolInventory({
+      targetName: 'filesystem',
+      source: 'mcpServers',
+      config: {
+        type: 'stdio',
+        command: 'node',
+        disabledTools: ['filesystem_1mcp_write_file'],
+      },
+      connections,
+    });
+
+    expect(inventory.rows).toMatchObject([{ name: 'write_file', enabled: false, observed: true, unresolved: false }]);
+  });
+
   it('unions Template Server tools and reports partial occurrence', async () => {
     const connections: OutboundConnections = new Map([
       [
@@ -138,12 +160,12 @@ describe('Configured Tool Inventory', () => {
   });
 
   it('changes generation for schema changes and snapshot availability', async () => {
-    const outbound = connection('filesystem', [
+    const outbound = connection('generation-target', [
       { name: 'read', description: 'Read', inputSchema: { type: 'object', properties: { path: { type: 'string' } } } },
     ]);
-    const connections: OutboundConnections = new Map([['filesystem', outbound]]);
+    const connections: OutboundConnections = new Map([['generation-target', outbound]]);
     const first = await createConfiguredToolInventory({
-      targetName: 'filesystem',
+      targetName: 'generation-target',
       source: 'mcpServers',
       config: { type: 'stdio', command: 'node' },
       connections,
@@ -152,14 +174,14 @@ describe('Configured Tool Inventory', () => {
       { name: 'read', description: 'Read', inputSchema: { type: 'object', properties: { path: { type: 'number' } } } },
     ]);
     const schemaChanged = await createConfiguredToolInventory({
-      targetName: 'filesystem',
+      targetName: 'generation-target',
       source: 'mcpServers',
       config: { type: 'stdio', command: 'node' },
       connections,
     });
-    connections.set('second', connection('filesystem', []));
+    connections.set('second', connection('generation-target', []));
     const availabilityChanged = await createConfiguredToolInventory({
-      targetName: 'filesystem',
+      targetName: 'generation-target',
       source: 'mcpServers',
       config: { type: 'stdio', command: 'node' },
       connections,

--- a/src/domains/admin/configuredToolInventory.test.ts
+++ b/src/domains/admin/configuredToolInventory.test.ts
@@ -1,0 +1,198 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { publishConfiguredToolSnapshot } from '@src/core/capabilities/configuredToolSnapshot.js';
+import { ClientStatus, type OutboundConnection, type OutboundConnections } from '@src/core/types/index.js';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createConfiguredToolInventory } from './configuredToolInventory.js';
+
+function connection(name: string, tools: Tool[]): OutboundConnection {
+  const outbound = {
+    name,
+    status: ClientStatus.Connected,
+    client: { listTools: vi.fn(async () => ({ tools })) },
+    transport: {},
+  } as unknown as OutboundConnection;
+  publishConfiguredToolSnapshot(outbound, tools);
+  return outbound;
+}
+
+describe('Configured Tool Inventory', () => {
+  it('combines observed tools with retained unresolved configuration', async () => {
+    const connections: OutboundConnections = new Map([
+      [
+        'filesystem',
+        connection('filesystem', [
+          { name: 'read_file', description: 'Read upstream', inputSchema: { type: 'object' } },
+          { name: 'write_file', description: 'Write upstream', inputSchema: { type: 'object' } },
+        ]),
+      ],
+    ]);
+
+    const inventory = await createConfiguredToolInventory({
+      targetName: 'filesystem',
+      source: 'mcpServers',
+      config: {
+        type: 'stdio',
+        command: 'node',
+        disabledTools: ['write_file', 'missing_tool'],
+        toolDescriptionOverrides: {
+          read_file: 'Read safely',
+          removed_tool: 'Removed description',
+        },
+      },
+      connections,
+      model: 'gpt-4o',
+    });
+
+    expect(inventory.freshness).toBe('live');
+    expect(inventory.rows).toMatchObject([
+      {
+        name: 'missing_tool',
+        enabled: false,
+        observed: false,
+        unresolved: true,
+      },
+      {
+        name: 'read_file',
+        enabled: true,
+        observed: true,
+        upstreamDescription: 'Read upstream',
+        effectiveDescription: 'Read safely',
+        descriptionOverridden: true,
+      },
+      {
+        name: 'removed_tool',
+        enabled: true,
+        observed: false,
+        unresolved: true,
+        effectiveDescription: 'Removed description',
+        descriptionOverridden: true,
+      },
+      {
+        name: 'write_file',
+        enabled: false,
+        observed: true,
+      },
+    ]);
+    expect(inventory.rows.find((row) => row.name === 'read_file')?.approximateTokens).toBeGreaterThan(0);
+    expect(connections.get('filesystem')?.client.listTools).not.toHaveBeenCalled();
+
+    connections.clear();
+    const disabledInventory = await createConfiguredToolInventory({
+      targetName: 'filesystem',
+      source: 'mcpServers',
+      config: { type: 'stdio', command: 'node' },
+      connections,
+    });
+    expect(disabledInventory.freshness).toBe('unavailable');
+    expect(disabledInventory.rows.map((row) => row.name)).toEqual(['read_file', 'write_file']);
+    expect(disabledInventory.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'read_file', observed: false, stale: true, unresolved: false }),
+      ]),
+    );
+    expect(disabledInventory.counts.observed).toBe(0);
+  });
+
+  it('unions Template Server tools and reports partial occurrence', async () => {
+    const connections: OutboundConnections = new Map([
+      [
+        'project:one',
+        connection('project', [
+          { name: 'common', description: 'Common', inputSchema: { type: 'object' } },
+          { name: 'only_one', description: 'One', inputSchema: { type: 'object' } },
+        ]),
+      ],
+      [
+        'project:two',
+        connection('project', [{ name: 'common', description: 'Common', inputSchema: { type: 'object' } }]),
+      ],
+    ]);
+
+    const inventory = await createConfiguredToolInventory({
+      targetName: 'project',
+      source: 'mcpTemplates',
+      config: { type: 'stdio', command: 'node' },
+      connections,
+      model: 'gpt-4o',
+    });
+
+    expect(inventory.activeInstanceCount).toBe(2);
+    expect(inventory.rows).toMatchObject([
+      { name: 'common', observedInstanceCount: 2, activeInstanceCount: 2, observedInSomeInstances: false },
+      { name: 'only_one', observedInstanceCount: 1, activeInstanceCount: 2, observedInSomeInstances: true },
+    ]);
+  });
+
+  it('uses the configured-server disabled semantics for rendered string values', async () => {
+    const inventory = await createConfiguredToolInventory({
+      targetName: 'project',
+      source: 'mcpTemplates',
+      config: { type: 'stdio', command: 'node', disabled: 'yes' },
+      connections: new Map(),
+    });
+
+    expect(inventory.targetEnabled).toBe(false);
+  });
+
+  it('changes generation for schema changes and snapshot availability', async () => {
+    const outbound = connection('filesystem', [
+      { name: 'read', description: 'Read', inputSchema: { type: 'object', properties: { path: { type: 'string' } } } },
+    ]);
+    const connections: OutboundConnections = new Map([['filesystem', outbound]]);
+    const first = await createConfiguredToolInventory({
+      targetName: 'filesystem',
+      source: 'mcpServers',
+      config: { type: 'stdio', command: 'node' },
+      connections,
+    });
+    publishConfiguredToolSnapshot(outbound, [
+      { name: 'read', description: 'Read', inputSchema: { type: 'object', properties: { path: { type: 'number' } } } },
+    ]);
+    const schemaChanged = await createConfiguredToolInventory({
+      targetName: 'filesystem',
+      source: 'mcpServers',
+      config: { type: 'stdio', command: 'node' },
+      connections,
+    });
+    connections.set('second', connection('filesystem', []));
+    const availabilityChanged = await createConfiguredToolInventory({
+      targetName: 'filesystem',
+      source: 'mcpServers',
+      config: { type: 'stdio', command: 'node' },
+      connections,
+    });
+
+    expect(schemaChanged.generation).not.toBe(first.generation);
+    expect(availabilityChanged.generation).not.toBe(schemaChanged.generation);
+  });
+
+  it('does not claim partial template occurrence when an active instance snapshot is unknown', async () => {
+    const observed = connection('partial-project', [
+      { name: 'search', description: 'Search', inputSchema: { type: 'object' } },
+    ]);
+    const listTools = vi.fn();
+    const unknown = {
+      name: 'partial-project',
+      status: ClientStatus.Connected,
+      client: { listTools },
+      transport: {},
+    } as unknown as OutboundConnection;
+    const inventory = await createConfiguredToolInventory({
+      targetName: 'partial-project',
+      source: 'mcpTemplates',
+      config: { type: 'stdio', command: 'node' },
+      connections: new Map([
+        ['partial-project:observed', observed],
+        ['partial-project:unknown', unknown],
+      ]),
+    });
+
+    expect(inventory.freshness).toBe('unavailable');
+    expect(inventory.rows[0]).toMatchObject({ observedInstanceCount: 1, activeInstanceCount: 2 });
+    expect(inventory.rows[0]?.observedInSomeInstances).toBe(false);
+    expect(listTools).not.toHaveBeenCalled();
+  });
+});

--- a/src/domains/admin/configuredToolInventory.ts
+++ b/src/domains/admin/configuredToolInventory.ts
@@ -1,0 +1,185 @@
+import { createHash } from 'node:crypto';
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+import { TokenEstimationService } from '@src/application/services/tokenEstimationService.js';
+import {
+  publishLastConfiguredToolSnapshot,
+  readConfiguredToolSnapshot,
+  readLastConfiguredToolSnapshot,
+} from '@src/core/capabilities/configuredToolSnapshot.js';
+import { getDisabledTools, isToolDisabled } from '@src/core/server/disabledTools.js';
+import {
+  applyEffectiveToolDescription,
+  getToolDescriptionOverrides,
+} from '@src/core/server/toolDescriptionOverrides.js';
+import { ClientStatus, type MCPServerParams, type OutboundConnections } from '@src/core/types/index.js';
+import { isConfiguredServerTargetDisabled } from '@src/domains/config-change/configChange.js';
+
+export type ConfiguredToolTargetSource = 'mcpServers' | 'mcpTemplates';
+
+export interface ConfiguredToolInventoryRow {
+  name: string;
+  upstreamDescription?: string;
+  effectiveDescription?: string;
+  descriptionOverride?: string;
+  descriptionOverridden: boolean;
+  enabled: boolean;
+  observed: boolean;
+  stale?: boolean;
+  unresolved: boolean;
+  observedInstanceCount: number;
+  activeInstanceCount: number;
+  observedInSomeInstances: boolean;
+  approximateTokens: number;
+}
+
+export interface ConfiguredToolInventory {
+  targetName: string;
+  source: ConfiguredToolTargetSource;
+  targetEnabled: boolean;
+  freshness: 'live' | 'unavailable';
+  model: string;
+  generation: string;
+  activeInstanceCount: number;
+  rows: ConfiguredToolInventoryRow[];
+  counts: { observed: number; enabled: number; disabled: number; unresolved: number };
+  approximateTokens: { enabled: number; allObserved: number; savings: number };
+}
+
+export async function createConfiguredToolInventory(input: {
+  targetName: string;
+  source: ConfiguredToolTargetSource;
+  config: MCPServerParams;
+  connections: OutboundConnections;
+  model?: string;
+}): Promise<ConfiguredToolInventory> {
+  const model = input.model?.trim() || 'gpt-4o';
+  const matchingConnections = Array.from(input.connections.entries()).filter(([, connection]) => {
+    const logicalName = connection.name;
+    return connection.status === ClientStatus.Connected && logicalName === input.targetName;
+  });
+  const activeInstanceCount = matchingConnections.length;
+  const toolsByName = new Map<string, { tool: Tool; instances: Set<string>; live: boolean }>();
+  let successfulInstances = 0;
+  const snapshotAvailability: Array<{ connectionKey: string; available: boolean }> = [];
+
+  for (const [connectionKey, connection] of matchingConnections) {
+    const tools = readConfiguredToolSnapshot(connection);
+    snapshotAvailability.push({ connectionKey, available: tools !== undefined });
+    if (!tools) continue;
+    successfulInstances += 1;
+    for (const tool of tools) {
+      const existing = toolsByName.get(tool.name);
+      if (existing) existing.instances.add(connectionKey);
+      else toolsByName.set(tool.name, { tool, instances: new Set([connectionKey]), live: true });
+    }
+  }
+  if (activeInstanceCount > 0 && successfulInstances === activeInstanceCount) {
+    publishLastConfiguredToolSnapshot(
+      input.targetName,
+      Array.from(toolsByName.values(), ({ tool }) => tool),
+    );
+  }
+  for (const tool of readLastConfiguredToolSnapshot(input.targetName)) {
+    if (!toolsByName.has(tool.name)) toolsByName.set(tool.name, { tool, instances: new Set(), live: false });
+  }
+
+  const overrides = getToolDescriptionOverrides(input.config);
+  const configuredNames = new Set([...getDisabledTools(input.config), ...Object.keys(overrides)]);
+  const allNames = new Set([...toolsByName.keys(), ...configuredNames]);
+  const tokenEstimator = new TokenEstimationService(model);
+  const serverConfigs = { [input.targetName]: input.config };
+
+  let rows: ConfiguredToolInventoryRow[];
+  try {
+    rows = Array.from(allNames)
+      .sort((left, right) => left.localeCompare(right))
+      .map((name): ConfiguredToolInventoryRow => {
+        const observed = toolsByName.get(name);
+        const effectiveTool = observed
+          ? applyEffectiveToolDescription(observed.tool, input.config, input.targetName)
+          : undefined;
+        const approximateTokens = effectiveTool
+          ? (tokenEstimator.estimateServerTokens(input.targetName, [effectiveTool], [], [], true).breakdown.tools[0]
+              ?.tokens ?? 0)
+          : 0;
+        const observedInstanceCount = observed?.instances.size ?? 0;
+        return {
+          name,
+          ...(observed?.tool.description !== undefined ? { upstreamDescription: observed.tool.description } : {}),
+          ...(effectiveTool?.description !== undefined
+            ? { effectiveDescription: effectiveTool.description }
+            : overrides[name]
+              ? { effectiveDescription: overrides[name] }
+              : {}),
+          ...(overrides[name] ? { descriptionOverride: overrides[name] } : {}),
+          descriptionOverridden: overrides[name] !== undefined,
+          enabled: !isToolDisabled(serverConfigs, input.targetName, name),
+          observed: observed?.live ?? false,
+          stale: observed !== undefined && !observed.live,
+          unresolved: observed === undefined,
+          observedInstanceCount,
+          activeInstanceCount,
+          observedInSomeInstances:
+            successfulInstances === activeInstanceCount &&
+            observedInstanceCount > 0 &&
+            observedInstanceCount < activeInstanceCount,
+          approximateTokens,
+        };
+      });
+  } finally {
+    tokenEstimator.dispose();
+  }
+
+  const allObservedTokens = rows.reduce((total, row) => total + row.approximateTokens, 0);
+  const enabledTokens = rows.reduce((total, row) => total + (row.enabled ? row.approximateTokens : 0), 0);
+  const generation = createHash('sha256')
+    .update(
+      JSON.stringify({
+        targetName: input.targetName,
+        source: input.source,
+        instances: snapshotAvailability.sort((left, right) => left.connectionKey.localeCompare(right.connectionKey)),
+        tools: Array.from(toolsByName.entries())
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([name, observed]) => ({
+            name,
+            tool: normalizeGenerationValue(observed.tool),
+            instances: Array.from(observed.instances).sort(),
+          })),
+      }),
+    )
+    .digest('base64url');
+
+  return {
+    targetName: input.targetName,
+    source: input.source,
+    targetEnabled: !isConfiguredServerTargetDisabled(input.config.disabled),
+    freshness: activeInstanceCount > 0 && successfulInstances === activeInstanceCount ? 'live' : 'unavailable',
+    model,
+    generation,
+    activeInstanceCount,
+    rows,
+    counts: {
+      observed: rows.filter((row) => row.observed).length,
+      enabled: rows.filter((row) => row.enabled).length,
+      disabled: rows.filter((row) => !row.enabled).length,
+      unresolved: rows.filter((row) => row.unresolved).length,
+    },
+    approximateTokens: {
+      enabled: enabledTokens,
+      allObserved: allObservedTokens,
+      savings: allObservedTokens - enabledTokens,
+    },
+  };
+}
+
+function normalizeGenerationValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeGenerationValue);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => [key, normalizeGenerationValue(nested)]),
+  );
+}

--- a/src/domains/admin/configuredToolInventory.ts
+++ b/src/domains/admin/configuredToolInventory.ts
@@ -8,7 +8,7 @@ import {
   readConfiguredToolSnapshot,
   readLastConfiguredToolSnapshot,
 } from '@src/core/capabilities/configuredToolSnapshot.js';
-import { getDisabledTools, isToolDisabled } from '@src/core/server/disabledTools.js';
+import { getDisabledTools, getLogicalToolName, isToolDisabled } from '@src/core/server/disabledTools.js';
 import {
   applyEffectiveToolDescription,
   getToolDescriptionOverrides,
@@ -86,7 +86,10 @@ export async function createConfiguredToolInventory(input: {
   }
 
   const overrides = getToolDescriptionOverrides(input.config);
-  const configuredNames = new Set([...getDisabledTools(input.config), ...Object.keys(overrides)]);
+  const configuredNames = new Set([
+    ...getDisabledTools(input.config).map((name) => getLogicalToolName(input.targetName, name)),
+    ...Object.keys(overrides).map((name) => getLogicalToolName(input.targetName, name)),
+  ]);
   const allNames = new Set([...toolsByName.keys(), ...configuredNames]);
   const tokenEstimator = new TokenEstimationService(model);
   const serverConfigs = { [input.targetName]: input.config };
@@ -105,16 +108,17 @@ export async function createConfiguredToolInventory(input: {
               ?.tokens ?? 0)
           : 0;
         const observedInstanceCount = observed?.instances.size ?? 0;
+        const descriptionOverride = overrides[name];
         return {
           name,
           ...(observed?.tool.description !== undefined ? { upstreamDescription: observed.tool.description } : {}),
           ...(effectiveTool?.description !== undefined
             ? { effectiveDescription: effectiveTool.description }
-            : overrides[name]
-              ? { effectiveDescription: overrides[name] }
+            : descriptionOverride !== undefined
+              ? { effectiveDescription: descriptionOverride }
               : {}),
-          ...(overrides[name] ? { descriptionOverride: overrides[name] } : {}),
-          descriptionOverridden: overrides[name] !== undefined,
+          ...(descriptionOverride !== undefined ? { descriptionOverride } : {}),
+          descriptionOverridden: descriptionOverride !== undefined,
           enabled: !isToolDisabled(serverConfigs, input.targetName, name),
           observed: observed?.live ?? false,
           stale: observed !== undefined && !observed.live,

--- a/src/domains/config-change/configChange.test.ts
+++ b/src/domains/config-change/configChange.test.ts
@@ -101,6 +101,44 @@ describe('Config Change', () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
+  it('edits a Template Server definition without creating per-instance state', async () => {
+    const original = { type: 'stdio' as const, command: 'node', disabledTools: ['write_file'] };
+    await writeConfig({
+      mcpTemplates: { project: original },
+      mcpServers: { unrelated: { type: 'stdio', command: 'bun' } },
+    });
+    const service = createConfigChangeService({ reloadConfig: reload });
+
+    const result = await service.editConfiguredServerTarget({
+      sourceName: 'project',
+      targetName: 'project',
+      serverConfig: {
+        ...original,
+        disabledTools: ['write_file', 'delete_file'],
+        toolDescriptionOverrides: { read_file: 'Read safely' },
+      },
+      expectedSourceFingerprint: fingerprintConfiguredServerTarget(original),
+    });
+
+    expect(result).toMatchObject({
+      status: 'changed',
+      operation: 'edit',
+      target: { name: 'project', source: 'mcpTemplates' },
+      backup: { created: true },
+      reload: { status: 'observed' },
+    });
+    expect(await readConfig()).toEqual({
+      mcpTemplates: {
+        project: {
+          ...original,
+          disabledTools: ['write_file', 'delete_file'],
+          toolDescriptionOverrides: { read_file: 'Read safely' },
+        },
+      },
+      mcpServers: { unrelated: { type: 'stdio', command: 'bun' } },
+    });
+  });
+
   it('rejects stale edit preconditions without backup, write, or reload', async () => {
     const original = { type: 'stdio' as const, command: 'node' };
     await writeConfig({ mcpServers: { alpha: original } });

--- a/src/transport/http/routes/adminRoutes.test.ts
+++ b/src/transport/http/routes/adminRoutes.test.ts
@@ -1987,6 +1987,18 @@ describe('admin routes', () => {
             },
           ],
         },
+        toolInventory: {
+          targetName: 'github/api server',
+          source: 'mcpServers',
+          targetEnabled: true,
+          freshness: 'live',
+          model: 'gpt-4o-mini',
+          generation: 'generation-1',
+          activeInstanceCount: 1,
+          rows: [],
+          counts: { observed: 0, enabled: 0, disabled: 0, unresolved: 0 },
+          approximateTokens: { enabled: 0, allObserved: 0, savings: 0 },
+        },
       },
     });
     const app = mountAdminRoutes();
@@ -1997,6 +2009,7 @@ describe('admin routes', () => {
 
     const response = await request(app)
       .get('/admin/api/configured-servers/github%2Fapi%20server')
+      .query({ model: 'gpt-4o-mini' })
       .set('Cookie', cookie);
 
     expect(response.status).toBe(200);
@@ -2015,6 +2028,7 @@ describe('admin routes', () => {
         schemaVersion: 3,
         target: { type: 'configured_server', id: 'github/api server', source: 'mcpServers' },
       },
+      toolInventory: { model: 'gpt-4o-mini', generation: 'generation-1' },
     });
     expect(response.body.server.id).toBe('github/api server');
     expect(response.body.editContract.capabilities).toMatchObject({
@@ -2033,6 +2047,7 @@ describe('admin routes', () => {
         target: { type: 'configured_server', id: 'mcpServers:github/api server' },
       }),
       targetName: 'github/api server',
+      model: 'gpt-4o-mini',
     });
     expect(JSON.stringify(response.body)).not.toMatch(/raw-token|raw-secret|Bearer raw/i);
   });
@@ -2185,7 +2200,7 @@ describe('admin routes', () => {
       .post('/admin/api/configured-servers/github%2Fapi/preview')
       .set('Cookie', cookie)
       .set('X-CSRF-Token', loginResponse.body.csrfToken)
-      .send({ edit, connectivityCheck: 'manual' });
+      .send({ edit, connectivityCheck: 'manual', model: 'gpt-4o-mini' });
 
     expect(rejected.status).toBe(403);
     expect(response.status).toBe(200);
@@ -2238,6 +2253,7 @@ describe('admin routes', () => {
       targetName: 'github/api',
       edit,
       connectivityCheck: 'manual',
+      model: 'gpt-4o-mini',
     });
     expect(response.text).not.toMatch(/raw-secret|raw-token|Bearer raw/i);
   });

--- a/src/transport/http/routes/adminRoutes.ts
+++ b/src/transport/http/routes/adminRoutes.ts
@@ -1252,6 +1252,7 @@ async function handleConfiguredServerDetail(
       }),
       targetName,
       ...(targetSource ? { targetSource } : {}),
+      ...(typeof req.query.model === 'string' ? { model: req.query.model } : {}),
     });
     if (!result.ok) {
       sendAdminOperationResult(res, result);
@@ -1263,6 +1264,7 @@ async function handleConfiguredServerDetail(
       operationId: result.operationId,
       server: result.result.server,
       editContract: result.result.editContract,
+      ...(result.result.toolInventory ? { toolInventory: result.result.toolInventory } : {}),
     });
   } catch (error) {
     if (error instanceof AdminConfiguredServerNotFoundError) {
@@ -1400,6 +1402,7 @@ async function handleConfiguredServerPreview(
       ...(targetSource ? { targetSource } : {}),
       edit: edit === undefined ? {} : edit,
       connectivityCheck: getBodyString(req.body, 'connectivityCheck') === 'manual' ? 'manual' : 'auto',
+      ...(getBodyString(req.body, 'model') ? { model: getBodyString(req.body, 'model') } : {}),
     });
     if (!result.ok) {
       sendAdminOperationResult(res, result);
@@ -1459,6 +1462,7 @@ async function handleConfiguredServerApply(
       ...(targetSource ? { targetSource } : {}),
       edit: getBodyValue(req.body, 'edit') ?? {},
       previewFingerprint: getBodyString(req.body, 'previewFingerprint'),
+      ...(getBodyString(req.body, 'model') ? { model: getBodyString(req.body, 'model') } : {}),
     });
     if (!result.ok && result.status === 'mutation_failed' && isConfiguredServerApplyErrorCode(result.error)) {
       sendConfiguredServerApplyError(res, result.error);

--- a/src/transport/http/routes/adminRoutes.ts
+++ b/src/transport/http/routes/adminRoutes.ts
@@ -85,6 +85,7 @@ const adminOAuthServiceParamsSchema = z.object({
 const backendLogSnapshotQuerySchema = z.object({
   sourceId: z.string().trim().min(1).max(256).optional(),
 });
+const configuredServerModelSchema = z.string().trim().min(1).max(64);
 const cliConfiguredServerMutationBodySchema = z.object({
   targetName: z.string().trim().min(1).max(256),
   dryRun: z.boolean().optional(),
@@ -1245,6 +1246,7 @@ async function handleConfiguredServerDetail(
 
   const targetName = req.params.name;
   try {
+    const model = configuredServerModelSchema.safeParse(req.query.model);
     const result = await options.configuredServerService.getConfiguredServerDetail({
       context: buildAdminOperationContext(req, options, {
         type: 'configured_server',
@@ -1252,7 +1254,7 @@ async function handleConfiguredServerDetail(
       }),
       targetName,
       ...(targetSource ? { targetSource } : {}),
-      ...(typeof req.query.model === 'string' ? { model: req.query.model } : {}),
+      ...(model.success ? { model: model.data } : {}),
     });
     if (!result.ok) {
       sendAdminOperationResult(res, result);
@@ -1393,6 +1395,7 @@ async function handleConfiguredServerPreview(
   const targetName = req.params.name;
   const edit = getBodyValue(req.body, 'edit');
   try {
+    const model = configuredServerModelSchema.safeParse(getBodyString(req.body, 'model'));
     const result = await options.configuredServerService.previewConfiguredServerEdit({
       context: buildAdminOperationContext(req, options, {
         type: 'configured_server',
@@ -1402,7 +1405,7 @@ async function handleConfiguredServerPreview(
       ...(targetSource ? { targetSource } : {}),
       edit: edit === undefined ? {} : edit,
       connectivityCheck: getBodyString(req.body, 'connectivityCheck') === 'manual' ? 'manual' : 'auto',
-      ...(getBodyString(req.body, 'model') ? { model: getBodyString(req.body, 'model') } : {}),
+      ...(model.success ? { model: model.data } : {}),
     });
     if (!result.ok) {
       sendAdminOperationResult(res, result);
@@ -1453,6 +1456,7 @@ async function handleConfiguredServerApply(
 
   const targetName = req.params.name;
   try {
+    const model = configuredServerModelSchema.safeParse(getBodyString(req.body, 'model'));
     const result = await options.configuredServerService.applyConfiguredServerEdit({
       context: buildAdminOperationContext(req, options, {
         type: 'configured_server',
@@ -1462,7 +1466,7 @@ async function handleConfiguredServerApply(
       ...(targetSource ? { targetSource } : {}),
       edit: getBodyValue(req.body, 'edit') ?? {},
       previewFingerprint: getBodyString(req.body, 'previewFingerprint'),
-      ...(getBodyString(req.body, 'model') ? { model: getBodyString(req.body, 'model') } : {}),
+      ...(model.success ? { model: model.data } : {}),
     });
     if (!result.ok && result.status === 'mutation_failed' && isConfiguredServerApplyErrorCode(result.error)) {
       sendConfiguredServerApplyError(res, result.error);

--- a/src/transport/http/routes/apiRoutes.inspect-session.test.ts
+++ b/src/transport/http/routes/apiRoutes.inspect-session.test.ts
@@ -10,6 +10,7 @@ const mockedLoadDeclaredServerConfigs = vi.hoisted(() => vi.fn());
 const mockedLoadConfigWithTemplates = vi.hoisted(() => vi.fn());
 const mockedExtractRequestContext = vi.hoisted(() => vi.fn());
 const mockedGetTransportConfig = vi.hoisted(() => vi.fn());
+const mockedGetConfiguredServerTargets = vi.hoisted(() => vi.fn());
 
 vi.mock('@src/config/configManager.js', () => ({
   ConfigManager: {
@@ -24,6 +25,7 @@ vi.mock('@src/config/mcpConfigManager.js', () => ({
   McpConfigManager: {
     getInstance: vi.fn(() => ({
       getTransportConfig: mockedGetTransportConfig,
+      getConfiguredServerTargets: mockedGetConfiguredServerTargets,
     })),
   },
 }));
@@ -122,6 +124,8 @@ describe('apiRoutes inspect', () => {
     });
     mockedGetTransportConfig.mockReset();
     mockedGetTransportConfig.mockReturnValue({});
+    mockedGetConfiguredServerTargets.mockReset();
+    mockedGetConfiguredServerTargets.mockImplementation(() => mockedGetTransportConfig());
     mockedLoadConfigWithTemplates.mockResolvedValue({
       staticServers: {},
       templateServers: {},

--- a/src/transport/http/routes/apiRoutes.inspect-template.test.ts
+++ b/src/transport/http/routes/apiRoutes.inspect-template.test.ts
@@ -206,6 +206,38 @@ describe('apiRoutes inspect', () => {
     inspectHandler = createInspectHandler(serverManager as never);
   });
 
+  it('uses the configured effective description in server and tool payloads', async () => {
+    mockedGetTransportConfig.mockReturnValue({
+      context7: {
+        type: 'stdio',
+        command: 'node',
+        toolDescriptionOverrides: { 'context7_1mcp_query-docs': 'Search the current documentation' },
+      },
+    });
+
+    const serverRequest = { query: { target: 'context7' } };
+    const serverResponse = createMockResponse();
+    await invokeInspectRoute(scopeAuthMiddleware, serverRequest, serverResponse);
+    await invokeInspectRoute(inspectHandler, serverRequest, serverResponse);
+
+    expect(serverResponse.statusCode, JSON.stringify(serverResponse.body)).toBe(200);
+    expect(serverResponse.body).toMatchObject({
+      kind: 'server',
+      tools: [{ tool: 'query-docs', description: 'Search the current documentation' }],
+    });
+
+    const toolRequest = { query: { target: 'context7/query-docs' } };
+    const toolResponse = createMockResponse();
+    await invokeInspectRoute(scopeAuthMiddleware, toolRequest, toolResponse);
+    await invokeInspectRoute(inspectHandler, toolRequest, toolResponse);
+
+    expect(toolResponse.statusCode, JSON.stringify(toolResponse.body)).toBe(200);
+    expect(toolResponse.body).toMatchObject({
+      kind: 'tool',
+      description: 'Search the current documentation',
+    });
+  });
+
   it('does not initialize template servers for bare inspect listings even when request context is present', async () => {
     mockedLoadDeclaredServerConfigs.mockReturnValue({
       staticServers: {},

--- a/src/transport/http/routes/apiRoutes.inspect-template.test.ts
+++ b/src/transport/http/routes/apiRoutes.inspect-template.test.ts
@@ -10,6 +10,7 @@ const mockedLoadDeclaredServerConfigs = vi.hoisted(() => vi.fn());
 const mockedLoadConfigWithTemplates = vi.hoisted(() => vi.fn());
 const mockedExtractRequestContext = vi.hoisted(() => vi.fn());
 const mockedGetTransportConfig = vi.hoisted(() => vi.fn());
+const mockedGetConfiguredServerTargets = vi.hoisted(() => vi.fn());
 
 vi.mock('@src/config/configManager.js', () => ({
   ConfigManager: {
@@ -24,6 +25,7 @@ vi.mock('@src/config/mcpConfigManager.js', () => ({
   McpConfigManager: {
     getInstance: vi.fn(() => ({
       getTransportConfig: mockedGetTransportConfig,
+      getConfiguredServerTargets: mockedGetConfiguredServerTargets,
     })),
   },
 }));
@@ -122,6 +124,8 @@ describe('apiRoutes inspect', () => {
     });
     mockedGetTransportConfig.mockReset();
     mockedGetTransportConfig.mockReturnValue({});
+    mockedGetConfiguredServerTargets.mockReset();
+    mockedGetConfiguredServerTargets.mockImplementation(() => mockedGetTransportConfig());
     mockedLoadConfigWithTemplates.mockResolvedValue({
       staticServers: {},
       templateServers: {},
@@ -207,7 +211,7 @@ describe('apiRoutes inspect', () => {
   });
 
   it('uses the configured effective description in server and tool payloads', async () => {
-    mockedGetTransportConfig.mockReturnValue({
+    mockedGetConfiguredServerTargets.mockReturnValue({
       context7: {
         type: 'stdio',
         command: 'node',

--- a/src/transport/http/routes/inspectRoutes.ts
+++ b/src/transport/http/routes/inspectRoutes.ts
@@ -14,6 +14,7 @@ import {
   getDisabledToolsForServer,
 } from '@src/core/server/disabledTools.js';
 import { ServerManager } from '@src/core/server/serverManager.js';
+import { applyEffectiveToolDescription } from '@src/core/server/toolDescriptionOverrides.js';
 import logger from '@src/logger/logger.js';
 
 import { Request, RequestHandler, Response } from 'express';
@@ -103,11 +104,15 @@ function hasDisabledTools(serverConfigs: ServerConfigMap, serverName: string): b
   return getDisabledToolsForServer(serverConfigs, serverName).length > 0;
 }
 
-function summarizeRegistryTools(tools: ReturnType<ToolRegistry['listTools']>['tools']): ToolSummary[] {
+function summarizeRegistryTools(
+  tools: ReturnType<ToolRegistry['listTools']>['tools'],
+  serverName: string,
+  serverConfigs: ServerConfigMap,
+): ToolSummary[] {
   return tools.map((tool) => ({
     tool: getToolName(tool.name),
     qualifiedName: tool.name,
-    description: tool.description,
+    description: applyEffectiveToolDescription(tool, serverConfigs[serverName], serverName).description,
     requiredArgs: 0,
     optionalArgs: 0,
   }));
@@ -122,7 +127,7 @@ function buildRegistryToolsResult(
   const disabledToolsConfigured = hasDisabledTools(serverConfigs, serverName);
 
   return {
-    tools: summarizeRegistryTools(filteredTools),
+    tools: summarizeRegistryTools(filteredTools, serverName, serverConfigs),
     totalTools: disabledToolsConfigured ? filteredTools.length : result.totalCount,
     hasMore: disabledToolsConfigured ? false : result.hasMore,
     nextCursor: disabledToolsConfigured ? undefined : result.nextCursor,
@@ -139,7 +144,9 @@ function buildDirectToolsResult(
   const disabledToolsConfigured = hasDisabledTools(serverConfigs, serverName);
 
   return {
-    tools: directTools.map((tool) => summarizeDirectServerTool(serverName, tool)),
+    tools: directTools.map((tool) =>
+      summarizeDirectServerTool(serverName, applyEffectiveToolDescription(tool, serverConfigs[serverName], serverName)),
+    ),
     totalTools: disabledToolsConfigured ? directTools.length : (directResult.totalCount ?? directTools.length),
     hasMore: disabledToolsConfigured ? false : (directResult.hasMore ?? Boolean(directResult.nextCursor)),
     nextCursor: disabledToolsConfigured ? undefined : directResult.nextCursor,
@@ -392,14 +399,15 @@ export function createInspectHandler(serverManager: ServerManager): RequestHandl
           return;
         }
 
+        const effectiveTool = applyEffectiveToolDescription(found, serverConfigs[serverName], serverName);
         const payload: InspectToolPayload = {
           kind: 'tool',
           server: serverName,
           tool: toolName,
           qualifiedName: found.name === qualifiedName ? qualifiedName : qualifyToolName(serverName, found.name),
-          description: found.description,
-          inputSchema: (found.inputSchema as Record<string, unknown>) ?? {},
-          outputSchema: found.outputSchema as Record<string, unknown> | undefined,
+          description: effectiveTool.description,
+          inputSchema: (effectiveTool.inputSchema as Record<string, unknown>) ?? {},
+          outputSchema: effectiveTool.outputSchema as Record<string, unknown> | undefined,
         };
         res.json(payload);
         return;

--- a/src/transport/http/routes/inspectRoutes.ts
+++ b/src/transport/http/routes/inspectRoutes.ts
@@ -58,7 +58,9 @@ interface DirectListToolsResult {
 
 type DeclaredServers = ReturnType<ConfigManager['loadDeclaredServerConfigs']>;
 type ServerConfigMap =
-  ReturnType<typeof McpConfigManager.getInstance> extends { getTransportConfig(): infer TResult } ? TResult : never;
+  ReturnType<typeof McpConfigManager.getInstance> extends { getConfiguredServerTargets(): infer TResult }
+    ? TResult
+    : never;
 
 async function listDirectServerTools(
   connection: NonNullable<FilteredConnections extends Map<unknown, infer TValue> ? TValue : never>,
@@ -75,7 +77,10 @@ async function listDirectServerTools(
 }
 
 function getServerConfigs() {
-  return McpConfigManager.getInstance().getTransportConfig();
+  const manager = McpConfigManager.getInstance();
+  return typeof manager.getConfiguredServerTargets === 'function'
+    ? manager.getConfiguredServerTargets()
+    : manager.getTransportConfig();
 }
 
 function getServerTargetConfigs(declaredServers: DeclaredServers): ServerConfigMap {
@@ -499,7 +504,9 @@ export function createInspectHandler(serverManager: ServerManager): RequestHandl
           serverName,
         );
         toolsResult = {
-          tools: capTools.map(summarizeToolSchema),
+          tools: capTools.map((tool) =>
+            summarizeToolSchema(applyEffectiveToolDescription(tool, serverConfigs[serverName], serverName)),
+          ),
           totalTools: capTools.length,
           hasMore: false,
         };

--- a/src/transport/http/routes/toolRoutes.ts
+++ b/src/transport/http/routes/toolRoutes.ts
@@ -1,6 +1,6 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 
-import { McpConfigManager } from '@src/config/mcpConfigManager.js';
+import { getConfiguredServerTargets } from '@src/config/configuredServerTargets.js';
 import { CapabilityCatalog } from '@src/core/capabilities/capabilityCatalog.js';
 import {
   type CapabilityVisibility,
@@ -28,7 +28,7 @@ import {
 } from './inspectRoutes.js';
 
 function getServerConfigs() {
-  return McpConfigManager.getInstance().getTransportConfig();
+  return getConfiguredServerTargets();
 }
 
 function getCapabilityVisibilityFromRequest(

--- a/src/transport/http/server.ts
+++ b/src/transport/http/server.ts
@@ -19,6 +19,7 @@ import type { ConfiguredServerConfigDocument } from '@src/domains/admin/adminCon
 import { createAdminConnectivityChecker } from '@src/domains/admin/adminConnectivityChecker.js';
 import { createAdminDomain } from '@src/domains/admin/adminDomain.js';
 import { createAdminInstructionPreviewRuntime } from '@src/domains/admin/adminInstructionPreviewRuntime.js';
+import { createConfiguredToolInventory } from '@src/domains/admin/configuredToolInventory.js';
 import {
   type AdminMutationAvailability,
   type RuntimeScopeAdminLockHandle,
@@ -418,6 +419,11 @@ export class ExpressServer {
       configChangeService: createConfigChangeService({ getConfigPath }),
       getConfigPath,
       readConfigDocument: () => readConfiguredServerConfigDocument(getConfigPath),
+      readToolInventory: (input) =>
+        createConfiguredToolInventory({
+          ...input,
+          connections: this.serverManager.getClients(),
+        }),
       checkConnectivity: createAdminConnectivityChecker(),
       presetManager: PresetManager.getInstance(path.dirname(adminConfigPath)),
       previewInstructions: createAdminInstructionPreviewRuntime(

--- a/test/e2e/admin-spa-browser-smoke.e2e.test.ts
+++ b/test/e2e/admin-spa-browser-smoke.e2e.test.ts
@@ -24,6 +24,7 @@ import { createAdminRoutes } from '@src/transport/http/routes/adminRoutes.js';
 import express from 'express';
 import { type Browser, chromium, type Locator, type Page } from 'playwright';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 const ADMIN_BUILD_DIR = path.join(process.cwd(), 'build', 'admin');
 const ADMIN_BUILD_INDEX = path.join(ADMIN_BUILD_DIR, 'index.html');
@@ -204,7 +205,7 @@ describe('admin SPA browser smoke', () => {
       await expectText(page, 'Configured Tool Selection');
 
       const searchTool = page.locator('.configured-tool-row', { hasText: 'search' });
-      await searchTool.getByRole('switch', { name: 'Enable search' }).click();
+      await searchTool.getByRole('switch', { name: 'Enable search' }).locator('..').click();
       await searchTool.getByRole('textbox', { name: 'Description override' }).fill('Search approved repositories');
 
       const tags = page.getByRole('textbox', { name: 'Tags' });
@@ -1150,6 +1151,13 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
         edit: input.edit,
       };
       const edit = input.edit && typeof input.edit === 'object' && !Array.isArray(input.edit) ? input.edit : {};
+      const toolEdit = z
+        .object({
+          disabledTools: z.array(z.string()).optional(),
+          toolDescriptionOverrides: z.record(z.string(), z.string()).optional(),
+        })
+        .passthrough()
+        .parse(edit);
       const proposedTargetName =
         typeof (edit as { id?: unknown }).id === 'string' ? (edit as { id: string }).id : input.targetName;
       const server =
@@ -1161,16 +1169,8 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
       const proposedTags = Array.isArray((edit as { tags?: unknown }).tags)
         ? (edit as { tags: unknown[] }).tags.filter((tag): tag is string => typeof tag === 'string')
         : (server?.tags ?? []);
-      const proposedDisabledTools = Array.isArray((edit as { disabledTools?: unknown }).disabledTools)
-        ? (edit as { disabledTools: unknown[] }).disabledTools.filter(
-            (name): name is string => typeof name === 'string',
-          )
-        : disabledTools;
-      const proposedOverrides =
-        (edit as { toolDescriptionOverrides?: unknown }).toolDescriptionOverrides &&
-        typeof (edit as { toolDescriptionOverrides?: unknown }).toolDescriptionOverrides === 'object'
-          ? ((edit as { toolDescriptionOverrides: Record<string, string> }).toolDescriptionOverrides ?? {})
-          : toolDescriptionOverrides;
+      const proposedDisabledTools = toolEdit.disabledTools ? toolEdit.disabledTools : disabledTools;
+      const proposedOverrides = toolEdit.toolDescriptionOverrides ?? toolDescriptionOverrides;
       const currentInventory = configuredToolInventory(disabledTools, toolDescriptionOverrides, input.model);
       const proposedInventory = configuredToolInventory(proposedDisabledTools, proposedOverrides, input.model);
       return operationSuccess('previewConfiguredServerEdit', 'op_preview', {
@@ -1225,6 +1225,13 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
     },
     async applyConfiguredServerEdit(input) {
       const edit = input.edit && typeof input.edit === 'object' && !Array.isArray(input.edit) ? input.edit : {};
+      const toolEdit = z
+        .object({
+          disabledTools: z.array(z.string()).optional(),
+          toolDescriptionOverrides: z.record(z.string(), z.string()).optional(),
+        })
+        .passthrough()
+        .parse(edit);
       const server =
         input.targetSource === 'mcpTemplates'
           ? templateServer.id === input.targetName
@@ -1246,19 +1253,8 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
       } else if (server && instructionOverride?.action === 'remove') {
         server.instructionOverride = { state: 'upstream' };
       }
-      if (Array.isArray((edit as { disabledTools?: unknown }).disabledTools)) {
-        disabledTools = (edit as { disabledTools: unknown[] }).disabledTools.filter(
-          (name): name is string => typeof name === 'string',
-        );
-      }
-      if (
-        (edit as { toolDescriptionOverrides?: unknown }).toolDescriptionOverrides &&
-        typeof (edit as { toolDescriptionOverrides?: unknown }).toolDescriptionOverrides === 'object'
-      ) {
-        toolDescriptionOverrides = {
-          ...(edit as { toolDescriptionOverrides: Record<string, string> }).toolDescriptionOverrides,
-        };
-      }
+      if (toolEdit.disabledTools) disabledTools = toolEdit.disabledTools;
+      if (toolEdit.toolDescriptionOverrides) toolDescriptionOverrides = { ...toolEdit.toolDescriptionOverrides };
       return operationSuccess('applyConfiguredServerEdit', 'op_apply', {
         originalTargetName: input.targetName,
         targetName: input.targetName,

--- a/test/e2e/admin-spa-browser-smoke.e2e.test.ts
+++ b/test/e2e/admin-spa-browser-smoke.e2e.test.ts
@@ -201,6 +201,11 @@ describe('admin SPA browser smoke', () => {
       await page.getByRole('button', { name: 'Edit static github server' }).click();
       await page.waitForURL(`${baseUrl}/admin/servers/github`);
       await expectVisible(page.getByRole('heading', { name: 'github', exact: true }));
+      await expectText(page, 'Configured Tool Selection');
+
+      const searchTool = page.locator('.configured-tool-row', { hasText: 'search' });
+      await searchTool.getByRole('switch', { name: 'Enable search' }).click();
+      await searchTool.getByRole('textbox', { name: 'Description override' }).fill('Search approved repositories');
 
       const tags = page.getByRole('textbox', { name: 'Tags' });
       await tags.fill('verified');
@@ -245,6 +250,10 @@ describe('admin SPA browser smoke', () => {
       await expectText(page, 'No changes yet');
       await expectVisible(page.getByRole('textbox', { name: 'Tags' }));
       await expectVisible(page.locator('.edit-section').getByText('verified', { exact: true }));
+      expect(await searchTool.getByRole('switch', { name: 'Enable search' }).isChecked()).toBe(false);
+      expect(await searchTool.getByRole('textbox', { name: 'Description override' }).inputValue()).toBe(
+        'Search approved repositories',
+      );
       expect(await page.getByRole('button', { name: 'Preview change' }).isDisabled()).toBe(true);
       expect(await page.getByRole('button', { name: 'Apply changes' }).count()).toBe(0);
     } finally {
@@ -950,12 +959,16 @@ async function adminApi(
 function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
   let servers = createConfiguredServerReadModels();
   let templateServer = createTemplateConfiguredServerReadModel();
+  let disabledTools: string[] = [];
+  let toolDescriptionOverrides: Record<string, string> = {};
 
   const fixture: ResettableConfiguredServerFixture = {
     reset() {
       servers = createConfiguredServerReadModels();
       templateServer = createTemplateConfiguredServerReadModel();
       fixture.lastEdit = undefined;
+      disabledTools = [];
+      toolDescriptionOverrides = {};
     },
     clear() {
       servers = [];
@@ -1125,6 +1138,9 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
             },
           ],
         },
+        ...(server.id === 'github'
+          ? { toolInventory: configuredToolInventory(disabledTools, toolDescriptionOverrides, input.model) }
+          : {}),
       });
     },
     async previewConfiguredServerEdit(input) {
@@ -1145,6 +1161,18 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
       const proposedTags = Array.isArray((edit as { tags?: unknown }).tags)
         ? (edit as { tags: unknown[] }).tags.filter((tag): tag is string => typeof tag === 'string')
         : (server?.tags ?? []);
+      const proposedDisabledTools = Array.isArray((edit as { disabledTools?: unknown }).disabledTools)
+        ? (edit as { disabledTools: unknown[] }).disabledTools.filter(
+            (name): name is string => typeof name === 'string',
+          )
+        : disabledTools;
+      const proposedOverrides =
+        (edit as { toolDescriptionOverrides?: unknown }).toolDescriptionOverrides &&
+        typeof (edit as { toolDescriptionOverrides?: unknown }).toolDescriptionOverrides === 'object'
+          ? ((edit as { toolDescriptionOverrides: Record<string, string> }).toolDescriptionOverrides ?? {})
+          : toolDescriptionOverrides;
+      const currentInventory = configuredToolInventory(disabledTools, toolDescriptionOverrides, input.model);
+      const proposedInventory = configuredToolInventory(proposedDisabledTools, proposedOverrides, input.model);
       return operationSuccess('previewConfiguredServerEdit', 'op_preview', {
         targetName: input.targetName,
         proposedTargetName,
@@ -1179,6 +1207,20 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
           warnings: [],
         },
         connectivityCheck: { status: 'skipped', reason: 'connection_critical_fields_unchanged' },
+        toolSelection: {
+          capabilityGeneration: currentInventory.generation,
+          model: proposedInventory.model,
+          targetEnabled: true,
+          changedTools: ['search'],
+          counts: proposedInventory.counts,
+          approximateTokens: {
+            before: currentInventory.approximateTokens.enabled,
+            after: proposedInventory.approximateTokens.enabled,
+            savings: currentInventory.approximateTokens.enabled - proposedInventory.approximateTokens.enabled,
+          },
+          effect: 'immediate' as const,
+          requiresZeroEnabledConfirmation: proposedInventory.counts.enabled === 0,
+        },
       });
     },
     async applyConfiguredServerEdit(input) {
@@ -1203,6 +1245,19 @@ function createConfiguredServerFixture(): ResettableConfiguredServerFixture {
           : { state: 'suppress', value: '' };
       } else if (server && instructionOverride?.action === 'remove') {
         server.instructionOverride = { state: 'upstream' };
+      }
+      if (Array.isArray((edit as { disabledTools?: unknown }).disabledTools)) {
+        disabledTools = (edit as { disabledTools: unknown[] }).disabledTools.filter(
+          (name): name is string => typeof name === 'string',
+        );
+      }
+      if (
+        (edit as { toolDescriptionOverrides?: unknown }).toolDescriptionOverrides &&
+        typeof (edit as { toolDescriptionOverrides?: unknown }).toolDescriptionOverrides === 'object'
+      ) {
+        toolDescriptionOverrides = {
+          ...(edit as { toolDescriptionOverrides: Record<string, string> }).toolDescriptionOverrides,
+        };
       }
       return operationSuccess('applyConfiguredServerEdit', 'op_apply', {
         originalTargetName: input.targetName,
@@ -1452,6 +1507,49 @@ function defaultInstructionVariants(): { initialization: string; cli: string } {
 
 function cloneInstructionState(state: InstructionTemplateAdminState): InstructionTemplateAdminState {
   return structuredClone(state);
+}
+
+function configuredToolInventory(
+  disabledTools: string[],
+  toolDescriptionOverrides: Record<string, string>,
+  model = 'gpt-4o',
+) {
+  const definitions = [
+    { name: 'search', description: 'Search repositories', approximateTokens: 24 },
+    { name: 'issues', description: 'List repository issues', approximateTokens: 20 },
+  ];
+  const rows = definitions.map((tool) => ({
+    name: tool.name,
+    upstreamDescription: tool.description,
+    effectiveDescription: toolDescriptionOverrides[tool.name] ?? tool.description,
+    ...(toolDescriptionOverrides[tool.name] ? { descriptionOverride: toolDescriptionOverrides[tool.name] } : {}),
+    descriptionOverridden: Boolean(toolDescriptionOverrides[tool.name]),
+    enabled: !disabledTools.includes(tool.name),
+    observed: true,
+    unresolved: false,
+    observedInstanceCount: 1,
+    activeInstanceCount: 1,
+    observedInSomeInstances: false,
+    approximateTokens: tool.approximateTokens,
+  }));
+  const enabledTokens = rows.reduce((total, row) => total + (row.enabled ? row.approximateTokens : 0), 0);
+  return {
+    targetName: 'github',
+    source: 'mcpServers' as const,
+    targetEnabled: true,
+    freshness: 'live' as const,
+    model,
+    generation: 'generation-smoke',
+    activeInstanceCount: 1,
+    rows,
+    counts: {
+      observed: rows.length,
+      enabled: rows.filter((row) => row.enabled).length,
+      disabled: rows.filter((row) => !row.enabled).length,
+      unresolved: 0,
+    },
+    approximateTokens: { enabled: enabledTokens, allObserved: 44, savings: 44 - enabledTokens },
+  };
 }
 
 function createFieldGroups() {

--- a/web/admin/src/api/adminApi.ts
+++ b/web/admin/src/api/adminApi.ts
@@ -376,6 +376,36 @@ export interface ConfiguredServerDetailResponse {
   operationId: string;
   server: ConfiguredServerReadModel;
   editContract: ConfiguredServerEditContract;
+  toolInventory?: ConfiguredToolInventory;
+}
+
+export interface ConfiguredToolInventoryRow {
+  name: string;
+  upstreamDescription?: string;
+  effectiveDescription?: string;
+  descriptionOverride?: string;
+  descriptionOverridden: boolean;
+  enabled: boolean;
+  observed: boolean;
+  stale?: boolean;
+  unresolved: boolean;
+  observedInstanceCount: number;
+  activeInstanceCount: number;
+  observedInSomeInstances: boolean;
+  approximateTokens: number;
+}
+
+export interface ConfiguredToolInventory {
+  targetName: string;
+  source: 'mcpServers' | 'mcpTemplates';
+  targetEnabled: boolean;
+  freshness: 'live' | 'unavailable';
+  model: string;
+  generation: string;
+  activeInstanceCount: number;
+  rows: ConfiguredToolInventoryRow[];
+  counts: { observed: number; enabled: number; disabled: number; unresolved: number };
+  approximateTokens: { enabled: number; allObserved: number; savings: number };
 }
 
 export interface ConfiguredServerSecretReplacement {
@@ -397,9 +427,12 @@ export interface ConfiguredServerEditDraft {
   secrets?: ConfiguredServerSecretEditDraft[];
   clearTransportOverrides?: string[];
   instructionOverride?: { action: 'set'; value: string } | { action: 'remove' };
+  disabledTools?: string[];
+  toolDescriptionOverrides?: Record<string, string>;
 }
 
-export type ConfiguredServerPreviewRiskFlag = 'rename' | 'connection_critical' | 'secret' | 'template_risk';
+export type ConfiguredServerPreviewRiskFlag =
+  'rename' | 'connection_critical' | 'secret' | 'template_risk' | 'tool_visibility' | 'tool_metadata';
 
 export type ConfiguredServerConnectivityCheck =
   | {
@@ -471,6 +504,16 @@ export interface ConfiguredServerPreviewResponse {
     }>;
     configChange: ConfiguredServerPreviewConfigChange;
     connectivityCheck: ConfiguredServerConnectivityCheck;
+    toolSelection?: {
+      capabilityGeneration: string;
+      model: string;
+      changedTools: string[];
+      counts: ConfiguredToolInventory['counts'];
+      approximateTokens: { before: number; after: number; savings: number };
+      targetEnabled: boolean;
+      effect: 'immediate' | 'deferred_until_target_enabled';
+      requiresZeroEnabledConfirmation: boolean;
+    };
   };
 }
 
@@ -858,8 +901,10 @@ export function createAdminApi(options: AdminApiOptions = {}) {
 
     getConfiguredServerDetail(
       target: string | ConfiguredServerTargetIdentity,
+      model?: string,
     ): Promise<ConfiguredServerDetailResponse> {
-      return request(configuredServerPath(target));
+      const query = model ? `?model=${encodeURIComponent(model)}` : '';
+      return request(`${configuredServerPath(target)}${query}`);
     },
 
     async listInstructionTemplates(): Promise<AdminInstructionTemplateStore> {
@@ -1025,6 +1070,7 @@ export function createAdminApi(options: AdminApiOptions = {}) {
       csrfToken: string;
       edit: ConfiguredServerEditDraft;
       connectivityCheck?: 'auto' | 'manual';
+      model?: string;
     }): Promise<ConfiguredServerPreviewResponse> {
       return request(`${configuredServerPath(input.target)}/preview`, {
         method: 'POST',
@@ -1034,6 +1080,7 @@ export function createAdminApi(options: AdminApiOptions = {}) {
         body: JSON.stringify({
           edit: input.edit,
           ...(input.connectivityCheck ? { connectivityCheck: input.connectivityCheck } : {}),
+          ...(input.model ? { model: input.model } : {}),
         }),
       });
     },
@@ -1045,6 +1092,7 @@ export function createAdminApi(options: AdminApiOptions = {}) {
       edit: ConfiguredServerEditDraft;
       previewFingerprint: string;
       confirmationFacts: Record<string, unknown>;
+      model?: string;
     }): Promise<ConfiguredServerApplyResponse> {
       return request(`${configuredServerPath(input.target)}/apply`, {
         method: 'POST',
@@ -1056,6 +1104,7 @@ export function createAdminApi(options: AdminApiOptions = {}) {
           edit: input.edit,
           previewFingerprint: input.previewFingerprint,
           confirmationFacts: input.confirmationFacts,
+          ...(input.model ? { model: input.model } : {}),
         }),
       });
     },

--- a/web/admin/src/components/AdminConsoleApp.fixtures.tsx
+++ b/web/admin/src/components/AdminConsoleApp.fixtures.tsx
@@ -69,6 +69,9 @@ function FixtureAdminConsoleApp({ state, overrides }: { state: AdminConsoleState
       editDispatch({ type: 'instructionOverrideChanged', mode, value });
       configuredServers?.changeInstructionOverride?.(mode, value);
     },
+    changeTool: (name, change) => editDispatch({ type: 'toolChanged', name, ...change }),
+    changeVisibleTools: (names, enabled) => editDispatch({ type: 'toolsBulkChanged', names, enabled }),
+    changeToolModel: () => undefined,
     preview: configuredServers?.preview ?? (() => undefined),
     apply: configuredServers?.apply ?? (() => undefined),
   };
@@ -189,6 +192,9 @@ function staticConfiguredServerEditModel(overrides?: ConfiguredServerOverrides):
     changeSecret: () => undefined,
     changeTransportOverride: () => undefined,
     changeInstructionOverride: overrides?.changeInstructionOverride ?? (() => undefined),
+    changeTool: () => undefined,
+    changeVisibleTools: () => undefined,
+    changeToolModel: () => undefined,
     preview: () => undefined,
     apply: overrides?.apply ?? (() => undefined),
   };

--- a/web/admin/src/components/adminConsoleUtils.ts
+++ b/web/admin/src/components/adminConsoleUtils.ts
@@ -120,6 +120,10 @@ export function riskFlagColor(flag: string): string {
       return 'grape';
     case 'template_risk':
       return 'orange';
+    case 'tool_visibility':
+      return 'yellow';
+    case 'tool_metadata':
+      return 'blue';
     default:
       return 'gray';
   }
@@ -135,6 +139,10 @@ export function riskFlagLabel(flag: string): string {
       return 'secret';
     case 'template_risk':
       return 'template risk';
+    case 'tool_visibility':
+      return 'tool visibility';
+    case 'tool_metadata':
+      return 'tool metadata';
     default:
       return flag;
   }

--- a/web/admin/src/components/configuredServerEditor/ConfiguredServerEditor.tsx
+++ b/web/admin/src/components/configuredServerEditor/ConfiguredServerEditor.tsx
@@ -13,6 +13,7 @@ import type { ConfiguredServerEditModel } from '../../configuredServerEdit/useCo
 import { configuredServerApplyEligibility } from '../../configuredServerEdit/useConfiguredServerEdit';
 import { EmptyState, Panel } from '../AdminConsoleShared';
 import { transportSummaryLabel } from '../adminConsoleUtils';
+import { ConfiguredToolTable } from './ConfiguredToolTable';
 import { ConfiguredServerFieldDraft, editGroupHelp, SecretFieldDraft } from './EditControls';
 import { PreviewResult } from './PreviewResult';
 
@@ -227,6 +228,18 @@ export function ConfiguredServerEditor({ model }: { model: ConfiguredServerEditM
             </Stack>
           </Paper>
         ))}
+        {state.detail.toolInventory ? (
+          <Paper className="edit-section" withBorder>
+            <ConfiguredToolTable
+              inventory={state.detail.toolInventory}
+              draft={state.toolDraft}
+              disabled={state.applyBusy}
+              onToolChange={model.changeTool}
+              onBulkChange={model.changeVisibleTools}
+              onModelChange={model.changeToolModel}
+            />
+          </Paper>
+        ) : null}
         {advancedFields.length > 0 ? (
           <details ref={advancedSettingsRef} className="advanced-settings">
             <summary>Advanced settings</summary>

--- a/web/admin/src/components/configuredServerEditor/ConfiguredToolTable.test.tsx
+++ b/web/admin/src/components/configuredServerEditor/ConfiguredToolTable.test.tsx
@@ -103,4 +103,25 @@ describe('ConfiguredToolTable', () => {
     await user.click(screen.getByRole('option', { name: 'gpt-4o-mini', hidden: true }));
     expect(onModelChange).toHaveBeenCalledWith('gpt-4o-mini');
   });
+
+  it('summarizes the current draft selection', () => {
+    render(
+      <MantineProvider>
+        <ConfiguredToolTable
+          inventory={inventory}
+          draft={{
+            common: { enabled: false, descriptionOverride: '' },
+            missing: { enabled: true, descriptionOverride: 'Retained override' },
+          }}
+          disabled={false}
+          onToolChange={vi.fn()}
+          onBulkChange={vi.fn()}
+          onModelChange={vi.fn()}
+        />
+      </MantineProvider>,
+    );
+
+    expect(screen.getByText(/1 observed, 1 disabled, 1 unresolved/)).toBeInTheDocument();
+    expect(screen.getByText(/approximately 0 enabled tokens/)).toBeInTheDocument();
+  });
 });

--- a/web/admin/src/components/configuredServerEditor/ConfiguredToolTable.test.tsx
+++ b/web/admin/src/components/configuredServerEditor/ConfiguredToolTable.test.tsx
@@ -1,0 +1,106 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { vi } from 'vitest';
+
+import type { ConfiguredToolInventory } from '../../api/adminApi';
+import { ConfiguredToolTable } from './ConfiguredToolTable';
+
+const inventory: ConfiguredToolInventory = {
+  targetName: 'project',
+  source: 'mcpTemplates',
+  targetEnabled: true,
+  freshness: 'live',
+  model: 'gpt-4o',
+  generation: 'generation-1',
+  activeInstanceCount: 2,
+  rows: [
+    {
+      name: 'common',
+      upstreamDescription: 'Common upstream',
+      effectiveDescription: 'Common upstream',
+      descriptionOverridden: false,
+      enabled: true,
+      observed: true,
+      unresolved: false,
+      observedInstanceCount: 2,
+      activeInstanceCount: 2,
+      observedInSomeInstances: false,
+      approximateTokens: 21,
+    },
+    {
+      name: 'missing',
+      effectiveDescription: 'Retained override',
+      descriptionOverride: 'Retained override',
+      descriptionOverridden: true,
+      enabled: false,
+      observed: false,
+      unresolved: true,
+      observedInstanceCount: 0,
+      activeInstanceCount: 2,
+      observedInSomeInstances: false,
+      approximateTokens: 0,
+    },
+  ],
+  counts: { observed: 1, enabled: 1, disabled: 1, unresolved: 1 },
+  approximateTokens: { enabled: 21, allObserved: 21, savings: 0 },
+};
+
+describe('ConfiguredToolTable', () => {
+  it('filters rows and scopes bulk selection to visible tools', async () => {
+    const user = userEvent.setup();
+    const onBulkChange = vi.fn();
+    render(
+      <MantineProvider>
+        <ConfiguredToolTable
+          inventory={inventory}
+          draft={{
+            common: { enabled: true, descriptionOverride: '' },
+            missing: { enabled: false, descriptionOverride: 'Retained override' },
+          }}
+          disabled={false}
+          onToolChange={vi.fn()}
+          onBulkChange={onBulkChange}
+          onModelChange={vi.fn()}
+        />
+      </MantineProvider>,
+    );
+
+    await user.click(screen.getByRole('radio', { name: 'Unresolved' }));
+    expect(screen.queryByText('common')).not.toBeInTheDocument();
+    expect(screen.getByText('missing')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Enable visible (1)' }));
+    expect(onBulkChange).toHaveBeenCalledWith(['missing'], true);
+  });
+
+  it('edits selection and resets a description override', async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    const user = userEvent.setup();
+    const onToolChange = vi.fn();
+    const onModelChange = vi.fn();
+    render(
+      <MantineProvider>
+        <ConfiguredToolTable
+          inventory={inventory}
+          draft={{
+            common: { enabled: true, descriptionOverride: '' },
+            missing: { enabled: false, descriptionOverride: 'Retained override' },
+          }}
+          disabled={false}
+          onToolChange={onToolChange}
+          onBulkChange={vi.fn()}
+          onModelChange={onModelChange}
+        />
+      </MantineProvider>,
+    );
+
+    await user.click(screen.getByRole('switch', { name: 'Enable common' }));
+    expect(onToolChange).toHaveBeenCalledWith('common', { enabled: false });
+    await user.click(screen.getByRole('button', { name: 'Reset missing description' }));
+    expect(onToolChange).toHaveBeenCalledWith('missing', { descriptionOverride: '' });
+    await user.click(screen.getByLabelText('Token estimate model'));
+    await user.click(screen.getByRole('option', { name: 'gpt-4o-mini', hidden: true }));
+    expect(onModelChange).toHaveBeenCalledWith('gpt-4o-mini');
+  });
+});

--- a/web/admin/src/components/configuredServerEditor/ConfiguredToolTable.tsx
+++ b/web/admin/src/components/configuredServerEditor/ConfiguredToolTable.tsx
@@ -1,0 +1,199 @@
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  SegmentedControl,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+
+import { RotateCcw, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import type { ConfiguredToolInventory } from '../../api/adminApi';
+
+type ToolDraft = Record<string, { enabled: boolean; descriptionOverride: string }>;
+type ToolFilter = 'all' | 'enabled' | 'disabled' | 'unresolved';
+
+export function ConfiguredToolTable({
+  inventory,
+  draft,
+  disabled,
+  onToolChange,
+  onBulkChange,
+  onModelChange,
+}: {
+  inventory: ConfiguredToolInventory;
+  draft: ToolDraft;
+  disabled: boolean;
+  onToolChange(name: string, change: { enabled?: boolean; descriptionOverride?: string }): void;
+  onBulkChange(names: string[], enabled: boolean): void;
+  onModelChange(model: string): void | Promise<void>;
+}) {
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<ToolFilter>('all');
+  const visibleRows = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return inventory.rows.filter((row) => {
+      const rowDraft = draft[row.name] ?? { enabled: row.enabled, descriptionOverride: row.descriptionOverride ?? '' };
+      const matchesQuery =
+        !normalizedQuery ||
+        row.name.toLowerCase().includes(normalizedQuery) ||
+        row.effectiveDescription?.toLowerCase().includes(normalizedQuery) ||
+        row.upstreamDescription?.toLowerCase().includes(normalizedQuery);
+      const matchesFilter =
+        filter === 'all' ||
+        (filter === 'enabled' && rowDraft.enabled) ||
+        (filter === 'disabled' && !rowDraft.enabled) ||
+        (filter === 'unresolved' && row.unresolved);
+      return matchesQuery && matchesFilter;
+    });
+  }, [draft, filter, inventory.rows, query]);
+  const visibleNames = visibleRows.map((row) => row.name);
+
+  return (
+    <Stack className="configured-tool-table" gap="sm">
+      <Group justify="space-between" align="flex-end">
+        <div>
+          <Text fw={800}>Configured Tool Selection</Text>
+          <Text c="dimmed" size="xs">
+            {inventory.counts.observed} observed, {inventory.counts.disabled} disabled, {inventory.counts.unresolved}{' '}
+            unresolved
+          </Text>
+          {inventory.freshness === 'unavailable' ? (
+            <Text c="yellow" size="xs">
+              Live inventory is unavailable. Rows may come from the last complete snapshot or stored configuration.
+            </Text>
+          ) : null}
+        </div>
+        <Select
+          label="Estimate model"
+          aria-label="Token estimate model"
+          value={inventory.model}
+          data={['gpt-4o', 'gpt-4o-mini', 'gpt-3.5-turbo']}
+          allowDeselect={false}
+          disabled={disabled}
+          onChange={(value) => {
+            if (value) void onModelChange(value);
+          }}
+        />
+      </Group>
+      <Group align="flex-end" grow>
+        <TextInput
+          label="Search tools"
+          leftSection={<Search size={15} />}
+          value={query}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+        />
+        <SegmentedControl
+          aria-label="Tool status filter"
+          value={filter}
+          onChange={(value) => setFilter(value as ToolFilter)}
+          data={[
+            { label: 'All', value: 'all' },
+            { label: 'Enabled', value: 'enabled' },
+            { label: 'Disabled', value: 'disabled' },
+            { label: 'Unresolved', value: 'unresolved' },
+          ]}
+        />
+      </Group>
+      <Group justify="space-between">
+        <Text c="dimmed" size="xs">
+          {visibleRows.length} visible tools, approximately {inventory.approximateTokens.enabled} enabled tokens
+        </Text>
+        <Group gap="xs">
+          <Button
+            size="compact-xs"
+            variant="default"
+            disabled={disabled || visibleNames.length === 0}
+            onClick={() => onBulkChange(visibleNames, true)}
+          >
+            Enable visible ({visibleNames.length})
+          </Button>
+          <Button
+            size="compact-xs"
+            variant="default"
+            disabled={disabled || visibleNames.length === 0}
+            onClick={() => onBulkChange(visibleNames, false)}
+          >
+            Disable visible ({visibleNames.length})
+          </Button>
+        </Group>
+      </Group>
+      <div className="configured-tool-rows">
+        {visibleRows.map((row) => {
+          const rowDraft = draft[row.name] ?? {
+            enabled: row.enabled,
+            descriptionOverride: row.descriptionOverride ?? '',
+          };
+          return (
+            <div className="configured-tool-row" key={row.name}>
+              <Group justify="space-between" align="flex-start" wrap="nowrap">
+                <div className="configured-tool-identity">
+                  <Group gap="xs">
+                    <Text fw={700}>{row.name}</Text>
+                    {row.stale ? <Badge color="orange">last observed</Badge> : null}
+                    {row.unresolved ? <Badge color="yellow">unresolved</Badge> : null}
+                    {row.observedInSomeInstances ? (
+                      <Badge variant="outline">
+                        {row.observedInstanceCount}/{row.activeInstanceCount} instances
+                      </Badge>
+                    ) : null}
+                    <Badge variant="outline">~{row.approximateTokens} tokens</Badge>
+                  </Group>
+                  <Text c="dimmed" size="xs">
+                    {row.effectiveDescription ?? 'No upstream description'}
+                  </Text>
+                  {row.descriptionOverridden && row.upstreamDescription ? (
+                    <Text c="dimmed" size="xs">
+                      Upstream: {row.upstreamDescription}
+                    </Text>
+                  ) : null}
+                </div>
+                <Switch
+                  aria-label={`Enable ${row.name}`}
+                  checked={rowDraft.enabled}
+                  disabled={disabled}
+                  onChange={(event) => onToolChange(row.name, { enabled: event.currentTarget.checked })}
+                />
+              </Group>
+              <Group mt="xs" align="flex-end" wrap="nowrap">
+                <TextInput
+                  className="configured-tool-description-input"
+                  label="Description override"
+                  placeholder={row.upstreamDescription ?? 'Add a description'}
+                  value={rowDraft.descriptionOverride}
+                  disabled={disabled}
+                  onChange={(event) => onToolChange(row.name, { descriptionOverride: event.currentTarget.value })}
+                />
+                <Tooltip label="Reset to upstream description">
+                  <ActionIcon
+                    aria-label={`Reset ${row.name} description`}
+                    variant="default"
+                    disabled={disabled || !rowDraft.descriptionOverride}
+                    onClick={() => onToolChange(row.name, { descriptionOverride: '' })}
+                  >
+                    <RotateCcw size={16} />
+                  </ActionIcon>
+                </Tooltip>
+              </Group>
+            </div>
+          );
+        })}
+      </div>
+      {inventory.targetEnabled ? null : (
+        <Text c="yellow" size="xs">
+          This target is disabled. Tool changes will take effect when the target is enabled.
+        </Text>
+      )}
+      <Text c="dimmed" size="xs">
+        Selection uses a denylist. Tools discovered later are enabled unless explicitly disabled.
+      </Text>
+    </Stack>
+  );
+}

--- a/web/admin/src/components/configuredServerEditor/ConfiguredToolTable.tsx
+++ b/web/admin/src/components/configuredServerEditor/ConfiguredToolTable.tsx
@@ -55,6 +55,20 @@ export function ConfiguredToolTable({
     });
   }, [draft, filter, inventory.rows, query]);
   const visibleNames = visibleRows.map((row) => row.name);
+  const modelOptions = useMemo(
+    () => Array.from(new Set(['gpt-4o', 'gpt-4o-mini', 'gpt-3.5-turbo', inventory.model].filter(Boolean))),
+    [inventory.model],
+  );
+  const draftSummary = useMemo(() => {
+    let disabledCount = 0;
+    let enabledTokens = 0;
+    for (const row of inventory.rows) {
+      const enabled = draft[row.name]?.enabled ?? row.enabled;
+      if (enabled) enabledTokens += row.approximateTokens;
+      else disabledCount += 1;
+    }
+    return { disabled: disabledCount, enabledTokens };
+  }, [draft, inventory.rows]);
 
   return (
     <Stack className="configured-tool-table" gap="sm">
@@ -62,7 +76,7 @@ export function ConfiguredToolTable({
         <div>
           <Text fw={800}>Configured Tool Selection</Text>
           <Text c="dimmed" size="xs">
-            {inventory.counts.observed} observed, {inventory.counts.disabled} disabled, {inventory.counts.unresolved}{' '}
+            {inventory.counts.observed} observed, {draftSummary.disabled} disabled, {inventory.counts.unresolved}{' '}
             unresolved
           </Text>
           {inventory.freshness === 'unavailable' ? (
@@ -75,7 +89,7 @@ export function ConfiguredToolTable({
           label="Estimate model"
           aria-label="Token estimate model"
           value={inventory.model}
-          data={['gpt-4o', 'gpt-4o-mini', 'gpt-3.5-turbo']}
+          data={modelOptions}
           allowDeselect={false}
           disabled={disabled}
           onChange={(value) => {
@@ -104,7 +118,7 @@ export function ConfiguredToolTable({
       </Group>
       <Group justify="space-between">
         <Text c="dimmed" size="xs">
-          {visibleRows.length} visible tools, approximately {inventory.approximateTokens.enabled} enabled tokens
+          {visibleRows.length} visible tools, approximately {draftSummary.enabledTokens} enabled tokens
         </Text>
         <Group gap="xs">
           <Button

--- a/web/admin/src/components/configuredServerEditor/PreviewResult.tsx
+++ b/web/admin/src/components/configuredServerEditor/PreviewResult.tsx
@@ -85,6 +85,34 @@ export function PreviewResult({
             </Stack>
           </Paper>
         </SimpleGrid>
+        {preview.toolSelection ? (
+          <Stack gap="xs">
+            <Group gap="xs">
+              <Text fw={800}>Tool impact</Text>
+              <Badge variant="outline">{preview.toolSelection.model}</Badge>
+            </Group>
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="xs">
+              <DetailRow
+                label="Selection"
+                value={`${preview.toolSelection.counts.enabled} enabled / ${preview.toolSelection.counts.disabled} disabled`}
+                meta={`${preview.toolSelection.counts.unresolved} unresolved`}
+              />
+              <DetailRow
+                label="Approximate tokens"
+                value={`${preview.toolSelection.approximateTokens.before} to ${preview.toolSelection.approximateTokens.after}`}
+                meta={`Savings: ${preview.toolSelection.approximateTokens.savings}`}
+              />
+              <DetailRow
+                label="Runtime effect"
+                value={preview.toolSelection.effect === 'immediate' ? 'Immediate' : 'Deferred'}
+                meta={`${preview.toolSelection.changedTools.length} changed tools`}
+              />
+            </SimpleGrid>
+            {preview.toolSelection.requiresZeroEnabledConfirmation ? (
+              <Alert color="red">Applying this preview disables every currently observed tool.</Alert>
+            ) : null}
+          </Stack>
+        ) : null}
         {preview.configChange.warnings?.map((warning) => (
           <DetailRow key={`warning:${warning}`} label="Warning" value={warning} />
         ))}

--- a/web/admin/src/components/configuredServerEditor/PreviewResult.tsx
+++ b/web/admin/src/components/configuredServerEditor/PreviewResult.tsx
@@ -109,7 +109,9 @@ export function PreviewResult({
               />
             </SimpleGrid>
             {preview.toolSelection.requiresZeroEnabledConfirmation ? (
-              <Alert color="red">Applying this preview disables every currently observed tool.</Alert>
+              <Alert color="red" role="alert">
+                Applying this preview disables every currently observed tool.
+              </Alert>
             ) : null}
           </Stack>
         ) : null}

--- a/web/admin/src/configuredServerEdit/configuredServerEditState.test.ts
+++ b/web/admin/src/configuredServerEdit/configuredServerEditState.test.ts
@@ -12,6 +12,21 @@ function detail() {
   return state.detail;
 }
 
+function toolInventoryRow(name: string) {
+  return {
+    name,
+    effectiveDescription: `${name} upstream`,
+    descriptionOverridden: false,
+    enabled: true,
+    observed: true,
+    unresolved: false,
+    observedInstanceCount: 1,
+    activeInstanceCount: 1,
+    observedInSomeInstances: false,
+    approximateTokens: 10,
+  };
+}
+
 describe('configured server edit state', () => {
   it('initializes a loaded contract without a dirty draft', () => {
     const state = reduceConfiguredServerEditState(createConfiguredServerEditState(), {
@@ -26,6 +41,113 @@ describe('configured server edit state', () => {
     expect(state.fieldDraft['transport\0url']).toBe('https://example.com/mcp?token=REDACTED');
     expect(state.secretDraft['url\0query\0token']).toMatchObject({ action: 'preserve' });
     expect(configuredServerEditDraft(state)).toEqual({});
+  });
+
+  it('serializes complete configured-tool selection and description overrides', () => {
+    const toolDetail = detail();
+    toolDetail.toolInventory = {
+      targetName: 'github',
+      source: 'mcpServers',
+      targetEnabled: true,
+      freshness: 'live',
+      model: 'gpt-4o',
+      generation: 'generation-1',
+      activeInstanceCount: 1,
+      rows: [
+        {
+          name: 'read',
+          effectiveDescription: 'Read upstream',
+          descriptionOverridden: false,
+          enabled: true,
+          observed: true,
+          unresolved: false,
+          observedInstanceCount: 1,
+          activeInstanceCount: 1,
+          observedInSomeInstances: false,
+          approximateTokens: 10,
+        },
+        {
+          name: 'write',
+          effectiveDescription: 'Write safely',
+          descriptionOverride: 'Write safely',
+          descriptionOverridden: true,
+          enabled: false,
+          observed: true,
+          unresolved: false,
+          observedInstanceCount: 1,
+          activeInstanceCount: 1,
+          observedInSomeInstances: false,
+          approximateTokens: 12,
+        },
+      ],
+      counts: { observed: 2, enabled: 1, disabled: 1, unresolved: 0 },
+      approximateTokens: { enabled: 10, allObserved: 22, savings: 12 },
+    };
+    let state = reduceConfiguredServerEditState(createConfiguredServerEditState(), {
+      type: 'detailLoaded',
+      serverId: 'github',
+      detail: toolDetail,
+    });
+    state = reduceConfiguredServerEditState(state, {
+      type: 'toolChanged',
+      name: 'read',
+      enabled: false,
+      descriptionOverride: 'Read safely',
+    });
+    state = reduceConfiguredServerEditState(state, {
+      type: 'toolChanged',
+      name: 'write',
+      enabled: true,
+      descriptionOverride: '',
+    });
+
+    expect(configuredServerEditDraft(state)).toEqual({
+      disabledTools: ['read'],
+      toolDescriptionOverrides: { read: 'Read safely' },
+    });
+  });
+
+  it('preserves unsaved tool edits and adds newly observed rows after recalculation', () => {
+    const toolDetail = detail();
+    toolDetail.toolInventory = {
+      targetName: 'github',
+      source: 'mcpServers',
+      targetEnabled: true,
+      freshness: 'live',
+      model: 'gpt-4o',
+      generation: 'generation-1',
+      activeInstanceCount: 1,
+      rows: [toolInventoryRow('search')],
+      counts: { observed: 1, enabled: 1, disabled: 0, unresolved: 0 },
+      approximateTokens: { enabled: 10, allObserved: 10, savings: 0 },
+    };
+    let state = reduceConfiguredServerEditState(createConfiguredServerEditState(), {
+      type: 'detailLoaded',
+      serverId: 'github',
+      detail: toolDetail,
+    });
+    state = reduceConfiguredServerEditState(state, {
+      type: 'toolChanged',
+      name: 'search',
+      descriptionOverride: 'Search safely',
+    });
+    state = reduceConfiguredServerEditState(state, {
+      type: 'toolInventoryRecalculated',
+      inventory: {
+        ...toolDetail.toolInventory,
+        model: 'gpt-4o-mini',
+        generation: 'generation-2',
+        rows: [toolInventoryRow('search'), toolInventoryRow('issues')],
+        counts: { observed: 2, enabled: 2, disabled: 0, unresolved: 0 },
+        approximateTokens: { enabled: 20, allObserved: 20, savings: 0 },
+      },
+    });
+    state = reduceConfiguredServerEditState(state, { type: 'toolChanged', name: 'issues', enabled: false });
+
+    expect(configuredServerEditDraft(state)).toEqual({
+      disabledTools: ['issues'],
+      toolDescriptionOverrides: { search: 'Search safely' },
+    });
   });
 
   it('owns normalized field and secret draft construction', () => {

--- a/web/admin/src/configuredServerEdit/configuredServerEditState.ts
+++ b/web/admin/src/configuredServerEdit/configuredServerEditState.ts
@@ -23,6 +23,9 @@ interface LoadedConfiguredServerEditState {
   clearedTransportOverrides: string[];
   instructionOverride: { mode: 'upstream' | 'replace' | 'suppress'; value: string };
   initialInstructionOverride: { mode: 'upstream' | 'replace' | 'suppress'; value: string };
+  toolDraft: Record<string, { enabled: boolean; descriptionOverride: string }>;
+  initialToolDraft: Record<string, { enabled: boolean; descriptionOverride: string }>;
+  toolModel: string;
   dirty: boolean;
   preview?: ConfiguredServerPreviewResponse['preview'];
   previewBusy: boolean;
@@ -52,6 +55,9 @@ export type ConfiguredServerEditAction =
   | { type: 'secretChanged'; fieldPath: string[]; value: SecretDraftState[string] }
   | { type: 'transportOverrideChanged'; key: string; clear: boolean }
   | { type: 'instructionOverrideChanged'; mode: 'upstream' | 'replace' | 'suppress'; value?: string }
+  | { type: 'toolChanged'; name: string; enabled?: boolean; descriptionOverride?: string }
+  | { type: 'toolsBulkChanged'; names: string[]; enabled: boolean }
+  | { type: 'toolInventoryRecalculated'; inventory: NonNullable<ConfiguredServerDetailResponse['toolInventory']> }
   | { type: 'previewStarted' }
   | { type: 'previewSucceeded'; preview: ConfiguredServerPreviewResponse['preview'] }
   | { type: 'previewFailed'; message: string }
@@ -88,6 +94,19 @@ export function configuredServerEditDraft(state: ConfiguredServerEditState): Con
       current.mode === 'upstream'
         ? { action: 'remove' }
         : { action: 'set', value: current.mode === 'suppress' ? '' : current.value };
+  }
+
+  if (JSON.stringify(state.toolDraft) !== JSON.stringify(state.initialToolDraft)) {
+    edit.disabledTools = Object.entries(state.toolDraft)
+      .filter(([, draft]) => !draft.enabled)
+      .map(([name]) => name)
+      .sort((left, right) => left.localeCompare(right));
+    edit.toolDescriptionOverrides = Object.fromEntries(
+      Object.entries(state.toolDraft)
+        .map(([name, draft]) => [name, draft.descriptionOverride.trim()] as const)
+        .filter(([, description]) => description.length > 0)
+        .sort(([left], [right]) => left.localeCompare(right)),
+    );
   }
   return edit;
 }
@@ -144,6 +163,60 @@ export function reduceConfiguredServerEditState(
               : state.instructionOverride.value,
         },
       });
+    case 'toolChanged': {
+      if (state.status !== 'loaded' || state.applyBusy) return state;
+      const current = state.toolDraft[action.name];
+      if (!current) return state;
+      return withDraftChange(state, {
+        toolDraft: {
+          ...state.toolDraft,
+          [action.name]: {
+            enabled: action.enabled ?? current.enabled,
+            descriptionOverride: action.descriptionOverride ?? current.descriptionOverride,
+          },
+        },
+      });
+    }
+    case 'toolsBulkChanged':
+      if (state.status !== 'loaded' || state.applyBusy) return state;
+      return withDraftChange(state, {
+        toolDraft: Object.fromEntries(
+          Object.entries(state.toolDraft).map(([name, draft]) => [
+            name,
+            action.names.includes(name) ? { ...draft, enabled: action.enabled } : draft,
+          ]),
+        ),
+      });
+    case 'toolInventoryRecalculated': {
+      if (state.status !== 'loaded' || state.applyBusy) return state;
+      const toolDraft = Object.fromEntries(
+        action.inventory.rows.map((row) => [
+          row.name,
+          state.toolDraft[row.name] ?? {
+            enabled: row.enabled,
+            descriptionOverride: row.descriptionOverride ?? '',
+          },
+        ]),
+      );
+      const initialToolDraft = Object.fromEntries(
+        action.inventory.rows.map((row) => [
+          row.name,
+          state.initialToolDraft[row.name] ?? {
+            enabled: row.enabled,
+            descriptionOverride: row.descriptionOverride ?? '',
+          },
+        ]),
+      );
+      return withDraftChange(
+        {
+          ...state,
+          detail: { ...state.detail, toolInventory: action.inventory },
+          toolModel: action.inventory.model,
+          initialToolDraft,
+        },
+        { toolDraft },
+      );
+    }
     case 'previewStarted':
       if (state.status !== 'loaded') return state;
       return { ...state, previewBusy: true, previewError: undefined };
@@ -210,6 +283,12 @@ function loadedState(serverId: string, detail: ConfiguredServerDetailResponse): 
       }
     }
   }
+  const toolDraft = Object.fromEntries(
+    (detail.toolInventory?.rows ?? []).map((row) => [
+      row.name,
+      { enabled: row.enabled, descriptionOverride: row.descriptionOverride ?? '' },
+    ]),
+  );
   return {
     status: 'loaded',
     serverId,
@@ -220,6 +299,9 @@ function loadedState(serverId: string, detail: ConfiguredServerDetailResponse): 
     clearedTransportOverrides: [],
     instructionOverride: instructionOverrideDraft(detail.server.instructionOverride),
     initialInstructionOverride: instructionOverrideDraft(detail.server.instructionOverride),
+    toolDraft,
+    initialToolDraft: toolDraft,
+    toolModel: detail.toolInventory?.model ?? 'gpt-4o',
     dirty: false,
     previewBusy: false,
     applyBusy: false,
@@ -231,7 +313,11 @@ function withDraftChange(
   change: Partial<
     Pick<
       LoadedConfiguredServerEditState,
-      'fieldDraft' | 'secretDraft' | 'clearedTransportOverrides' | 'instructionOverride'
+      | 'fieldDraft'
+      | 'secretDraft'
+      | 'clearedTransportOverrides'
+      | 'instructionOverride'
+      | 'toolDraft'
     >
   >,
 ): LoadedConfiguredServerEditState {

--- a/web/admin/src/configuredServerEdit/useConfiguredServerEdit.test.tsx
+++ b/web/admin/src/configuredServerEdit/useConfiguredServerEdit.test.tsx
@@ -212,6 +212,48 @@ describe('useConfiguredServerEdit', () => {
     expect(result.current.state).toMatchObject({ status: 'loaded', serverId: 'slack' });
   });
 
+  it('ignores stale token-model recalculations that resolve out of order', async () => {
+    const slower = deferred<ConfiguredServerDetailResponse>();
+    const newer = deferred<ConfiguredServerDetailResponse>();
+    const initial = detail();
+    initial.toolInventory = {
+      targetName: 'github',
+      source: 'mcpServers',
+      targetEnabled: true,
+      freshness: 'live',
+      model: 'gpt-4o',
+      generation: 'generation-1',
+      activeInstanceCount: 1,
+      rows: [],
+      counts: { observed: 0, enabled: 0, disabled: 0, unresolved: 0 },
+      approximateTokens: { enabled: 0, allObserved: 0, savings: 0 },
+    };
+    const withModel = (model: string): ConfiguredServerDetailResponse => ({
+      ...initial,
+      toolInventory: { ...initial.toolInventory!, model },
+    });
+    const adminApi = api({
+      getConfiguredServerDetail: vi.fn((_serverId: string, model?: string) => {
+        if (!model) return Promise.resolve(initial);
+        return model === 'gpt-4o-mini' ? slower.promise : newer.promise;
+      }),
+    });
+    const browserAdapter = browser('/admin/servers/github');
+    const { result } = renderHook(() =>
+      useConfiguredServerEdit({ api: adminApi, session, browser: browserAdapter.adapter, onUnauthenticated: vi.fn() }),
+    );
+    await waitFor(() => expect(result.current.state.status).toBe('loaded'));
+
+    act(() => void result.current.changeToolModel('gpt-4o-mini'));
+    act(() => void result.current.changeToolModel('gpt-3.5-turbo'));
+    newer.resolve(withModel('gpt-3.5-turbo'));
+    await waitFor(() => expect(result.current.state).toMatchObject({ status: 'loaded', toolModel: 'gpt-3.5-turbo' }));
+    slower.resolve(withModel('gpt-4o-mini'));
+    await act(async () => undefined);
+
+    expect(result.current.state).toMatchObject({ status: 'loaded', toolModel: 'gpt-3.5-turbo' });
+  });
+
   it('restores the current edit URL without adding history when dirty navigation is canceled', async () => {
     const browserAdapter = browser('/admin/servers/github');
     browserAdapter.adapter.confirm = vi.fn(async () => false);
@@ -445,6 +487,71 @@ describe('useConfiguredServerEdit', () => {
           connectionCriticalConfirmed: true,
           connectivityFailureOverrideConfirmed: true,
         }),
+      }),
+    );
+  });
+
+  it('requires a danger confirmation and sends the zero-tool confirmation fact', async () => {
+    const browserAdapter = browser('/admin/servers/github');
+    const loadedDetail = detail();
+    loadedDetail.editContract.capabilities.apply.supported = true;
+    loadedDetail.toolInventory = {
+      targetName: 'github',
+      source: 'mcpServers',
+      targetEnabled: true,
+      freshness: 'live',
+      model: 'gpt-4o',
+      generation: 'generation-1',
+      activeInstanceCount: 1,
+      rows: [
+        {
+          name: 'search',
+          effectiveDescription: 'Search',
+          descriptionOverridden: false,
+          enabled: true,
+          observed: true,
+          unresolved: false,
+          observedInstanceCount: 1,
+          activeInstanceCount: 1,
+          observedInSomeInstances: false,
+          approximateTokens: 25,
+        },
+      ],
+      counts: { observed: 1, enabled: 1, disabled: 0, unresolved: 0 },
+      approximateTokens: { enabled: 25, allObserved: 25, savings: 0 },
+    };
+    const zeroPreview = applyPreview();
+    zeroPreview.preview.toolSelection = {
+      capabilityGeneration: 'generation-1',
+      model: 'gpt-4o',
+      targetEnabled: true,
+      changedTools: ['search'],
+      counts: { observed: 1, enabled: 0, disabled: 1, unresolved: 0 },
+      approximateTokens: { before: 25, after: 0, savings: 25 },
+      effect: 'immediate',
+      requiresZeroEnabledConfirmation: true,
+    };
+    const adminApi = api({
+      getConfiguredServerDetail: vi.fn(async () => loadedDetail),
+      previewConfiguredServerEdit: vi.fn(async () => zeroPreview),
+      applyConfiguredServerEdit: vi.fn(async () => applyResponse()),
+    });
+    const { result } = renderHook(() =>
+      useConfiguredServerEdit({ api: adminApi, session, browser: browserAdapter.adapter, onUnauthenticated: vi.fn() }),
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('loaded'));
+    act(() => result.current.changeTool('search', { enabled: false }));
+    await act(() => result.current.preview());
+    await act(() => result.current.apply());
+
+    expect(browserAdapter.adapter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: 'danger', confirmLabel: 'Disable all tools' }),
+    );
+    expect(adminApi.applyConfiguredServerEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gpt-4o',
+        confirmationFacts: expect.objectContaining({ zeroEnabledToolsConfirmed: true }),
       }),
     );
   });

--- a/web/admin/src/configuredServerEdit/useConfiguredServerEdit.ts
+++ b/web/admin/src/configuredServerEdit/useConfiguredServerEdit.ts
@@ -28,6 +28,9 @@ export interface ConfiguredServerEditModel {
   changeSecret(fieldPath: string[], value: SecretDraftState[string]): void;
   changeTransportOverride(key: string, clear: boolean): void;
   changeInstructionOverride(mode: 'upstream' | 'replace' | 'suppress', value?: string): void;
+  changeTool(name: string, change: { enabled?: boolean; descriptionOverride?: string }): void;
+  changeVisibleTools(names: string[], enabled: boolean): void;
+  changeToolModel(model: string): void | Promise<void>;
   preview(connectivityCheck?: 'auto' | 'manual'): void | Promise<void>;
   apply(): void | Promise<void>;
 }
@@ -52,6 +55,7 @@ export function useConfiguredServerEdit({
   const sessionRef = useRef(session);
   const apiRef = useRef(api);
   const onUnauthenticatedRef = useRef(onUnauthenticated);
+  const toolModelRequestRef = useRef(0);
   stateRef.current = state;
   sessionRef.current = session;
   apiRef.current = api;
@@ -168,6 +172,49 @@ export function useConfiguredServerEdit({
     [invalidatePreview],
   );
 
+  const changeTool = useCallback(
+    (name: string, change: { enabled?: boolean; descriptionOverride?: string }) => {
+      invalidatePreview();
+      dispatch({ type: 'toolChanged', name, ...change });
+    },
+    [invalidatePreview],
+  );
+
+  const changeVisibleTools = useCallback(
+    (names: string[], enabled: boolean) => {
+      invalidatePreview();
+      dispatch({ type: 'toolsBulkChanged', names, enabled });
+    },
+    [invalidatePreview],
+  );
+
+  const changeToolModel = useCallback(
+    async (model: string) => {
+      const current = stateRef.current;
+      if (current.status !== 'loaded' || current.applyBusy || model === current.toolModel) return;
+      const requestId = toolModelRequestRef.current + 1;
+      toolModelRequestRef.current = requestId;
+      invalidatePreview();
+      try {
+        const detail = await apiRef.current.getConfiguredServerDetail(current.serverId, model);
+        if (
+          requestId !== toolModelRequestRef.current ||
+          stateRef.current.status !== 'loaded' ||
+          stateRef.current.serverId !== current.serverId
+        ) {
+          return;
+        }
+        if (detail.toolInventory) dispatch({ type: 'toolInventoryRecalculated', inventory: detail.toolInventory });
+      } catch (error) {
+        if (requestId !== toolModelRequestRef.current) return;
+        if (!handleUnauthenticated(error)) {
+          dispatch({ type: 'previewFailed', message: `Token estimate failed: ${failureMessage(error)}` });
+        }
+      }
+    },
+    [handleUnauthenticated, invalidatePreview],
+  );
+
   const preview = useCallback(
     async (connectivityCheck: 'auto' | 'manual' = 'auto') => {
       const activeSession = sessionRef.current;
@@ -183,6 +230,7 @@ export function useConfiguredServerEdit({
           target: configuredServerTarget(current),
           csrfToken: sessionKey,
           connectivityCheck,
+          ...(current.detail.toolInventory ? { model: current.toolModel } : {}),
           edit: configuredServerEditDraft(current),
         });
         if (requestId !== previewRequestRef.current || sessionRef.current?.csrfToken !== sessionKey) return;
@@ -214,15 +262,24 @@ export function useConfiguredServerEdit({
       const previewResult = current.preview;
       const riskFlags = Array.from(new Set(previewResult.diff.flatMap((entry) => entry.riskFlags)));
       const overridingConnectivityFailure = previewResult.connectivityCheck.status === 'failed';
+      const disablingAllTools = previewResult.toolSelection?.requiresZeroEnabledConfirmation === true;
       const confirmed = await browser.confirm({
-        title: overridingConnectivityFailure
-          ? `Apply despite failed connectivity to ${previewResult.proposedTargetName}?`
-          : `Apply changes to ${previewResult.proposedTargetName}?`,
-        message: overridingConnectivityFailure
-          ? 'The bounded connectivity check failed. Applying may make this configured server unavailable.'
-          : 'This writes the validated configuration and reloads the Runtime Scope.',
-        confirmLabel: overridingConnectivityFailure ? 'Apply despite failure' : 'Apply changes',
-        tone: overridingConnectivityFailure ? 'danger' : undefined,
+        title: disablingAllTools
+          ? `Disable all observed tools for ${previewResult.proposedTargetName}?`
+          : overridingConnectivityFailure
+            ? `Apply despite failed connectivity to ${previewResult.proposedTargetName}?`
+            : `Apply changes to ${previewResult.proposedTargetName}?`,
+        message: disablingAllTools
+          ? 'No currently observed tools will remain enabled. Newly discovered tools will still be enabled by default.'
+          : overridingConnectivityFailure
+            ? 'The bounded connectivity check failed. Applying may make this configured server unavailable.'
+            : 'This writes the validated configuration and reloads the Runtime Scope.',
+        confirmLabel: disablingAllTools
+          ? 'Disable all tools'
+          : overridingConnectivityFailure
+            ? 'Apply despite failure'
+            : 'Apply changes',
+        tone: disablingAllTools || overridingConnectivityFailure ? 'danger' : undefined,
         details: [
           { label: 'Current target', value: previewResult.targetName },
           { label: 'Final target', value: previewResult.proposedTargetName },
@@ -255,6 +312,7 @@ export function useConfiguredServerEdit({
           idempotencyKey: attempt.idempotencyKey,
           edit: configuredServerEditDraft(current),
           previewFingerprint: previewResult.previewFingerprint,
+          ...(current.detail.toolInventory ? { model: current.toolModel } : {}),
           confirmationFacts: {
             previewConfirmed: previewResult.previewFingerprint,
             ...(previewResult.proposedTargetName !== previewResult.targetName
@@ -263,6 +321,9 @@ export function useConfiguredServerEdit({
             ...(riskFlags.includes('connection_critical') ? { connectionCriticalConfirmed: true } : {}),
             ...(riskFlags.includes('secret') ? { secretChangeConfirmed: true } : {}),
             ...(overridingConnectivityFailure ? { connectivityFailureOverrideConfirmed: true } : {}),
+            ...(previewResult.toolSelection?.requiresZeroEnabledConfirmation
+              ? { zeroEnabledToolsConfirmed: true }
+              : {}),
           },
         });
       } catch (error) {
@@ -351,6 +412,9 @@ export function useConfiguredServerEdit({
     changeSecret,
     changeTransportOverride,
     changeInstructionOverride,
+    changeTool,
+    changeVisibleTools,
+    changeToolModel,
     preview,
     apply,
   };

--- a/web/admin/src/configuredServerEdit/useConfiguredServerEdit.ts
+++ b/web/admin/src/configuredServerEdit/useConfiguredServerEdit.ts
@@ -192,6 +192,9 @@ export function useConfiguredServerEdit({
     async (model: string) => {
       const current = stateRef.current;
       if (current.status !== 'loaded' || current.applyBusy || model === current.toolModel) return;
+      const activeSession = sessionRef.current;
+      if (!activeSession) return;
+      const sessionKey = activeSession.csrfToken;
       const requestId = toolModelRequestRef.current + 1;
       toolModelRequestRef.current = requestId;
       invalidatePreview();
@@ -199,6 +202,7 @@ export function useConfiguredServerEdit({
         const detail = await apiRef.current.getConfiguredServerDetail(current.serverId, model);
         if (
           requestId !== toolModelRequestRef.current ||
+          sessionRef.current?.csrfToken !== sessionKey ||
           stateRef.current.status !== 'loaded' ||
           stateRef.current.serverId !== current.serverId
         ) {
@@ -206,7 +210,7 @@ export function useConfiguredServerEdit({
         }
         if (detail.toolInventory) dispatch({ type: 'toolInventoryRecalculated', inventory: detail.toolInventory });
       } catch (error) {
-        if (requestId !== toolModelRequestRef.current) return;
+        if (requestId !== toolModelRequestRef.current || sessionRef.current?.csrfToken !== sessionKey) return;
         if (!handleUnauthenticated(error)) {
           dispatch({ type: 'previewFailed', message: `Token estimate failed: ${failureMessage(error)}` });
         }

--- a/web/admin/src/styles.css
+++ b/web/admin/src/styles.css
@@ -1320,6 +1320,41 @@ input {
   font-weight: 700;
 }
 
+.configured-tool-table {
+  container-type: inline-size;
+}
+
+.configured-tool-rows {
+  border-top: 1px solid var(--admin-line);
+}
+
+.configured-tool-row {
+  min-width: 0;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--admin-line);
+}
+
+.configured-tool-identity,
+.configured-tool-description-input {
+  min-width: 0;
+  flex: 1;
+}
+
+.configured-tool-identity .mantine-Text-root {
+  overflow-wrap: anywhere;
+}
+
+@container (max-width: 620px) {
+  .configured-tool-table > .mantine-Group-root {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .configured-tool-table .mantine-SegmentedControl-root {
+    width: 100%;
+  }
+}
+
 @container (max-width: 520px) {
   .preset-tag-header,
   .preset-impact-header {


### PR DESCRIPTION
## Summary

- add per-server effective tool description overrides across MCP, REST, inspect, lazy/meta discovery, static servers, and templates
- add Admin configured-tool inventory, filtering, token estimates, preview/apply, stale-generation protection, and zero-enabled confirmation
- preserve complete paginated snapshots for disabled and template targets, with correct metadata notification and lifecycle behavior
- document the configuration contract in English and Chinese and update the public schema

Closes #418
Closes #419

## Verification

- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit` (314 files, 4545 tests)
- `pnpm test:admin` (14 files, 133 tests)
- `pnpm docs:build`
- packaged Admin browser smoke
- targeted ESLint over changed implementation files

Full repository ESLint exhausted Node heap at both 4 GB and 8 GB; targeted lint passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-server tool description overrides with validation and support for static and template servers.
  * Enhanced Admin tools management with inventory views, search and filtering, bulk visibility controls, per-tool descriptions, model selection, token estimates, and preview impact details.
  * Added template-aware tool configuration, including precedence and instance aggregation.
* **Bug Fixes**
  * Improved paginated tool discovery, snapshot recovery, stale pagination handling, and client notifications after tool metadata changes.
  * Preserved active template instances when only tool metadata changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->