### PR TITLE
fix(security): write token files with 0600 and storage dir with 0700 permissions

### DIFF
--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -136,6 +136,22 @@ describe('FileStorageService', () => {
       expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
     });
 
+    it('hardens pre-existing migration flag permissions to 0600', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const customDir = path.join(tmpdir(), `custom-migration-flag-test-${Date.now()}`);
+      const sessionsPath = path.join(customDir, 'sessions');
+      fs.mkdirSync(sessionsPath, { recursive: true, mode: 0o700 });
+      const flagPath = path.join(sessionsPath, '.migrated-to-server');
+      fs.writeFileSync(flagPath, JSON.stringify({ migrated: true }), { mode: 0o644 });
+      fs.chmodSync(flagPath, 0o644);
+
+      const serverService = new FileStorageService(customDir, 'server');
+      expect(fs.statSync(flagPath).mode & 0o777).toBe(0o600);
+      serverService.shutdown();
+      fs.rmSync(customDir, { recursive: true, force: true });
+    });
+
     it('preserves the previous record when a replacement write fails after truncation', () => {
       service.writeData(testPrefix, testId, testData);
       const targetPath = service.getFilePath(testPrefix, testId);

--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -198,6 +198,34 @@ describe('FileStorageService', () => {
       fs.rmSync(customDir, { recursive: true, force: true });
     });
 
+    it('does not create migration flag if file hardening fails during migration', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const customDir = path.join(tmpdir(), `custom-migration-fail-test-${Date.now()}`);
+      const sessionsDir = path.join(customDir, 'sessions');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+
+      const legacyFileName = 'session_sess-12345678-1234-4abc-89de-123456789012.json';
+      const legacyFilePath = path.join(sessionsDir, legacyFileName);
+      fs.writeFileSync(legacyFilePath, JSON.stringify(testData), { mode: 0o644 });
+      fs.chmodSync(legacyFilePath, 0o644);
+
+      const originalChmodSync = fs.chmodSync;
+      vi.spyOn(fs, 'chmodSync').mockImplementation((pathArg, modeArg) => {
+        if (String(pathArg).includes(legacyFileName)) {
+          throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' });
+        }
+        return originalChmodSync(pathArg, modeArg);
+      });
+
+      const serverService = new FileStorageService(customDir, 'server');
+      const flagPath = path.join(sessionsDir, '.migrated-to-server');
+      expect(fs.existsSync(flagPath)).toBe(false);
+
+      serverService.shutdown();
+      fs.rmSync(customDir, { recursive: true, force: true });
+    });
+
     it('preserves the previous record when a replacement write fails after truncation', () => {
       service.writeData(testPrefix, testId, testData);
       const targetPath = service.getFilePath(testPrefix, testId);

--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -87,6 +87,14 @@ describe('FileStorageService', () => {
       expect(retrieved).toEqual(testData);
     });
 
+    it('writes token data files with 0600 permissions', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      service.writeData(testPrefix, testId, testData);
+      const filePath = path.join(tempDir, `${testPrefix}${testId}.json`);
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+    });
+
     it('preserves the previous record when a replacement write fails after truncation', () => {
       service.writeData(testPrefix, testId, testData);
       const targetPath = service.getFilePath(testPrefix, testId);

--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -64,10 +64,11 @@ describe('FileStorageService', () => {
     });
 
     it('should handle directory creation errors', () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValueOnce(false);
       vi.spyOn(fs, 'mkdirSync').mockImplementationOnce(() => {
         throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
       });
-      expect(() => new FileStorageService('/any/path')).toThrow();
+      expect(() => new FileStorageService(tempDir)).toThrow(/EACCES/);
     });
   });
 
@@ -92,7 +93,7 @@ describe('FileStorageService', () => {
       // POSIX-only: Windows ACLs do not map to fs.stat modes
       if (process.platform === 'win32') return;
       service.writeData(testPrefix, testId, testData);
-      const filePath = path.join(tempDir, `${testPrefix}${testId}.json`);
+      const filePath = service.getFilePath(testPrefix, testId);
       expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
     });
 
@@ -100,14 +101,39 @@ describe('FileStorageService', () => {
       // POSIX-only: Windows ACLs do not map to fs.stat modes
       if (process.platform === 'win32') return;
       service.writeDataDurable(testPrefix, testId, testData);
-      const filePath = path.join(tempDir, `${testPrefix}${testId}.json`);
+      const filePath = service.getFilePath(testPrefix, testId);
       expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
     });
 
     it('creates storage directory with 0700 permissions', () => {
       // POSIX-only: Windows ACLs do not map to fs.stat modes
       if (process.platform === 'win32') return;
-      expect(fs.statSync(tempDir).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(service.getStorageDir()).mode & 0o777).toBe(0o700);
+    });
+
+    it('hardens pre-existing storage directory permissions to 0700', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const customDir = path.join(tmpdir(), `custom-perm-test-${Date.now()}`);
+      const sessionsPath = path.join(customDir, 'sessions');
+      fs.mkdirSync(sessionsPath, { recursive: true, mode: 0o755 });
+      fs.chmodSync(sessionsPath, 0o755);
+
+      const customService = new FileStorageService(customDir);
+      expect(fs.statSync(sessionsPath).mode & 0o777).toBe(0o700);
+      customService.shutdown();
+      fs.rmSync(customDir, { recursive: true, force: true });
+    });
+
+    it('hardens pre-existing data file permissions to 0600 on writeData', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const filePath = service.getFilePath(testPrefix, testId);
+      fs.writeFileSync(filePath, JSON.stringify(testData, null, 2), { mode: 0o644 });
+      fs.chmodSync(filePath, 0o644);
+
+      service.writeData(testPrefix, testId, testData);
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
     });
 
     it('preserves the previous record when a replacement write fails after truncation', () => {

--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -64,9 +64,10 @@ describe('FileStorageService', () => {
     });
 
     it('should handle directory creation errors', () => {
-      const invalidDir =
-        process.platform === 'win32' ? 'Z:\\nonexistent_drive_123\\sessions' : '/invalid/path/that/cannot/be/created';
-      expect(() => new FileStorageService(invalidDir)).toThrow();
+      vi.spyOn(fs, 'mkdirSync').mockImplementationOnce(() => {
+        throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+      });
+      expect(() => new FileStorageService('/any/path')).toThrow();
     });
   });
 
@@ -93,6 +94,20 @@ describe('FileStorageService', () => {
       service.writeData(testPrefix, testId, testData);
       const filePath = path.join(tempDir, `${testPrefix}${testId}.json`);
       expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+    });
+
+    it('durable write: token data files land with 0600 permissions (regression)', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      service.writeDataDurable(testPrefix, testId, testData);
+      const filePath = path.join(tempDir, `${testPrefix}${testId}.json`);
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+    });
+
+    it('creates storage directory with 0700 permissions', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      expect(fs.statSync(tempDir).mode & 0o777).toBe(0o700);
     });
 
     it('preserves the previous record when a replacement write fails after truncation', () => {

--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import fs from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
@@ -32,8 +31,8 @@ describe('FileStorageService', () => {
   let tempDir: string;
 
   beforeEach(() => {
-    // Create a temporary directory for testing
-    tempDir = path.join(tmpdir(), `file-storage-test-${randomUUID()}`);
+    // Create a unique temporary directory for testing
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), 'file-storage-test-'));
     service = new FileStorageService(tempDir);
   });
 
@@ -148,6 +147,53 @@ describe('FileStorageService', () => {
 
       const serverService = new FileStorageService(customDir, 'server');
       expect(fs.statSync(flagPath).mode & 0o777).toBe(0o600);
+      serverService.shutdown();
+      fs.rmSync(customDir, { recursive: true, force: true });
+    });
+
+    it('does not write replacement secret if chmod fails on pre-existing permissive file', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const filePath = service.getFilePath(testPrefix, testId);
+      fs.writeFileSync(filePath, JSON.stringify({ ...testData, value: 'old-secret' }), { mode: 0o644 });
+      fs.chmodSync(filePath, 0o644);
+
+      const originalChmodSync = fs.chmodSync;
+      vi.spyOn(fs, 'chmodSync').mockImplementation((pathArg, modeArg) => {
+        if (pathArg === filePath) {
+          throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' });
+        }
+        return originalChmodSync(pathArg, modeArg);
+      });
+
+      expect(() =>
+        service.writeData(testPrefix, testId, {
+          ...testData,
+          value: 'new-secret',
+        }),
+      ).toThrow(/EPERM/);
+
+      const contentOnDisk = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      expect(contentOnDisk.value).toBe('old-secret');
+    });
+
+    it('hardens legacy data files to 0600 during migration', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const customDir = path.join(tmpdir(), `custom-migration-harden-test-${Date.now()}`);
+      const sessionsDir = path.join(customDir, 'sessions');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+
+      const legacyFileName = 'session_sess-12345678-1234-4abc-89de-123456789012.json';
+      const legacyFilePath = path.join(sessionsDir, legacyFileName);
+      fs.writeFileSync(legacyFilePath, JSON.stringify(testData), { mode: 0o644 });
+      fs.chmodSync(legacyFilePath, 0o644);
+
+      const serverService = new FileStorageService(customDir, 'server');
+      const migratedFilePath = path.join(customDir, 'sessions', 'server', legacyFileName);
+      expect(fs.existsSync(migratedFilePath)).toBe(true);
+      expect(fs.statSync(migratedFilePath).mode & 0o777).toBe(0o600);
+
       serverService.shutdown();
       fs.rmSync(customDir, { recursive: true, force: true });
     });

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -368,7 +368,7 @@ export class FileStorageService {
   writeData<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
     try {
       const filePath = this.getFilePath(filePrefix, id);
-      fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
       logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
     } catch (error) {
       logger.error(

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -138,6 +138,13 @@ export class FileStorageService {
 
         try {
           fs.renameSync(oldPath, newPath);
+          if (process.platform !== 'win32') {
+            try {
+              fs.chmodSync(newPath, 0o600);
+            } catch (error) {
+              logger.warn(`Failed to harden migrated file permissions for ${file}: ${error}`);
+            }
+          }
           migrationCount++;
           logger.info(`Migrated ${this.getLoggableFileName(file)} from ${sourceDir} to ${this.storageDir}`);
         } catch (error) {
@@ -386,6 +393,9 @@ export class FileStorageService {
   writeData<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
     try {
       const filePath = this.getFilePath(filePrefix, id);
+      if (process.platform !== 'win32' && fs.existsSync(filePath)) {
+        fs.chmodSync(filePath, 0o600);
+      }
       fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
       if (process.platform !== 'win32') {
         fs.chmodSync(filePath, 0o600);

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -52,6 +52,11 @@ export class FileStorageService {
         fs.mkdirSync(this.storageDir, { recursive: true, mode: 0o700 });
         logger.info(`Created storage directory: ${this.storageDir}`);
       }
+      try {
+        fs.chmodSync(this.storageDir, 0o700);
+      } catch {
+        // Ignore chmod errors on systems that don't support POSIX modes (e.g. Windows)
+      }
     } catch (error) {
       logger.error(`Failed to create storage directory: ${error}`);
       throw error;
@@ -370,6 +375,11 @@ export class FileStorageService {
     try {
       const filePath = this.getFilePath(filePrefix, id);
       fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
+      try {
+        fs.chmodSync(filePath, 0o600);
+      } catch {
+        // Ignore chmod errors on systems that don't support POSIX modes (e.g. Windows)
+      }
       logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
     } catch (error) {
       logger.error(

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -127,6 +127,7 @@ export class FileStorageService {
     }
 
     let migrationCount = 0;
+    let hasFailures = false;
 
     // Migrate files matching current subdirectory's prefixes
     for (const file of files) {
@@ -137,17 +138,17 @@ export class FileStorageService {
         const newPath = path.join(this.storageDir, file);
 
         try {
+          if (process.platform !== 'win32') {
+            fs.chmodSync(oldPath, 0o600);
+          }
           fs.renameSync(oldPath, newPath);
           if (process.platform !== 'win32') {
-            try {
-              fs.chmodSync(newPath, 0o600);
-            } catch (error) {
-              logger.warn(`Failed to harden migrated file permissions for ${file}: ${error}`);
-            }
+            fs.chmodSync(newPath, 0o600);
           }
           migrationCount++;
           logger.info(`Migrated ${this.getLoggableFileName(file)} from ${sourceDir} to ${this.storageDir}`);
         } catch (error) {
+          hasFailures = true;
           logger.error(
             `Failed to migrate ${this.getLoggableFileName(file)}: ${this.getLoggableErrorForFileName(file, error)}`,
           );
@@ -155,11 +156,11 @@ export class FileStorageService {
       }
     }
 
-    if (migrationCount > 0) {
+    if (!hasFailures) {
       this.createMigrationFlag(sourceDir, currentSubDir);
-      logger.info(`Migration completed: ${migrationCount} files migrated to ${currentSubDir}/`);
-    } else {
-      this.createMigrationFlag(sourceDir, currentSubDir);
+      if (migrationCount > 0) {
+        logger.info(`Migration completed: ${migrationCount} files migrated to ${currentSubDir}/`);
+      }
     }
   }
 

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -49,7 +49,7 @@ export class FileStorageService {
   private ensureDirectory(): void {
     try {
       if (!fs.existsSync(this.storageDir)) {
-        fs.mkdirSync(this.storageDir, { recursive: true });
+        fs.mkdirSync(this.storageDir, { recursive: true, mode: 0o700 });
         logger.info(`Created storage directory: ${this.storageDir}`);
       }
     } catch (error) {
@@ -159,6 +159,7 @@ export class FileStorageService {
           targetSubDir,
           timestamp: Date.now(),
         }),
+        { mode: 0o600 },
       );
       logger.debug(`Created migration flag: .migrated-to-${targetSubDir} in ${sourceDir}`);
     } catch (error) {

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -52,10 +52,8 @@ export class FileStorageService {
         fs.mkdirSync(this.storageDir, { recursive: true, mode: 0o700 });
         logger.info(`Created storage directory: ${this.storageDir}`);
       }
-      try {
+      if (process.platform !== 'win32') {
         fs.chmodSync(this.storageDir, 0o700);
-      } catch {
-        // Ignore chmod errors on systems that don't support POSIX modes (e.g. Windows)
       }
     } catch (error) {
       logger.error(`Failed to create storage directory: ${error}`);
@@ -111,6 +109,13 @@ export class FileStorageService {
     // Check subdirectory-specific migration flag
     const migrationFlagPath = path.join(sourceDir, `.migrated-to-${currentSubDir}`);
     if (fs.existsSync(migrationFlagPath)) {
+      if (process.platform !== 'win32') {
+        try {
+          fs.chmodSync(migrationFlagPath, 0o600);
+        } catch (error) {
+          logger.warn(`Failed to harden migration flag permissions: ${error}`);
+        }
+      }
       logger.debug(`Migration from ${sourceDir} to ${currentSubDir} already completed`);
       return;
     }
@@ -166,6 +171,13 @@ export class FileStorageService {
         }),
         { mode: 0o600 },
       );
+      if (process.platform !== 'win32') {
+        try {
+          fs.chmodSync(migrationFlagPath, 0o600);
+        } catch (error) {
+          logger.warn(`Failed to harden migration flag permissions: ${error}`);
+        }
+      }
       logger.debug(`Created migration flag: .migrated-to-${targetSubDir} in ${sourceDir}`);
     } catch (error) {
       logger.warn(`Failed to create migration flag: ${error}`);
@@ -375,10 +387,8 @@ export class FileStorageService {
     try {
       const filePath = this.getFilePath(filePrefix, id);
       fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
-      try {
+      if (process.platform !== 'win32') {
         fs.chmodSync(filePath, 0o600);
-      } catch {
-        // Ignore chmod errors on systems that don't support POSIX modes (e.g. Windows)
       }
       logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
     } catch (error) {


### PR DESCRIPTION
Fixes #491

### Problem

`FileStorageService.writeData()` persisted token and session records via `fs.writeFileSync()` without specifying a `mode` option, leaving newly created files subject to the default process umask (typically `0o644` on POSIX systems, allowing other local users to read credentials). Furthermore, because `fs.writeFileSync` ignores the `mode` option on pre-existing files, updating an existing file did not correct permissive permissions. Additionally, writing replacement secret content before applying `chmodSync` could leave secrets in a permissive file if chmod failed.

Similarly, `ensureDirectory()` created the storage directory without `mode: 0o700` and did not harden pre-existing directories created under older permissions. Legacy migration did not harden migrated files before/after moving, and a hardening failure still marked migration as complete.

### Changes

- **`src/auth/storage/fileStorageService.ts`**:
  - `ensureDirectory()`: Create storage directory with `mode: 0o700` and apply `fs.chmodSync(this.storageDir, 0o700)` on POSIX platforms so pre-existing directories are hardened during upgrades.
  - `migrateOldFilesIfNeeded()`: Pre-harden source files with `fs.chmodSync(oldPath, 0o600)` prior to move, apply `fs.chmodSync(newPath, 0o600)` post-move, apply `fs.chmodSync(migrationFlagPath, 0o600)` when detecting an existing flag, and do not create the migration completion flag if any file fails hardening (allowing retries on subsequent startups).
  - `createMigrationFlag()`: Write migration flag files with `{ mode: 0o600 }` and apply `fs.chmodSync(migrationFlagPath, 0o600)` on POSIX platforms.
  - `writeData()`: Pre-harden existing files to `0o600` before writing replacement content, write files with `{ mode: 0o600 }`, apply post-write `fs.chmodSync(filePath, 0o600)` on POSIX platforms, and preserve log redaction for sensitive identifiers.

- **`src/auth/storage/fileStorageService.test.ts`**:
  - Mock `fs.existsSync` and `fs.mkdirSync` in the directory creation error test, asserting the `EACCES` error directly.
  - Add test verifying `writeData()` creates files with `0o600` permissions (POSIX-only).
  - Add regression test verifying `writeDataDurable()` preserves `0o600` permissions (POSIX-only).
  - Add test verifying `ensureDirectory()` creates the storage directory with `0o700` permissions (POSIX-only).
  - Add upgrade regression test verifying pre-existing `0o755` storage directories are hardened to `0o700` (POSIX-only).
  - Add upgrade regression test verifying pre-existing `0o644` data files are hardened to `0o600` upon `writeData()` (POSIX-only).
  - Add upgrade regression test verifying pre-existing `0o644` migration flag files are hardened to `0o600` (POSIX-only).
  - Add fault-injection regression test verifying replacement secrets are not written if pre-write chmod fails on pre-existing permissive files (POSIX-only).
  - Add upgrade regression test verifying legacy `0o644` data files are hardened to `0o600` during migration (POSIX-only).
  - Add fault-injection regression test verifying migration completion flag is not created if file hardening fails during migration (POSIX-only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Storage directories and authentication data files now use restrictive permissions to help prevent unauthorized access.
  * Existing files and migrated data are automatically hardened on supported platforms.
  * Migration completion is recorded only after all files are secured successfully.
  * Permission-setting failures are handled consistently while preserving existing error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->