### PR TITLE
fix(security): mitigate CI script injection and drop secrets inherit

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -115,7 +115,9 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --access public --provenance --tag ${{ inputs.npm_tag }}
+        env:
+          NPM_TAG: ${{ inputs.npm_tag }}
+        run: pnpm publish --no-git-checks --access public --provenance --tag "$NPM_TAG"
 
       - name: Resolve release changelog range
         id: release-notes-range

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -60,7 +60,6 @@ jobs:
     with:
       release_ref: ${{ needs.validate.outputs.release_ref }}
       version: ${{ needs.validate.outputs.version }}
-    secrets: inherit
     permissions:
       contents: write
 
@@ -103,7 +102,6 @@ jobs:
       version_tag: ${{ needs.validate.outputs.version_tag }}
       npm_tag: ${{ needs.validate.outputs.npm_tag }}
       is_prerelease: ${{ needs.validate.outputs.is_prerelease == 'true' }}
-    secrets: inherit
     permissions:
       contents: write
       id-token: write

--- a/src/release/publish-to-npm-workflow.test.ts
+++ b/src/release/publish-to-npm-workflow.test.ts
@@ -32,11 +32,11 @@ describe('publish-to-npm workflow', () => {
 
   it('passes npm_tag via environment variable rather than direct shell interpolation', () => {
     const workflow = readPublishWorkflow();
+    const publishStep = workflow.match(/- name: Publish to npm\n(?<body>(?:\s{8}.*\n)+)/)?.groups?.body;
 
-    expect(workflow).not.toContain(
-      'pnpm publish --no-git-checks --access public --provenance --tag ${{ inputs.npm_tag }}',
-    );
-    expect(workflow).toContain('NPM_TAG: ${{ inputs.npm_tag }}');
-    expect(workflow).toContain('pnpm publish --no-git-checks --access public --provenance --tag "$NPM_TAG"');
+    expect(publishStep).toBeDefined();
+    expect(publishStep).not.toMatch(/run:[\s\S]*?\${{\s*inputs\.npm_tag\s*}}/);
+    expect(publishStep).toContain('NPM_TAG: ${{ inputs.npm_tag }}');
+    expect(publishStep).toContain('pnpm publish --no-git-checks --access public --provenance --tag "$NPM_TAG"');
   });
 });

--- a/src/release/publish-to-npm-workflow.test.ts
+++ b/src/release/publish-to-npm-workflow.test.ts
@@ -4,7 +4,9 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 function readPublishWorkflow(): string {
-  return fs.readFileSync(path.join(process.cwd(), '.github', 'workflows', 'publish-to-npm.yml'), 'utf8');
+  return fs
+    .readFileSync(path.join(process.cwd(), '.github', 'workflows', 'publish-to-npm.yml'), 'utf8')
+    .replace(/\r\n/g, '\n');
 }
 
 describe('publish-to-npm workflow', () => {
@@ -26,5 +28,15 @@ describe('publish-to-npm workflow', () => {
     expect(workflow).toContain('binaries/**/*.tar.gz');
     expect(workflow).toContain('binaries/**/*.zip');
     expect(workflow).not.toContain('files: binaries/*/*');
+  });
+
+  it('passes npm_tag via environment variable rather than direct shell interpolation', () => {
+    const workflow = readPublishWorkflow();
+
+    expect(workflow).not.toContain(
+      'pnpm publish --no-git-checks --access public --provenance --tag ${{ inputs.npm_tag }}',
+    );
+    expect(workflow).toContain('NPM_TAG: ${{ inputs.npm_tag }}');
+    expect(workflow).toContain('pnpm publish --no-git-checks --access public --provenance --tag "$NPM_TAG"');
   });
 });

--- a/src/release/release-pipeline-workflow.test.ts
+++ b/src/release/release-pipeline-workflow.test.ts
@@ -4,7 +4,9 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 function readReleasePipelineWorkflow(): string {
-  return fs.readFileSync(path.join(process.cwd(), '.github', 'workflows', 'release-pipeline.yml'), 'utf8');
+  return fs
+    .readFileSync(path.join(process.cwd(), '.github', 'workflows', 'release-pipeline.yml'), 'utf8')
+    .replace(/\r\n/g, '\n');
 }
 
 describe('release-pipeline workflow', () => {
@@ -24,5 +26,11 @@ describe('release-pipeline workflow', () => {
     expect(finalizeJob).toBeDefined();
     expect(finalizeJob).toContain("if: ${{ needs.validate.outputs.release_ref == 'main' }}");
     expect(finalizeJob).not.toContain('is_prerelease');
+  });
+
+  it('does not pass secrets: inherit to reusable workflows', () => {
+    const workflow = readReleasePipelineWorkflow();
+
+    expect(workflow).not.toContain('secrets: inherit');
   });
 });


### PR DESCRIPTION
Fixes #469

## Summary

This PR hardens the GitHub Actions release pipeline by mitigating potential script injection surfaces in `publish-to-npm.yml` and removing unnecessary `secrets: inherit` declarations in `release-pipeline.yml`.

## Key Changes

1. **Script Injection Mitigation (`publish-to-npm.yml`)**:
   - Parameterized `${{ inputs.npm_tag }}` via intermediate environment variable `NPM_TAG: ${{ inputs.npm_tag }}` and quoted `"$NPM_TAG"` within the shell `run:` step.
   - Prevents shell metacharacter expansion during dynamic workflow generation (CWE-78 / GitHub Actions Security BCP).

2. **Least-Privilege Secret Forwarding (`release-pipeline.yml`)**:
   - Removed `secrets: inherit` from `update-version` and `release` reusable workflow jobs.
   - Both target workflows rely strictly on automatically provisioned `GITHUB_TOKEN` (via explicit job `permissions`) and OIDC tokens (`id-token: write`), requiring no repository secrets.

3. **Automated Regression Guard (`src/release/*.test.ts`)**:
   - Added unit test assertions in `src/release/publish-to-npm-workflow.test.ts` verifying that `npm_tag` is passed via `env: NPM_TAG` and not inlined into `run:`.
   - Added unit test assertions in `src/release/release-pipeline-workflow.test.ts` verifying that `secrets: inherit` is absent.
   - Normalized line endings in workflow test readers to ensure deterministic cross-platform execution.

## Verification

- `pnpm vitest run src/release` (9 test suites, 28/28 tests passed)
- `pnpm typecheck` (0 type errors)
- `pnpm lint` (0 ESLint errors)
- `node build/index.js --version` (CLI process liveness verified: 0.35.0)

## References

- Ref Issue: #469
- [GitHub Docs — Understanding the risk of script injections](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
- [GitHub Docs — Reusing workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-secrets-to-reusable-workflows)
- CWE-78 & CWE-272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm publishing to reliably apply the selected release tag.
  * Removed unnecessary secret inheritance from release workflow steps.
  * Improved compatibility when processing workflow files across operating systems.

* **Tests**
  * Added coverage for release tag handling and secure workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->