### PR TITLE
fix: resolve declared Runtime Scope environment references

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -176,14 +176,6 @@ _Avoid_: log dump, health blob, debug page
 An explainable, ranked cause candidate within a **Server Diagnosis**, containing severity, supporting evidence, confidence, and safe guided next actions.
 _Avoid_: error string, health flag, guessed root cause
 
-**Diagnostic Finding**:
-An explainable, ranked cause candidate within a **Server Diagnosis**, containing severity, supporting evidence, confidence, and safe guided next actions.
-_Avoid_: error string, health flag, guessed root cause
-
-**Server Diagnosis**:
-A point-in-time, redacted explanation of why one **Configured Server Target** is unavailable, degraded, or behaving unexpectedly, with ranked likely causes and safe guided recovery actions.
-_Avoid_: log dump, health blob, debug page
-
 **Environment Secret Reference**:
 A configuration value that names or references a secret supplied by the runtime environment or external secret management instead of storing the secret material directly in a **Runtime Scope** config file.
 _Avoid_: inline secret, copied env value

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,12 +161,28 @@ The source-qualified identity of one **Configured Server Target**, combining whe
 _Avoid_: server name, bare target ID
 
 **Global Transport Config**:
-Shared transport settings inherited by **Configured Server Targets** unless a target sets its own override.
+The explicit normalized set of top-level transport defaults that **Configured Server Targets** may inherit unless a target sets its own override. It excludes unrelated global runtime configuration and unknown configuration fields.
 _Avoid_: global server config, default target config
 
 **Configured Server Read Model**:
 A normalized admin-facing view of **Configured Server Targets** with secrets and raw environment values redacted.
 _Avoid_: raw config DTO, config passthrough
+
+**Server Diagnosis**:
+A point-in-time, redacted explanation of why one **Configured Server Target** is unavailable, degraded, or behaving unexpectedly, with ranked likely causes and safe guided recovery actions.
+_Avoid_: log dump, health blob, debug page
+
+**Diagnostic Finding**:
+An explainable, ranked cause candidate within a **Server Diagnosis**, containing severity, supporting evidence, confidence, and safe guided next actions.
+_Avoid_: error string, health flag, guessed root cause
+
+**Diagnostic Finding**:
+An explainable, ranked cause candidate within a **Server Diagnosis**, containing severity, supporting evidence, confidence, and safe guided next actions.
+_Avoid_: error string, health flag, guessed root cause
+
+**Server Diagnosis**:
+A point-in-time, redacted explanation of why one **Configured Server Target** is unavailable, degraded, or behaving unexpectedly, with ranked likely causes and safe guided recovery actions.
+_Avoid_: log dump, health blob, debug page
 
 **Environment Secret Reference**:
 A configuration value that names or references a secret supplied by the runtime environment or external secret management instead of storing the secret material directly in a **Runtime Scope** config file.

--- a/docs/en/reference/mcp-servers.md
+++ b/docs/en/reference/mcp-servers.md
@@ -320,6 +320,8 @@ Both `$VARIABLE_NAME` and `${VARIABLE_NAME}` references can read from the parent
 - `--config-dir <directory>` uses `<directory>/.env`.
 - `--config <path>` uses the `.env` beside that selected file, regardless of the invoking working directory.
 
+References are supported in stdio `command`, `args`, `cwd`, and `env` values, and in HTTP/SSE `url`, header values, and OAuth fields.
+
 For example:
 
 ```dotenv
@@ -353,6 +355,8 @@ Use `envFilter` to control which variables are inherited using pattern matching:
   "envFilter": ["PATH", "HOME", "NODE_*", "NPM_*", "!SECRET_*", "!BASH_FUNC_*"]
 }
 ```
+
+For explicit `env` entries, `envFilter` controls only implicit inheritance. A variable declared in `env` may reference a parent or Runtime Scope value without also listing that source key in `envFilter`; the declaration itself is the intentional allow. Variables that are neither declared nor matched by `envFilter` remain excluded.
 
 **Filter Patterns:**
 

--- a/docs/public/schemas/v1.0.0/mcp-config.json
+++ b/docs/public/schemas/v1.0.0/mcp-config.json
@@ -217,8 +217,7 @@
           },
           "url": {
             "description": "URL for HTTP or SSE transport",
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           },
           "headers": {
             "description": "Custom HTTP headers to send with requests",
@@ -448,8 +447,7 @@
           },
           "url": {
             "description": "URL for HTTP or SSE transport",
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           },
           "headers": {
             "description": "Custom HTTP headers to send with requests",

--- a/docs/public/schemas/v1.0.0/mcp-config.json
+++ b/docs/public/schemas/v1.0.0/mcp-config.json
@@ -217,7 +217,16 @@
           },
           "url": {
             "description": "URL for HTTP or SSE transport",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "string",
+                "pattern": "\\$\\{[^}]+\\}|\\$[A-Za-z_][A-Za-z0-9_]*"
+              }
+            ]
           },
           "headers": {
             "description": "Custom HTTP headers to send with requests",
@@ -447,7 +456,16 @@
           },
           "url": {
             "description": "URL for HTTP or SSE transport",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "string",
+                "pattern": "\\$\\{[^}]+\\}|\\$[A-Za-z_][A-Za-z0-9_]*"
+              }
+            ]
           },
           "headers": {
             "description": "Custom HTTP headers to send with requests",

--- a/docs/zh/reference/mcp-servers.md
+++ b/docs/zh/reference/mcp-servers.md
@@ -304,6 +304,8 @@ Admin 使用相同的 `disabledTools` 和 `toolDescriptionOverrides` 字段。�
 - `--config-dir <directory>`：使用 `<directory>/.env`
 - 通过 `--config` 指定配置：与该配置文件相邻的 `.env`
 
+引用可用于 stdio 的 `command`、`args`、`cwd` 和 `env` 值，也可用于 HTTP/SSE 的 `url`、请求头值和 OAuth 字段。
+
 父进程中的同名值优先于 Runtime Scope 文件。文件中的值只用于后端环境机密引用和显式环境继承：不会写入 1MCP 的进程环境、不会配置 `ONE_MCP_*` 选项，也不会自动传递给无关后端。`mcp.json` 中的字面量仍具有最高优先级。
 
 启用配置热重载后，1MCP 会监视 `.env` 的创建、修改、原子替换和删除。只有解析后有效配置发生变化的静态服务器和模板实例会重启；无关服务器保持连接。缺少 `.env` 是有效状态。文件不可读或格式错误时，1MCP 会保留上一次有效值，并在文件再次变化后重试。
@@ -330,6 +332,8 @@ Admin 使用相同的 `disabledTools` 和 `toolDescriptionOverrides` 字段。�
   "envFilter": ["PATH", "HOME", "NODE_*", "NPM_*", "!SECRET_*", "!BASH_FUNC_*"]
 }
 ```
+
+对于显式 `env` 条目，`envFilter` 只控制隐式继承。在 `env` 中声明的变量可以引用父进程或 Runtime Scope 中的值，无需再把源变量名加入 `envFilter`；该声明本身就是明确的允许。既未显式声明、也未被 `envFilter` 匹配的变量仍会被排除。
 
 **过滤模式：**
 

--- a/src/config/configContext.ts
+++ b/src/config/configContext.ts
@@ -1,4 +1,5 @@
 import { getConfigPath } from '@src/constants.js';
+
 import { getRuntimeScopeEnvPath } from './runtimeScopeEnv.js';
 
 /**

--- a/src/config/configLoader.ts
+++ b/src/config/configLoader.ts
@@ -16,7 +16,7 @@ import {
 import logger, { debugIf } from '@src/logger/logger.js';
 
 import { parse as parseToml } from 'smol-toml';
-import { z, ZodError } from 'zod';
+import { ZodError } from 'zod';
 
 import { getRuntimeScopeEnvPath } from './runtimeScopeEnv.js';
 
@@ -48,16 +48,6 @@ interface ConfigLoaderOptions {
 interface LoadParsedConfigOptions {
   includeAppConfig?: boolean;
 }
-
-const ENV_PLACEHOLDER_PATTERN = /\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*/;
-const serverConfigValidationSchema = transportConfigSchema.extend({
-  url: z
-    .string()
-    .refine((value) => ENV_PLACEHOLDER_PATTERN.test(value) || z.string().url().safeParse(value).success, {
-      message: 'Invalid url',
-    })
-    .optional(),
-});
 
 function formatZodIssues(error: ZodError): string {
   return error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
@@ -283,7 +273,7 @@ export class ConfigLoader {
 
   public validateServerConfig(serverName: string, config: unknown): MCPServerParams {
     try {
-      return serverConfigValidationSchema.parse(config);
+      return transportConfigSchema.parse(config);
     } catch (error) {
       throw new Error(getValidationErrorMessage(`Invalid configuration for server '${serverName}'`, error));
     }

--- a/src/config/configManager.test.ts
+++ b/src/config/configManager.test.ts
@@ -160,6 +160,26 @@ describe('ConfigManager (Integration)', () => {
   });
 
   describe('initialization', () => {
+    it('accepts environment references in declared HTTP URLs', async () => {
+      const configWithUrlReference = {
+        mcpServers: {
+          'http-server': {
+            type: 'http',
+            url: 'http://127.0.0.1:${HTTP_PORT}/mcp',
+          },
+        },
+      };
+      await fsPromises.writeFile(configFilePath, JSON.stringify(configWithUrlReference, null, 2));
+
+      const declared = configManager.loadDeclaredServerConfigs();
+
+      expect(declared.errors).toEqual([]);
+      expect(declared.staticServers['http-server']?.url).toBe('http://127.0.0.1:${HTTP_PORT}/mcp');
+      expect(configManager.getRuntimeInstructionConfiguration().configuredTargets.mcpServers['http-server']?.url).toBe(
+        'http://127.0.0.1:${HTTP_PORT}/mcp',
+      );
+    });
+
     it('preserves published instruction variants across reload and restart', async () => {
       const updatedConfig = {
         mcpServers: {},

--- a/src/config/configWatcher.test.ts
+++ b/src/config/configWatcher.test.ts
@@ -141,9 +141,7 @@ describe('ConfigWatcher', () => {
     it('does not reschedule a failed Runtime Scope signature until the file changes again', async () => {
       vi.useFakeTimers();
       vi.spyOn(configLoader, 'checkFileModified').mockReturnValue(false);
-      const reloadSpy = vi.fn(() =>
-        configLoader.markRuntimeEnvAttempted(configLoader.captureRuntimeEnvSignature()),
-      );
+      const reloadSpy = vi.fn(() => configLoader.markRuntimeEnvAttempted(configLoader.captureRuntimeEnvSignature()));
       configWatcher.on('reload', reloadSpy);
       configWatcher.startWatching();
       await fsPromises.writeFile(join(tempConfigDir, '.env'), 'invalid line\n');
@@ -163,9 +161,7 @@ describe('ConfigWatcher', () => {
     it('does not repeat a direct Runtime Scope reload after a successful transactional acknowledgement', async () => {
       vi.useFakeTimers();
       vi.spyOn(configLoader, 'checkFileModified').mockReturnValue(false);
-      const reloadSpy = vi.fn(() =>
-        configLoader.markRuntimeEnvObserved(configLoader.captureRuntimeEnvSignature()),
-      );
+      const reloadSpy = vi.fn(() => configLoader.markRuntimeEnvObserved(configLoader.captureRuntimeEnvSignature()));
       configWatcher.on('reload', reloadSpy);
       configWatcher.startWatching();
       await fsPromises.writeFile(join(tempConfigDir, '.env'), 'TOKEN=changed\n');

--- a/src/config/envProcessor.test.ts
+++ b/src/config/envProcessor.test.ts
@@ -230,7 +230,25 @@ describe('EnvProcessor', () => {
       });
     });
 
-    it('should not substitute custom environment variables from filtered parent env', () => {
+    it('resolves explicit Runtime Scope references independently of inherited environment filters', () => {
+      const result = processEnvironment({
+        inheritParentEnv: true,
+        envFilter: ['PUBLIC_*'],
+        runtimeEnv: {
+          PRIVATE_TOKEN: 'scope-token',
+          UNDECLARED_SECRET: 'must-stay-filtered',
+        },
+        env: {
+          PRIVATE_TOKEN: '${PRIVATE_TOKEN}',
+        },
+      });
+
+      expect(result.processedEnv).toEqual({ PRIVATE_TOKEN: 'scope-token' });
+      expect(result.processedEnv.UNDECLARED_SECRET).toBeUndefined();
+      expect(result.sources.filtered).toContain('UNDECLARED_SECRET');
+    });
+
+    it('substitutes explicit custom environment references without inheriting their source variables', () => {
       process.env.CONTEXT7_API_KEY = 'context7-key';
 
       const result = processEnvironment({
@@ -242,7 +260,7 @@ describe('EnvProcessor', () => {
       });
 
       expect(result.processedEnv).toEqual({
-        API_KEY_COPY: '$CONTEXT7_API_KEY',
+        API_KEY_COPY: 'context7-key',
       });
       expect(result.sources.filtered).toContain('CONTEXT7_API_KEY');
     });

--- a/src/config/envProcessor.test.ts
+++ b/src/config/envProcessor.test.ts
@@ -265,6 +265,17 @@ describe('EnvProcessor', () => {
       expect(result.sources.filtered).toContain('CONTEXT7_API_KEY');
     });
 
+    it('prefers parent values over SDK defaults when resolving explicit references', () => {
+      process.env.PATH = '/parent/bin';
+
+      const result = processEnvironment({
+        runtimeEnv: { PATH: '/runtime-scope/bin' },
+        env: { PATH_COPY: '$PATH' },
+      });
+
+      expect(result.processedEnv.PATH_COPY).toBe('/parent/bin');
+    });
+
     it('should keep custom environment placeholders when substitution is disabled', () => {
       process.env.CONTEXT7_API_KEY = 'context7-key';
 

--- a/src/config/envProcessor.ts
+++ b/src/config/envProcessor.ts
@@ -238,7 +238,7 @@ export function processEnvironment(config: EnvProcessingConfig): ProcessedEnviro
 
     // Apply environment variable substitution to custom env.
     if (config.substituteEnv !== false) {
-      const substitutionEnv = { ...referenceEnvironment, ...combinedEnv, ...customEnv };
+      const substitutionEnv = { ...combinedEnv, ...referenceEnvironment, ...customEnv };
 
       for (const key of Object.keys(customEnv)) {
         const value = customEnv[key];

--- a/src/config/envProcessor.ts
+++ b/src/config/envProcessor.ts
@@ -238,15 +238,19 @@ export function processEnvironment(config: EnvProcessingConfig): ProcessedEnviro
 
     // Apply environment variable substitution to custom env.
     if (config.substituteEnv !== false) {
-      const substitutionEnv =
-        config.envFilter && config.envFilter.length > 0
-          ? { ...combinedEnv, ...customEnv }
-          : { ...referenceEnvironment, ...combinedEnv, ...customEnv };
+      const substitutionEnv = { ...referenceEnvironment, ...combinedEnv, ...customEnv };
 
       for (const key of Object.keys(customEnv)) {
         const value = customEnv[key];
         if (typeof value === 'string') {
+          const sourceValue = referenceEnvironment[key] ?? combinedEnv[key];
+          if (sourceValue === undefined) {
+            delete substitutionEnv[key];
+          } else {
+            substitutionEnv[key] = sourceValue;
+          }
           customEnv[key] = substituteEnvVars(value, substitutionEnv);
+          substitutionEnv[key] = customEnv[key];
         }
       }
     }

--- a/src/config/runtimeScopeEnv.test.ts
+++ b/src/config/runtimeScopeEnv.test.ts
@@ -283,17 +283,17 @@ describe('Runtime Scope environment', () => {
   it.skipIf(process.platform === 'win32' || (typeof process.getuid === 'function' && process.getuid() === 0))(
     'reports unreadable files without exposing contents',
     async () => {
-    const directory = await mkdtemp(path.join(tmpdir(), 'runtime-env-'));
-    directories.push(directory);
-    const envPath = path.join(directory, '.env');
-    await writeFile(envPath, 'SECRET=must-not-appear\n');
-    await chmod(envPath, 0o000);
+      const directory = await mkdtemp(path.join(tmpdir(), 'runtime-env-'));
+      directories.push(directory);
+      const envPath = path.join(directory, '.env');
+      await writeFile(envPath, 'SECRET=must-not-appear\n');
+      await chmod(envPath, 0o000);
 
-    try {
-      expect(() => loadRuntimeScopeEnvironment(path.join(directory, 'mcp.json'))).toThrow(envPath);
-    } finally {
-      await chmod(envPath, 0o600);
-    }
+      try {
+        expect(() => loadRuntimeScopeEnvironment(path.join(directory, 'mcp.json'))).toThrow(envPath);
+      } finally {
+        await chmod(envPath, 0o600);
+      }
     },
   );
 });

--- a/src/core/server/backendStdioSupervisor.ts
+++ b/src/core/server/backendStdioSupervisor.ts
@@ -1,3 +1,5 @@
+import { sanitizeRuntimeScopeError } from '@src/config/runtimeScopeEnv.js';
+
 export type BackendSupervisionState = 'connected' | 'restarting' | 'crash-loop' | 'stopped';
 
 export interface BackendSupervisionPolicy {
@@ -256,4 +258,3 @@ export class BackendStdioSupervisor {
     this.onStateChange?.(this.snapshot());
   }
 }
-import { sanitizeRuntimeScopeError } from '@src/config/runtimeScopeEnv.js';

--- a/src/core/server/clientInstancePool.test.ts
+++ b/src/core/server/clientInstancePool.test.ts
@@ -146,10 +146,7 @@ describe('ClientInstancePool', () => {
       } as any;
       const firstTransport = { close: vi.fn().mockResolvedValue(undefined) } as any;
       const secondTransport = { close: vi.fn().mockResolvedValue(undefined) } as any;
-      const pooledClientFactory = vi
-        .fn()
-        .mockReturnValueOnce(firstClient)
-        .mockReturnValueOnce(secondClient);
+      const pooledClientFactory = vi.fn().mockReturnValueOnce(firstClient).mockReturnValueOnce(secondClient);
       vi.mocked(ClientManager.getOrCreateInstance).mockReturnValue({
         createPooledClientInstance: pooledClientFactory,
       } as any);

--- a/src/core/server/templateServerManager.test.ts
+++ b/src/core/server/templateServerManager.test.ts
@@ -317,9 +317,7 @@ describe('TemplateServerManager', () => {
 
       const targets = await templateServerManager.retireTemplatesForRuntimeEnvironment([]);
 
-      expect(targets).toEqual([
-        { sessionId: 'affected-session', templateName: 'worker', lifecycle: 'ephemeral' },
-      ]);
+      expect(targets).toEqual([{ sessionId: 'affected-session', templateName: 'worker', lifecycle: 'ephemeral' }]);
       expect(manager.clientInstancePool.removeInstance).toHaveBeenCalledOnce();
       expect(manager.clientInstancePool.removeInstance).toHaveBeenCalledWith('worker:affected');
       expect(manager.sessionToRenderedHash.has('affected-session')).toBe(false);

--- a/src/core/types/transport.test.ts
+++ b/src/core/types/transport.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import { mcpServerConfigSchema, transportConfigSchema } from './transport.js';
 
@@ -19,6 +20,24 @@ describe('transportConfigSchema stderr', () => {
 describe('transportConfigSchema restart policy', () => {
   it('rejects a fractional maxRestarts value', () => {
     expect(() => transportConfigSchema.parse({ type: 'stdio', command: 'node', maxRestarts: 1.5 })).toThrow();
+  });
+});
+
+describe('transportConfigSchema URL JSON schema', () => {
+  it('publishes the same URI-or-environment-reference alternatives accepted at runtime', () => {
+    const jsonSchema = z.toJSONSchema(transportConfigSchema, {
+      target: 'draft-7',
+      io: 'input',
+      unrepresentable: 'any',
+    });
+    const urlSchema = (jsonSchema.properties as Record<string, Record<string, unknown>>).url;
+
+    expect(urlSchema.anyOf).toEqual(
+      expect.arrayContaining([
+        { type: 'string', format: 'uri' },
+        { type: 'string', pattern: '\\$\\{[^}]+\\}|\\$[A-Za-z_][A-Za-z0-9_]*' },
+      ]),
+    );
   });
 });
 

--- a/src/core/types/transport.ts
+++ b/src/core/types/transport.ts
@@ -5,6 +5,13 @@ import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
 import { z } from 'zod';
 
+const ENVIRONMENT_REFERENCE_PATTERN = /\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*/u;
+const transportUrlSchema = z
+  .string()
+  .refine((value) => ENVIRONMENT_REFERENCE_PATTERN.test(value) || z.string().url().safeParse(value).success, {
+    message: 'URL must be a valid URL or environment substitution reference.',
+  });
+
 /**
  * Enhanced transport interface that includes MCP-specific properties
  *
@@ -270,7 +277,7 @@ export const transportConfigSchema = z.object({
   oauth: oAuthConfigSchema.optional().describe('OAuth configuration for authentication'),
 
   // HTTP/SSE Parameters
-  url: z.string().url().optional().describe('URL for HTTP or SSE transport'),
+  url: transportUrlSchema.optional().describe('URL for HTTP or SSE transport'),
   headers: z.record(z.string(), z.string()).optional().describe('Custom HTTP headers to send with requests'),
 
   // StdioServerParameters fields

--- a/src/core/types/transport.ts
+++ b/src/core/types/transport.ts
@@ -6,11 +6,10 @@ import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { z } from 'zod';
 
 const ENVIRONMENT_REFERENCE_PATTERN = /\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*/u;
-const transportUrlSchema = z
-  .string()
-  .refine((value) => ENVIRONMENT_REFERENCE_PATTERN.test(value) || z.string().url().safeParse(value).success, {
-    message: 'URL must be a valid URL or environment substitution reference.',
-  });
+const transportUrlSchema = z.union([
+  z.string().url(),
+  z.string().regex(ENVIRONMENT_REFERENCE_PATTERN, 'URL must be a valid URL or environment substitution reference.'),
+]);
 
 /**
  * Enhanced transport interface that includes MCP-specific properties

--- a/src/domains/admin/adminConfiguredServerService.ts
+++ b/src/domains/admin/adminConfiguredServerService.ts
@@ -38,15 +38,6 @@ import type { ConfiguredToolInventory, ConfiguredToolTargetSource } from './conf
 
 type ConfiguredServerSecretAction = 'preserve' | 'replace' | 'clear';
 type ConfiguredServerSecretReplacementKind = 'environmentReference' | 'inlineSecret';
-const ENV_PLACEHOLDER_PATTERN = /\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*/u;
-const previewTransportConfigSchema = transportConfigSchema.extend({
-  url: z
-    .string()
-    .refine((value) => ENV_PLACEHOLDER_PATTERN.test(value) || z.string().url().safeParse(value).success, {
-      message: 'URL must be a valid URL or environment substitution reference.',
-    })
-    .optional(),
-});
 
 interface AdminConfiguredServerServiceOptions {
   operationService: AdminOperationService;
@@ -242,7 +233,7 @@ function createWorkflowValidation(
     });
   }
   if (config) {
-    const parsed = previewTransportConfigSchema.safeParse(config);
+    const parsed = transportConfigSchema.safeParse(config);
     if (!parsed.success) {
       for (const issue of parsed.error.issues) {
         errors.push({
@@ -2631,7 +2622,7 @@ function validatePreviewServerConfig(serverConfig: MCPServerParams): ConfiguredS
   const type = typeof serverConfig.type === 'string' ? serverConfig.type : undefined;
   const url = typeof serverConfig.url === 'string' ? serverConfig.url : undefined;
   const command = typeof serverConfig.command === 'string' ? serverConfig.command : undefined;
-  const schemaResult = previewTransportConfigSchema.safeParse(serverConfig);
+  const schemaResult = transportConfigSchema.safeParse(serverConfig);
 
   if (!schemaResult.success) {
     for (const issue of schemaResult.error.issues) {


### PR DESCRIPTION
## Description

- allow explicitly declared `env` entries to resolve parent or Runtime Scope values without duplicating their keys in `envFilter`
- accept environment references in HTTP/SSE URLs through the shared transport schema, while preserving filtered implicit inheritance
- document supported substitution fields in English and Chinese and publish the matching JSON schema
- refine Runtime Scope diagnostic vocabulary and clean up related environment-processing code and tests

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [ ] Breaking change

## Testing

- [x] `CI=true pnpm test:unit` (4,732 tests)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] `pnpm build`
- [x] `pnpm docs:build`
- [x] Manual `.tmp-test` verification for declared env, URL, and header substitution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for environment-variable references in server commands, arguments, working directories, environment values, URLs, headers, and OAuth settings.
  - Added concepts for server diagnoses and diagnostic findings, including ranked causes, evidence, confidence, severity, and recovery actions.

- **Bug Fixes**
  - Server URLs containing environment-variable placeholders are now accepted and preserved for runtime resolution.
  - Explicit environment entries can reference inherited values without being blocked by environment filtering.

- **Documentation**
  - Clarified environment inheritance and filtering behavior in English and Chinese guides.
  - Updated configuration schemas to accept either URI-formatted URLs or environment-variable references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->