### PR TITLE
fix(security): make authorization code redemption atomic and drop plaintext code logs

### DIFF
--- a/src/auth/sdkOAuthServerProvider.refresh.test.ts
+++ b/src/auth/sdkOAuthServerProvider.refresh.test.ts
@@ -45,12 +45,13 @@ describe('SDKOAuthServerProvider refresh token families', () => {
     provider = new SDKOAuthServerProvider(tempDir, 'runtime-scope-a');
     const configManager = AgentConfigManager.getInstance();
     originalAuthEnabled = configManager.get('features').auth;
-    configManager.get('features').auth = true;
+    configManager.updateConfig({ features: { ...configManager.get('features'), auth: true } });
   });
 
   afterEach(() => {
     provider.shutdown();
-    AgentConfigManager.getInstance().get('features').auth = originalAuthEnabled;
+    const configManager = AgentConfigManager.getInstance();
+    configManager.updateConfig({ features: { ...configManager.get('features'), auth: originalAuthEnabled } });
     fs.rmSync(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
@@ -339,12 +340,13 @@ describe('authorization-code-atomic (goiabada#77 double-spend)', () => {
     provider = new SDKOAuthServerProvider(tempDir, 'runtime-scope-a');
     const configManager = AgentConfigManager.getInstance();
     originalAuthEnabled = configManager.get('features').auth;
-    configManager.get('features').auth = true;
+    configManager.updateConfig({ features: { ...configManager.get('features'), auth: true } });
   });
 
   afterEach(() => {
     provider.shutdown();
-    AgentConfigManager.getInstance().get('features').auth = originalAuthEnabled;
+    const configManager = AgentConfigManager.getInstance();
+    configManager.updateConfig({ features: { ...configManager.get('features'), auth: originalAuthEnabled } });
     fs.rmSync(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });

--- a/src/auth/sdkOAuthServerProvider.refresh.test.ts
+++ b/src/auth/sdkOAuthServerProvider.refresh.test.ts
@@ -419,4 +419,40 @@ describe('authorization-code-atomic (goiabada#77 double-spend)', () => {
     expect(allLoggedContent).not.toContain(code);
     expect(allLoggedContent).not.toMatch(/auth_code_code-[0-9a-f-]+/i);
   });
+
+  it('failure paths in storage operations do not expose the plaintext code or path in error logs', async () => {
+    const errorSpy = vi.spyOn(logger, 'error');
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    const code = provider.oauthStorage.authCodeRepository.create(
+      ACCESS_ONLY_CLIENT.client_id,
+      ACCESS_ONLY_CLIENT.redirect_uris[0],
+      RESOURCE,
+      SCOPES,
+      60_000,
+      'challenge',
+    );
+
+    // Simulate an IO failure during deletion that includes the sensitive file path in the native error message
+    const realUnlinkSync = fs.unlinkSync;
+    vi.spyOn(fs, 'unlinkSync').mockImplementation((targetPath) => {
+      const err = new Error(`EACCES: permission denied, unlink '${String(targetPath)}'`);
+      (err as unknown as { code: string }).code = 'EACCES';
+      throw err;
+    });
+
+    // Attempting to delete triggers the failure path
+    expect(() => provider.oauthStorage.authCodeRepository.delete(code)).toThrow();
+
+    const allLoggedErrors = [...errorSpy.mock.calls, ...warnSpy.mock.calls]
+      .map((call) => JSON.stringify(call))
+      .join('\n');
+
+    expect(allLoggedErrors).not.toContain(code);
+    expect(allLoggedErrors).not.toMatch(/auth_code_code-[0-9a-f-]+/i);
+    expect(allLoggedErrors).toContain('[REDACTED]');
+    expect(allLoggedErrors).toContain('EACCES');
+
+    fs.unlinkSync = realUnlinkSync;
+  });
 });

--- a/src/auth/sdkOAuthServerProvider.refresh.test.ts
+++ b/src/auth/sdkOAuthServerProvider.refresh.test.ts
@@ -328,3 +328,71 @@ function readSoleFamily(tempDir: string) {
   expect(familyFiles).toHaveLength(1);
   return RefreshTokenFamilyDataSchema.parse(JSON.parse(fs.readFileSync(familyFiles[0], 'utf8')));
 }
+
+describe('authorization-code-atomic (goiabada#77 double-spend)', () => {
+  let provider: SDKOAuthServerProvider;
+  let tempDir: string;
+  let originalAuthEnabled: boolean;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), '1mcp-authcode-atomic-'));
+    provider = new SDKOAuthServerProvider(tempDir, 'runtime-scope-a');
+    const configManager = AgentConfigManager.getInstance();
+    originalAuthEnabled = configManager.get('features').auth;
+    configManager.get('features').auth = true;
+  });
+
+  afterEach(() => {
+    provider.shutdown();
+    AgentConfigManager.getInstance().get('features').auth = originalAuthEnabled;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('allows exactly one winner for concurrent exchanges of the same code', async () => {
+    const code = provider.oauthStorage.authCodeRepository.create(
+      CLIENT.client_id,
+      CLIENT.redirect_uris[0],
+      RESOURCE,
+      SCOPES,
+      60_000,
+      'challenge',
+    );
+
+    const attempt = () =>
+      provider.exchangeAuthorizationCode(CLIENT, code, undefined, CLIENT.redirect_uris[0], new URL(RESOURCE));
+
+    const results = await Promise.allSettled([attempt(), attempt(), attempt(), attempt(), attempt()]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled') as PromiseFulfilledResult<OAuthTokens>[];
+    const rejected = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[];
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected.length).toBeGreaterThanOrEqual(4);
+    for (const r of rejected) {
+      expect(r.reason).toBeInstanceOf(InvalidGrantError);
+      expect((r.reason as Error).message).toBe('Invalid or expired authorization code');
+    }
+
+    const accessTokens = new Set(fulfilled.map((r) => r.value.access_token));
+    expect(accessTokens.size).toBe(1);
+
+    // code is consumed: a later sequential attempt also fails
+    await expect(attempt()).rejects.toBeInstanceOf(InvalidGrantError);
+    expect(provider.oauthStorage.authCodeRepository.get(code)).toBeNull();
+  }, 20_000);
+
+  it('logs do not contain the plaintext authorization code', async () => {
+    const infoSpy = vi.spyOn(logger, 'info');
+    const debugSpy = vi.spyOn(logger, 'debug');
+
+    const tokens = await exchangeAuthorizationCode(provider, ACCESS_ONLY_CLIENT);
+    expect(tokens.access_token).toBeDefined();
+
+    for (const spy of [infoSpy, debugSpy]) {
+      for (const call of spy.mock.calls) {
+        expect(JSON.stringify(call)).not.toMatch(/auth-code|ac_[0-9a-f-]{8}/i);
+      }
+    }
+  });
+});

--- a/src/auth/sdkOAuthServerProvider.refresh.test.ts
+++ b/src/auth/sdkOAuthServerProvider.refresh.test.ts
@@ -387,14 +387,36 @@ describe('authorization-code-atomic (goiabada#77 double-spend)', () => {
   it('logs do not contain the plaintext authorization code', async () => {
     const infoSpy = vi.spyOn(logger, 'info');
     const debugSpy = vi.spyOn(logger, 'debug');
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const errorSpy = vi.spyOn(logger, 'error');
 
-    const tokens = await exchangeAuthorizationCode(provider, ACCESS_ONLY_CLIENT);
+    const code = provider.oauthStorage.authCodeRepository.create(
+      ACCESS_ONLY_CLIENT.client_id,
+      ACCESS_ONLY_CLIENT.redirect_uris[0],
+      RESOURCE,
+      SCOPES,
+      60_000,
+      'challenge',
+    );
+    const tokens = await provider.exchangeAuthorizationCode(
+      ACCESS_ONLY_CLIENT,
+      code,
+      undefined,
+      ACCESS_ONLY_CLIENT.redirect_uris[0],
+      new URL(RESOURCE),
+    );
     expect(tokens.access_token).toBeDefined();
 
-    for (const spy of [infoSpy, debugSpy]) {
-      for (const call of spy.mock.calls) {
-        expect(JSON.stringify(call)).not.toMatch(/auth-code|ac_[0-9a-f-]{8}/i);
-      }
-    }
+    const allLoggedContent = [
+      ...infoSpy.mock.calls,
+      ...debugSpy.mock.calls,
+      ...warnSpy.mock.calls,
+      ...errorSpy.mock.calls,
+    ]
+      .map((call) => JSON.stringify(call))
+      .join('\n');
+
+    expect(allLoggedContent).not.toContain(code);
+    expect(allLoggedContent).not.toMatch(/auth_code_code-[0-9a-f-]+/i);
   });
 });

--- a/src/auth/sdkOAuthServerProvider.refresh.test.ts
+++ b/src/auth/sdkOAuthServerProvider.refresh.test.ts
@@ -455,4 +455,32 @@ describe('authorization-code-atomic (goiabada#77 double-spend)', () => {
 
     fs.unlinkSync = realUnlinkSync;
   });
+
+  it('cleanup of expired authorization codes does not log plaintext codes or paths', async () => {
+    const debugSpy = vi.spyOn(logger, 'debug');
+    const infoSpy = vi.spyOn(logger, 'info');
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const errorSpy = vi.spyOn(logger, 'error');
+
+    // Create an expired authorization code
+    const code = provider.oauthStorage.authCodeRepository.create(
+      ACCESS_ONLY_CLIENT.client_id,
+      ACCESS_ONLY_CLIENT.redirect_uris[0],
+      RESOURCE,
+      SCOPES,
+      -1000, // Expired in the past
+      'challenge',
+    );
+
+    const cleanedCount = provider.oauthStorage.fileStorage.cleanupExpiredData();
+    expect(cleanedCount).toBeGreaterThanOrEqual(1);
+
+    const allLogged = [...debugSpy.mock.calls, ...infoSpy.mock.calls, ...warnSpy.mock.calls, ...errorSpy.mock.calls]
+      .map((call) => JSON.stringify(call))
+      .join('\n');
+
+    expect(allLogged).not.toContain(code);
+    expect(allLogged).not.toMatch(/auth_code_code-[0-9a-f-]+/i);
+    expect(allLogged).toContain('auth_code_[REDACTED].json');
+  });
 });

--- a/src/auth/sdkOAuthServerProvider.refresh.test.ts
+++ b/src/auth/sdkOAuthServerProvider.refresh.test.ts
@@ -483,4 +483,45 @@ describe('authorization-code-atomic (goiabada#77 double-spend)', () => {
     expect(allLogged).not.toMatch(/auth_code_code-[0-9a-f-]+/i);
     expect(allLogged).toContain('auth_code_[REDACTED].json');
   });
+
+  it('failure when cleaning temporary files for sensitive codes does not log plaintext codes or paths', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const errorSpy = vi.spyOn(logger, 'error');
+
+    const storageDir = provider.oauthStorage.fileStorage.getStorageDir();
+    const sensitiveTmpFile = `auth_code_code-11112222-3333-4444-5555-666677778888.json.${process.pid}.random.tmp`;
+    const sensitiveTmpPath = path.join(storageDir, sensitiveTmpFile);
+    fs.writeFileSync(sensitiveTmpPath, 'temp');
+
+    // Age the temporary file so it qualifies for cleanup (>60s)
+    const oldTime = (Date.now() - 120_000) / 1000;
+    fs.utimesSync(sensitiveTmpPath, oldTime, oldTime);
+
+    // Mock unlinkSync to fail on this file
+    const realUnlinkSync = fs.unlinkSync;
+    vi.spyOn(fs, 'unlinkSync').mockImplementation((targetPath) => {
+      if (String(targetPath).includes('auth_code_code-11112222')) {
+        const err = new Error(`EACCES: permission denied, unlink '${String(targetPath)}'`);
+        (err as unknown as { code: string }).code = 'EACCES';
+        throw err;
+      }
+      return realUnlinkSync(targetPath);
+    });
+
+    try {
+      provider.oauthStorage.fileStorage.cleanupExpiredData();
+
+      const allLogged = [...warnSpy.mock.calls, ...errorSpy.mock.calls].map((call) => JSON.stringify(call)).join('\n');
+
+      expect(allLogged).not.toContain('code-11112222-3333-4444-5555-666677778888');
+      expect(allLogged).not.toMatch(/auth_code_code-[0-9a-f-]+/i);
+      expect(allLogged).toContain('auth_code_[REDACTED].tmp');
+      expect(allLogged).toContain('EACCES');
+    } finally {
+      fs.unlinkSync = realUnlinkSync;
+      if (fs.existsSync(sensitiveTmpPath)) {
+        fs.unlinkSync(sensitiveTmpPath);
+      }
+    }
+  });
 });

--- a/src/auth/sdkOAuthServerProvider.ts
+++ b/src/auth/sdkOAuthServerProvider.ts
@@ -336,7 +336,7 @@ export class SDKOAuthServerProvider implements OAuthServerProvider {
    * Retrieves the PKCE challenge for an authorization code
    */
   async challengeForAuthorizationCode(client: OAuthClientInformationFull, authorizationCode: string): Promise<string> {
-    logger.debug('Challenge for authorization code', { clientId: client.client_id, authorizationCode });
+    logger.debug('Challenge for authorization code', { clientId: client.client_id });
 
     const codeData = this.oauthStorage.authCodeRepository.get(authorizationCode);
     if (!codeData || codeData.clientId !== client.client_id) {
@@ -360,82 +360,83 @@ export class SDKOAuthServerProvider implements OAuthServerProvider {
   ): Promise<OAuthTokens> {
     logger.debug('Exchanging authorization code', {
       clientId: client.client_id,
-      authorizationCode,
       redirectUri,
       resource,
     });
 
-    const codeData = this.oauthStorage.authCodeRepository.get(authorizationCode);
-    if (!codeData) {
-      throw new InvalidGrantError('Invalid or expired authorization code');
-    }
+    return this.oauthStorage.fileStorage.withExclusiveLock('auth-code-exchange', async () => {
+      const codeData = this.oauthStorage.authCodeRepository.get(authorizationCode);
+      if (!codeData) {
+        throw new InvalidGrantError('Invalid or expired authorization code');
+      }
 
-    // Validate client ID
-    if (codeData.clientId !== client.client_id) {
-      throw new InvalidGrantError('Invalid or expired authorization code');
-    }
+      // Validate client ID
+      if (codeData.clientId !== client.client_id) {
+        throw new InvalidGrantError('Invalid or expired authorization code');
+      }
 
-    // Validate redirect URI if provided
-    if (redirectUri && codeData.redirectUri !== redirectUri) {
-      throw new InvalidGrantError('Redirect URI mismatch');
-    }
+      // Validate redirect URI if provided
+      if (redirectUri && codeData.redirectUri !== redirectUri) {
+        throw new InvalidGrantError('Redirect URI mismatch');
+      }
 
-    // Validate resource if provided
-    if (resource && codeData.resource && codeData.resource !== resource.toString()) {
-      throw new InvalidTargetError('Resource mismatch');
-    }
+      // Validate resource if provided
+      if (resource && codeData.resource && codeData.resource !== resource.toString()) {
+        throw new InvalidTargetError('Resource mismatch');
+      }
 
-    // Delete the authorization code (one-time use)
-    this.oauthStorage.authCodeRepository.delete(authorizationCode);
+      // Delete the authorization code (one-time use)
+      this.oauthStorage.authCodeRepository.delete(authorizationCode);
 
-    // Create access token
-    const tokenId = randomUUID();
-    const accessToken = AUTH_CONFIG.SERVER.TOKEN.ID_PREFIX + tokenId;
-    const ttlMs = this.configManager.get('auth').oauthTokenTtlMs;
+      // Create access token
+      const tokenId = randomUUID();
+      const accessToken = AUTH_CONFIG.SERVER.TOKEN.ID_PREFIX + tokenId;
+      const ttlMs = this.configManager.get('auth').oauthTokenTtlMs;
 
-    const refreshFamily = client.grant_types?.includes('refresh_token')
-      ? await this.oauthStorage.refreshTokenFamilyRepository.create(
-          client.client_id,
-          codeData.scopes,
-          codeData.resource || '',
+      const refreshFamily = client.grant_types?.includes('refresh_token')
+        ? await this.oauthStorage.refreshTokenFamilyRepository.create(
+            client.client_id,
+            codeData.scopes,
+            codeData.resource || '',
+            tokenId,
+            (familyId) =>
+              this.oauthStorage.sessionRepository.createRefreshFamilyAccessSession({
+                tokenId,
+                clientId: client.client_id,
+                resource: codeData.resource || '',
+                scopes: codeData.scopes,
+                ttlMs,
+                familyId,
+              }),
+          )
+        : undefined;
+
+      if (!refreshFamily) {
+        this.oauthStorage.sessionRepository.createWithId(
           tokenId,
-          (familyId) =>
-            this.oauthStorage.sessionRepository.createRefreshFamilyAccessSession({
-              tokenId,
-              clientId: client.client_id,
-              resource: codeData.resource || '',
-              scopes: codeData.scopes,
-              ttlMs,
-              familyId,
-            }),
-        )
-      : undefined;
+          client.client_id,
+          codeData.resource || '',
+          codeData.scopes,
+          ttlMs,
+        );
+      }
 
-    if (!refreshFamily) {
-      this.oauthStorage.sessionRepository.createWithId(
-        tokenId,
-        client.client_id,
-        codeData.resource || '',
-        codeData.scopes,
-        ttlMs,
-      );
-    }
+      const tokens: OAuthTokens = {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: Math.floor(ttlMs / 1000),
+        scope: codeData.scopes ? codeData.scopes.join(' ') : '',
+        ...(refreshFamily ? { refresh_token: refreshFamily.refreshToken } : {}),
+      };
 
-    const tokens: OAuthTokens = {
-      access_token: accessToken,
-      token_type: 'Bearer',
-      expires_in: Math.floor(ttlMs / 1000),
-      scope: codeData.scopes ? codeData.scopes.join(' ') : '',
-      ...(refreshFamily ? { refresh_token: refreshFamily.refreshToken } : {}),
-    };
+      logger.info(`Exchanged authorization code for access token`, {
+        clientId: client.client_id,
+        tokenId: tokenId.substring(0, 8) + '...',
+        expiresIn: tokens.expires_in,
+      });
 
-    logger.info(`Exchanged authorization code for access token`, {
-      clientId: client.client_id,
-      tokenId: tokenId.substring(0, 8) + '...',
-      expiresIn: tokens.expires_in,
+      return tokens;
     });
-
-    return tokens;
   }
 
   /**

--- a/src/auth/storage/authCodeRepository.ts
+++ b/src/auth/storage/authCodeRepository.ts
@@ -38,7 +38,7 @@ export class AuthCodeRepository {
     };
 
     this.storage.writeData(AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX, code, authCodeData);
-    logger.info(`Created auth code: ${code} for client: ${clientId}`);
+    logger.info(`Created auth code for client: ${clientId}`);
     return code;
   }
 
@@ -55,7 +55,7 @@ export class AuthCodeRepository {
   delete(code: string): boolean {
     const result = this.storage.deleteData(AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX, code);
     if (result) {
-      logger.info(`Deleted auth code: ${code}`);
+      logger.info('Deleted auth code');
     }
     return result;
   }

--- a/src/auth/storage/authRequestRepository.ts
+++ b/src/auth/storage/authRequestRepository.ts
@@ -39,7 +39,7 @@ export class AuthRequestRepository {
     };
 
     this.storage.writeData(AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX, authRequestId, authRequestData);
-    logger.info(`Created auth request: ${authRequestId} for client: ${clientId}`);
+    logger.info(`Created auth request for client: ${clientId}`);
     return authRequestId;
   }
 
@@ -56,7 +56,7 @@ export class AuthRequestRepository {
   delete(authRequestId: string): boolean {
     const result = this.storage.deleteData(AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX, authRequestId);
     if (result) {
-      logger.info(`Deleted auth request: ${authRequestId}`);
+      logger.info('Deleted auth request');
     }
     return result;
   }

--- a/src/auth/storage/fileStorageService.migration.test.ts
+++ b/src/auth/storage/fileStorageService.migration.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import path from 'path';
 
 import { FILE_PREFIX_MAPPING, STORAGE_SUBDIRS } from '@src/constants.js';
+import logger from '@src/logger/logger.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -456,6 +457,73 @@ describe('FileStorageService', () => {
 
       for (const id of invalidIds) {
         expect(() => service.getFilePath('test_', id)).toThrow();
+      }
+    });
+  });
+
+  describe('Migration Log Redaction', () => {
+    it('redacts sensitive authorization codes and requests during migration', () => {
+      const baseDir = path.join(tmpdir(), `migration-redaction-test-${Date.now()}`);
+      const sessionsDir = path.join(baseDir, 'sessions');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+
+      const sensitiveAuthCode = 'code-99998888-7777-6666-5555-444433332222';
+      const sensitiveAuthRequest = 'code-11112222-3333-4444-5555-666677778888';
+      const authCodeFileName = `auth_code_${sensitiveAuthCode}.json`;
+      const authRequestFileName = `auth_request_${sensitiveAuthRequest}.json`;
+
+      fs.writeFileSync(path.join(sessionsDir, authCodeFileName), JSON.stringify({ test: 'data' }));
+      fs.writeFileSync(path.join(sessionsDir, authRequestFileName), JSON.stringify({ test: 'data' }));
+
+      const testService = new FileStorageService(baseDir, 'server');
+
+      const infoCalls = (logger.info as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+      const allInfo = infoCalls.map((call) => JSON.stringify(call)).join('\n');
+
+      expect(allInfo).not.toContain(sensitiveAuthCode);
+      expect(allInfo).not.toContain(sensitiveAuthRequest);
+      expect(allInfo).not.toMatch(/auth_code_code-[0-9a-f-]+/i);
+      expect(allInfo).not.toMatch(/auth_request_code-[0-9a-f-]+/i);
+      expect(allInfo).toContain('auth_code_[REDACTED].json');
+      expect(allInfo).toContain('auth_request_[REDACTED].json');
+
+      testService.shutdown();
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it('redacts sensitive file paths and errors on migration failure', () => {
+      const baseDir = path.join(tmpdir(), `migration-fail-redaction-test-${Date.now()}`);
+      const sessionsDir = path.join(baseDir, 'sessions');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+
+      const sensitiveAuthCode = 'code-99998888-7777-6666-5555-444433332222';
+      const authCodeFileName = `auth_code_${sensitiveAuthCode}.json`;
+      fs.writeFileSync(path.join(sessionsDir, authCodeFileName), JSON.stringify({ test: 'data' }));
+
+      const realRenameSync = fs.renameSync;
+      vi.spyOn(fs, 'renameSync').mockImplementation((oldPath, newPath) => {
+        if (String(oldPath).includes(sensitiveAuthCode)) {
+          const err = new Error(`EACCES: permission denied, rename '${String(oldPath)}' -> '${String(newPath)}'`);
+          (err as unknown as { code: string }).code = 'EACCES';
+          throw err;
+        }
+        return realRenameSync(oldPath, newPath);
+      });
+
+      try {
+        const testService = new FileStorageService(baseDir, 'server');
+        testService.shutdown();
+
+        const errorCalls = (logger.error as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+        const allError = errorCalls.map((call) => JSON.stringify(call)).join('\n');
+
+        expect(allError).not.toContain(sensitiveAuthCode);
+        expect(allError).not.toMatch(/auth_code_code-[0-9a-f-]+/i);
+        expect(allError).toContain('auth_code_[REDACTED].json');
+        expect(allError).toContain('EACCES');
+      } finally {
+        fs.renameSync = realRenameSync;
+        fs.rmSync(baseDir, { recursive: true, force: true });
       }
     });
   });

--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import fs from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
@@ -32,7 +33,7 @@ describe('FileStorageService', () => {
 
   beforeEach(() => {
     // Create a temporary directory for testing
-    tempDir = path.join(tmpdir(), `file-storage-test-${Date.now()}`);
+    tempDir = path.join(tmpdir(), `file-storage-test-${randomUUID()}`);
     service = new FileStorageService(tempDir);
   });
 
@@ -63,7 +64,8 @@ describe('FileStorageService', () => {
     });
 
     it('should handle directory creation errors', () => {
-      const invalidDir = '/invalid/path/that/cannot/be/created';
+      const invalidDir =
+        process.platform === 'win32' ? 'Z:\\nonexistent_drive_123\\sessions' : '/invalid/path/that/cannot/be/created';
       expect(() => new FileStorageService(invalidDir)).toThrow();
     });
   });

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -285,7 +285,10 @@ export class FileStorageService {
    * Checks if an ID/filePrefix represents sensitive data that should be redacted from logs.
    */
   private isSensitiveId(filePrefix?: string): boolean {
-    return filePrefix === AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX;
+    return (
+      filePrefix === AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX ||
+      filePrefix === AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX
+    );
   }
 
   /**

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -129,9 +129,11 @@ export class FileStorageService {
         try {
           fs.renameSync(oldPath, newPath);
           migrationCount++;
-          logger.info(`Migrated ${file} from ${sourceDir} to ${this.storageDir}`);
+          logger.info(`Migrated ${this.getLoggableFileName(file)} from ${sourceDir} to ${this.storageDir}`);
         } catch (error) {
-          logger.error(`Failed to migrate ${file}: ${error}`);
+          logger.error(
+            `Failed to migrate ${this.getLoggableFileName(file)}: ${this.getLoggableErrorForFileName(file, error)}`,
+          );
         }
       }
     }
@@ -281,17 +283,19 @@ export class FileStorageService {
     return false;
   }
 
-  private static readonly SENSITIVE_FILE_PREFIXES = [
-    AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX,
-    AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX,
-  ] as const;
+  private static getSensitivePrefixes(): readonly string[] {
+    return [
+      AUTH_CONFIG?.SERVER?.AUTH_CODE?.FILE_PREFIX ?? 'auth_code_',
+      AUTH_CONFIG?.SERVER?.AUTH_REQUEST?.FILE_PREFIX ?? 'auth_request_',
+    ];
+  }
 
   /**
    * Checks if an ID/filePrefix or filename represents sensitive data that should be redacted from logs.
    */
   private isSensitivePrefix(prefixOrFileName?: string): boolean {
     if (!prefixOrFileName) return false;
-    return FileStorageService.SENSITIVE_FILE_PREFIXES.some((prefix) => prefixOrFileName.startsWith(prefix));
+    return FileStorageService.getSensitivePrefixes().some((prefix) => prefixOrFileName.startsWith(prefix));
   }
 
   /**
@@ -309,7 +313,10 @@ export class FileStorageService {
    */
   private getLoggableFilePath(filePrefix: string, id: string): string {
     if (this.isSensitivePrefix(filePrefix)) {
-      return path.join(this.storageDir, `${filePrefix}[REDACTED]${AUTH_CONFIG.SERVER.STORAGE.FILE_EXTENSION}`);
+      return path.join(
+        this.storageDir,
+        `${filePrefix}[REDACTED]${AUTH_CONFIG?.SERVER?.STORAGE?.FILE_EXTENSION ?? '.json'}`,
+      );
     }
     return this.getFilePath(filePrefix, id);
   }
@@ -331,12 +338,12 @@ export class FileStorageService {
    * Gets a log-safe representation of a file name (including .tmp files).
    */
   private getLoggableFileName(fileName: string): string {
-    for (const prefix of FileStorageService.SENSITIVE_FILE_PREFIXES) {
+    for (const prefix of FileStorageService.getSensitivePrefixes()) {
       if (fileName.startsWith(prefix)) {
         if (fileName.endsWith('.tmp')) {
           return `${prefix}[REDACTED].tmp`;
         }
-        return `${prefix}[REDACTED]${AUTH_CONFIG.SERVER.STORAGE.FILE_EXTENSION}`;
+        return `${prefix}[REDACTED]${AUTH_CONFIG?.SERVER?.STORAGE?.FILE_EXTENSION ?? '.json'}`;
       }
     }
     return fileName;

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -282,15 +282,42 @@ export class FileStorageService {
   }
 
   /**
+   * Checks if an ID/filePrefix represents sensitive data that should be redacted from logs.
+   */
+  private isSensitiveId(filePrefix?: string): boolean {
+    return filePrefix === AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX;
+  }
+
+  /**
+   * Gets a log-safe representation of an ID.
+   */
+  private getLoggableId(filePrefix: string, id: string): string {
+    if (this.isSensitiveId(filePrefix)) {
+      return '[REDACTED]';
+    }
+    return id;
+  }
+
+  /**
+   * Gets a log-safe representation of a file path.
+   */
+  private getLoggableFilePath(filePrefix: string, id: string): string {
+    if (this.isSensitiveId(filePrefix)) {
+      return path.join(this.storageDir, `${filePrefix}[REDACTED]${AUTH_CONFIG.SERVER.STORAGE.FILE_EXTENSION}`);
+    }
+    return this.getFilePath(filePrefix, id);
+  }
+
+  /**
    * Writes data to a file with the specified prefix and ID
    */
   writeData<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
     try {
       const filePath = this.getFilePath(filePrefix, id);
       fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
-      logger.debug(`Wrote data to ${filePath}`);
+      logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
     } catch (error) {
-      logger.error(`Failed to write data for ${id}: ${error}`);
+      logger.error(`Failed to write data for ${this.getLoggableId(filePrefix, id)}: ${error}`);
       throw error;
     }
   }
@@ -313,7 +340,7 @@ export class FileStorageService {
       fs.renameSync(temporaryPath, filePath);
       temporaryPath = undefined;
       this.flushStorageDirectory();
-      logger.debug(`Wrote data to ${filePath}`);
+      logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
     } catch (error) {
       if (temporaryPath) {
         try {
@@ -322,7 +349,7 @@ export class FileStorageService {
           // A later startup cleanup removes abandoned temporary files.
         }
       }
-      logger.error(`Failed to write data for ${id}: ${error}`);
+      logger.error(`Failed to write data for ${this.getLoggableId(filePrefix, id)}: ${error}`);
       throw error;
     }
   }
@@ -333,7 +360,7 @@ export class FileStorageService {
    */
   readData<T extends ExpirableData>(filePrefix: string, id: string, schema?: ZodType<T>): T | null {
     if (!this.isValidId(id, filePrefix)) {
-      logger.warn(`Rejected readData with invalid ID: ${id}`);
+      logger.warn(`Rejected readData with invalid ID: ${this.getLoggableId(filePrefix, id)}`);
       return null;
     }
 
@@ -355,7 +382,7 @@ export class FileStorageService {
 
       return parsedData;
     } catch (error) {
-      logger.error(`Failed to read data for ${id}: ${error}`);
+      logger.error(`Failed to read data for ${this.getLoggableId(filePrefix, id)}: ${error}`);
       return null;
     }
   }
@@ -365,7 +392,7 @@ export class FileStorageService {
    */
   deleteData(filePrefix: string, id: string): boolean {
     if (!this.isValidId(id, filePrefix)) {
-      logger.warn(`Rejected deleteData with invalid ID: ${id}`);
+      logger.warn(`Rejected deleteData with invalid ID: ${this.getLoggableId(filePrefix, id)}`);
       return false;
     }
 
@@ -373,12 +400,12 @@ export class FileStorageService {
       const filePath = this.getFilePath(filePrefix, id);
       if (fs.existsSync(filePath)) {
         fs.unlinkSync(filePath);
-        logger.debug(`Deleted data file: ${filePath}`);
+        logger.debug(`Deleted data file: ${this.getLoggableFilePath(filePrefix, id)}`);
         return true;
       }
       return false;
     } catch (error) {
-      logger.error(`Failed to delete data for ${id}: ${error}`);
+      logger.error(`Failed to delete data for ${this.getLoggableId(filePrefix, id)}: ${error}`);
       throw error;
     }
   }

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -312,6 +312,19 @@ export class FileStorageService {
   }
 
   /**
+   * Gets a log-safe representation of an error object.
+   */
+  private getLoggableError(filePrefix: string, error: unknown): string {
+    if (this.isSensitiveId(filePrefix)) {
+      if (error instanceof Error && 'code' in error && typeof (error as { code?: unknown }).code === 'string') {
+        return `${error.name} (${(error as { code: string }).code})`;
+      }
+      return '[REDACTED]';
+    }
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  /**
    * Writes data to a file with the specified prefix and ID
    */
   writeData<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
@@ -320,7 +333,9 @@ export class FileStorageService {
       fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
       logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
     } catch (error) {
-      logger.error(`Failed to write data for ${this.getLoggableId(filePrefix, id)}: ${error}`);
+      logger.error(
+        `Failed to write data for ${this.getLoggableId(filePrefix, id)}: ${this.getLoggableError(filePrefix, error)}`,
+      );
       throw error;
     }
   }
@@ -352,7 +367,9 @@ export class FileStorageService {
           // A later startup cleanup removes abandoned temporary files.
         }
       }
-      logger.error(`Failed to write data for ${this.getLoggableId(filePrefix, id)}: ${error}`);
+      logger.error(
+        `Failed to write data for ${this.getLoggableId(filePrefix, id)}: ${this.getLoggableError(filePrefix, error)}`,
+      );
       throw error;
     }
   }
@@ -385,7 +402,9 @@ export class FileStorageService {
 
       return parsedData;
     } catch (error) {
-      logger.error(`Failed to read data for ${this.getLoggableId(filePrefix, id)}: ${error}`);
+      logger.error(
+        `Failed to read data for ${this.getLoggableId(filePrefix, id)}: ${this.getLoggableError(filePrefix, error)}`,
+      );
       return null;
     }
   }
@@ -408,7 +427,9 @@ export class FileStorageService {
       }
       return false;
     } catch (error) {
-      logger.error(`Failed to delete data for ${this.getLoggableId(filePrefix, id)}: ${error}`);
+      logger.error(
+        `Failed to delete data for ${this.getLoggableId(filePrefix, id)}: ${this.getLoggableError(filePrefix, error)}`,
+      );
       throw error;
     }
   }

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -325,6 +325,34 @@ export class FileStorageService {
   }
 
   /**
+   * Gets a log-safe representation of a file name.
+   */
+  private getLoggableFileName(fileName: string): string {
+    const sensitivePrefixes = [AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX, AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX];
+    for (const prefix of sensitivePrefixes) {
+      if (fileName.startsWith(prefix)) {
+        return `${prefix}[REDACTED]${AUTH_CONFIG.SERVER.STORAGE.FILE_EXTENSION}`;
+      }
+    }
+    return fileName;
+  }
+
+  /**
+   * Gets a log-safe representation of an error object associated with a file name.
+   */
+  private getLoggableErrorForFileName(fileName: string, error: unknown): string {
+    const sensitivePrefixes = [AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX, AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX];
+    const isSensitive = sensitivePrefixes.some((prefix) => fileName.startsWith(prefix));
+    if (isSensitive) {
+      if (error instanceof Error && 'code' in error && typeof (error as { code?: unknown }).code === 'string') {
+        return `${error.name} (${(error as { code: string }).code})`;
+      }
+      return '[REDACTED]';
+    }
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  /**
    * Writes data to a file with the specified prefix and ID
    */
   writeData<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
@@ -509,16 +537,20 @@ export class FileStorageService {
             if (parsedData.expires && parsedData.expires < Date.now()) {
               fs.unlinkSync(filePath);
               cleanedCount++;
-              logger.debug(`Cleaned up expired file: ${file}`);
+              logger.debug(`Cleaned up expired file: ${this.getLoggableFileName(file)}`);
             }
           } catch (error) {
             // Remove corrupted files
-            logger.warn(`Removing corrupted file ${file}: ${error}`);
+            logger.warn(
+              `Removing corrupted file ${this.getLoggableFileName(file)}: ${this.getLoggableErrorForFileName(file, error)}`,
+            );
             try {
               fs.unlinkSync(filePath);
               cleanedCount++;
             } catch (unlinkError) {
-              logger.error(`Failed to remove corrupted file ${file}: ${unlinkError}`);
+              logger.error(
+                `Failed to remove corrupted file ${this.getLoggableFileName(file)}: ${this.getLoggableErrorForFileName(file, unlinkError)}`,
+              );
             }
           }
         }
@@ -529,7 +561,7 @@ export class FileStorageService {
       }
       return cleanedCount;
     } catch (error) {
-      logger.error(`Failed to cleanup expired data: ${error}`);
+      logger.error(`Failed to cleanup expired data: ${this.getLoggableError('', error)}`);
       return 0;
     }
   }

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -281,21 +281,24 @@ export class FileStorageService {
     return false;
   }
 
+  private static readonly SENSITIVE_FILE_PREFIXES = [
+    AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX,
+    AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX,
+  ] as const;
+
   /**
-   * Checks if an ID/filePrefix represents sensitive data that should be redacted from logs.
+   * Checks if an ID/filePrefix or filename represents sensitive data that should be redacted from logs.
    */
-  private isSensitiveId(filePrefix?: string): boolean {
-    return (
-      filePrefix === AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX ||
-      filePrefix === AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX
-    );
+  private isSensitivePrefix(prefixOrFileName?: string): boolean {
+    if (!prefixOrFileName) return false;
+    return FileStorageService.SENSITIVE_FILE_PREFIXES.some((prefix) => prefixOrFileName.startsWith(prefix));
   }
 
   /**
    * Gets a log-safe representation of an ID.
    */
   private getLoggableId(filePrefix: string, id: string): string {
-    if (this.isSensitiveId(filePrefix)) {
+    if (this.isSensitivePrefix(filePrefix)) {
       return '[REDACTED]';
     }
     return id;
@@ -305,7 +308,7 @@ export class FileStorageService {
    * Gets a log-safe representation of a file path.
    */
   private getLoggableFilePath(filePrefix: string, id: string): string {
-    if (this.isSensitiveId(filePrefix)) {
+    if (this.isSensitivePrefix(filePrefix)) {
       return path.join(this.storageDir, `${filePrefix}[REDACTED]${AUTH_CONFIG.SERVER.STORAGE.FILE_EXTENSION}`);
     }
     return this.getFilePath(filePrefix, id);
@@ -315,7 +318,7 @@ export class FileStorageService {
    * Gets a log-safe representation of an error object.
    */
   private getLoggableError(filePrefix: string, error: unknown): string {
-    if (this.isSensitiveId(filePrefix)) {
+    if (this.isSensitivePrefix(filePrefix)) {
       if (error instanceof Error && 'code' in error && typeof (error as { code?: unknown }).code === 'string') {
         return `${error.name} (${(error as { code: string }).code})`;
       }
@@ -325,12 +328,14 @@ export class FileStorageService {
   }
 
   /**
-   * Gets a log-safe representation of a file name.
+   * Gets a log-safe representation of a file name (including .tmp files).
    */
   private getLoggableFileName(fileName: string): string {
-    const sensitivePrefixes = [AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX, AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX];
-    for (const prefix of sensitivePrefixes) {
+    for (const prefix of FileStorageService.SENSITIVE_FILE_PREFIXES) {
       if (fileName.startsWith(prefix)) {
+        if (fileName.endsWith('.tmp')) {
+          return `${prefix}[REDACTED].tmp`;
+        }
         return `${prefix}[REDACTED]${AUTH_CONFIG.SERVER.STORAGE.FILE_EXTENSION}`;
       }
     }
@@ -341,9 +346,7 @@ export class FileStorageService {
    * Gets a log-safe representation of an error object associated with a file name.
    */
   private getLoggableErrorForFileName(fileName: string, error: unknown): string {
-    const sensitivePrefixes = [AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX, AUTH_CONFIG.SERVER.AUTH_REQUEST.FILE_PREFIX];
-    const isSensitive = sensitivePrefixes.some((prefix) => fileName.startsWith(prefix));
-    if (isSensitive) {
+    if (this.isSensitivePrefix(fileName)) {
       if (error instanceof Error && 'code' in error && typeof (error as { code?: unknown }).code === 'string') {
         return `${error.name} (${(error as { code: string }).code})`;
       }
@@ -522,7 +525,9 @@ export class FileStorageService {
               cleanedCount++;
             }
           } catch (error) {
-            logger.warn(`Failed to clean temporary file ${file}: ${error}`);
+            logger.warn(
+              `Failed to clean temporary file ${this.getLoggableFileName(file)}: ${this.getLoggableErrorForFileName(file, error)}`,
+            );
           }
           continue;
         }

--- a/src/auth/storage/oauthStorageService.ts
+++ b/src/auth/storage/oauthStorageService.ts
@@ -147,6 +147,9 @@ export class OAuthStorageService {
     return this.sessions;
   }
 
+  /**
+   * Underlying file storage service used for exclusive locking and persistence management.
+   */
   get fileStorage(): FileStorageService {
     return this.storage;
   }

--- a/src/auth/storage/oauthStorageService.ts
+++ b/src/auth/storage/oauthStorageService.ts
@@ -147,6 +147,10 @@ export class OAuthStorageService {
     return this.sessions;
   }
 
+  get fileStorage(): FileStorageService {
+    return this.storage;
+  }
+
   get authCodeRepository(): AuthCodeRepository {
     return this.authCodes;
   }


### PR DESCRIPTION
Fixes #468

## Summary

This PR ensures OAuth 2.0 authorization code redemption is strictly atomic to eliminate TOCTOU / double-spending race conditions under concurrent token requests, and centralizes log redaction across the entire storage lifecycle (CRUD operations, filesystem failure paths, expiry cleanup, and directory migration).

## Changes

- **Atomic Code Redemption (`src/auth/sdkOAuthServerProvider.ts`)**:
  - Wrapped authorization code lookup, validation, deletion, and token issuance in `this.oauthStorage.fileStorage.withExclusiveLock('auth-code-exchange', ...)`.
  - Competing redemption attempts for the same code fail with standard `InvalidGrantError('Invalid or expired authorization code')`.
- **Centralized Redaction & Storage Lifecycle Logs (`src/auth/storage/fileStorageService.ts`)**:
  - Centralized sensitive prefix detection for authorization codes and requests via `getSensitivePrefixes()` and `isSensitivePrefix()`.
  - Redacted file paths and identifiers in `writeData`, `writeDataDurable`, `readData`, and `deleteData` logs.
  - Redacted native filesystem error messages (`getLoggableError`) to prevent error paths (such as `EACCES`) from exposing absolute file paths while preserving safe error codes (e.g. `Error (EACCES)`).
  - Redacted expired `.json` and orphaned `.tmp` file cleanup logs in `cleanupExpiredData`.
  - Redacted migration success and error logs in `migrateOldFilesIfNeeded`.
- **Repository Log Sanitization (`src/auth/storage/authCodeRepository.ts`, `src/auth/storage/authRequestRepository.ts`, `src/auth/sdkOAuthServerProvider.ts`)**:
  - Removed plaintext `${code}` and `${authRequestId}` interpolations from repository info logs.
  - Scrubbed `authorizationCode` fields from debug logs in `challengeForAuthorizationCode` and `exchangeAuthorizationCode`.
- **Storage Encapsulation (`src/auth/storage/oauthStorageService.ts`)**:
  - Added documented `fileStorage` getter to expose the underlying storage lock mutex.
- **Regression Tests (`src/auth/sdkOAuthServerProvider.refresh.test.ts`, `src/auth/storage/fileStorageService.migration.test.ts`)**:
  - **Concurrency**: 5 concurrent exchange requests assert strictly 1 fulfilled response with remaining requests rejected as `InvalidGrantError`.
  - **Log Zero-Leakage**: Asserted that generated `code` values are absent across all log levels (`info`, `debug`, `warn`, `error`) during normal exchange, storage deletion failure, and expiry cleanup.
  - **Migration & Failure Redaction**: Added test cases in `fileStorageService.migration.test.ts` asserting that migration logs and simulated rename failures redact file names to `auth_code_[REDACTED].json` and preserve error codes.

## References
- RFC 9700 §4.2.4 (OAuth 2.0 Security BCP)
- RFC 6749 §4.1.2
- CWE-532 (Insertion of Sensitive Information into Log File)