### PR TITLE
fix(security): escape control characters in secureLogger (CWE-117 log forging)

### DIFF
--- a/src/commands/wait/wait.ts
+++ b/src/commands/wait/wait.ts
@@ -150,7 +150,7 @@ export async function waitForServers(
     if (response.status === 401 || response.status === 403) {
       return { status: 'auth_required', message: formatClientSurfaceAuthRequiredMessage(context) };
     }
-    if (Date.now() >= deadline) {
+    if (Date.now() >= deadline || response.error?.startsWith('Request timed out')) {
       throwWaitTimeout(timeout, context.options.server, lastServers);
     }
     if (!response.ok) {

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -177,6 +177,17 @@ describe('secureLogger', () => {
       const sanitizedCause = result.cause as Record<string, unknown>;
       expect(sanitizedCause.message).toContain('[REDACTED]');
       expect(sanitizedCause.message).not.toContain('rootpass123');
+
+      // Non-string Error.name containing credentials
+      const nonStringNameError = new Error('Normal message');
+      (nonStringNameError as any).name = {
+        toString: () => 'CustomToken_NONSTRING_SECRET_123\nInjected',
+      };
+      const sanitizedNonStringErr = sanitizeForLogging(nonStringNameError) as Record<string, unknown>;
+      expect(sanitizedNonStringErr.name).toContain('[REDACTED]');
+      expect(sanitizedNonStringErr.name).not.toContain('NONSTRING_SECRET_123');
+      expect(sanitizedNonStringErr.name).not.toContain('\n');
+      expect(sanitizedNonStringErr.name).toContain('\\n');
     });
 
     it('should escape Unicode line separators and Trojan Source Bidi overrides', () => {
@@ -188,7 +199,7 @@ describe('secureLogger', () => {
       expect(result).not.toContain('\u202E');
     });
 
-    it('should redact PEM private keys including full body content, Basic auth, and JWT tokens', () => {
+    it('should redact PEM private keys including full body content, unterminated blocks, Basic auth, and JWT tokens', () => {
       const pem =
         '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA0base64secretkeypayload...\n-----END RSA PRIVATE KEY-----';
       const sanitizedPem = sanitizeForLogging(pem) as string;
@@ -196,6 +207,11 @@ describe('secureLogger', () => {
       expect(sanitizedPem).not.toContain('BEGIN RSA PRIVATE KEY');
       expect(sanitizedPem).not.toContain('MIIEowIBAAKCAQEA0base64secretkeypayload');
       expect(sanitizedPem).not.toContain('END RSA PRIVATE KEY');
+
+      const unterminatedPem = '-----BEGIN RSA PRIVATE KEY-----\nUNTERMINATED_PRIVATE_BODY_123';
+      const sanitizedUnterminated = sanitizeForLogging(unterminatedPem) as string;
+      expect(sanitizedUnterminated).toBe('[REDACTED]');
+      expect(sanitizedUnterminated).not.toContain('UNTERMINATED_PRIVATE_BODY_123');
 
       const basic = 'Authorization: Basic dXNlcjpwYXNzd29yZDEyMw==';
       expect(sanitizeForLogging(basic)).toContain('[REDACTED]');
@@ -206,7 +222,7 @@ describe('secureLogger', () => {
       expect(sanitizeForLogging(jwt)).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
     });
 
-    it('should safely serialize complex data types (BigInt, Date, RegExp, Set, Map)', () => {
+    it('should safely serialize complex data types (BigInt, Date, RegExp, Set, Map, Symbol) and sanitize credentials', () => {
       const date = new Date('2026-08-24T00:00:00.000Z');
       expect(sanitizeForLogging(date)).toBe('2026-08-24T00:00:00.000Z');
 
@@ -215,6 +231,16 @@ describe('secureLogger', () => {
 
       const regex = /test\npattern/g;
       expect(sanitizeForLogging(regex)).toBe('/test\\npattern/g');
+
+      const regexWithCreds = /password=REGEXP_SECRET_123/i;
+      const sanitizedRegex = sanitizeForLogging(regexWithCreds) as string;
+      expect(sanitizedRegex).toContain('[REDACTED]');
+      expect(sanitizedRegex).not.toContain('REGEXP_SECRET_123');
+
+      const symbolWithCreds = Symbol('password=SYMBOL_SECRET_123');
+      const sanitizedSymbol = sanitizeForLogging(symbolWithCreds) as string;
+      expect(sanitizedSymbol).toContain('[REDACTED]');
+      expect(sanitizedSymbol).not.toContain('SYMBOL_SECRET_123');
 
       const set = new Set(['user1', 'token=secret999']);
       const sanitizedSet = sanitizeForLogging(set) as string[];

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -76,6 +76,83 @@ describe('secureLogger', () => {
       // The circular reference should eventually be cut off with [MAX_DEPTH]
       expect(JSON.stringify(result)).toContain('[MAX_DEPTH]');
     });
+
+    it('should escape CRLF to prevent log forging (CWE-117)', () => {
+      // Attacker-controlled input attempting to forge a second log line
+      const input = 'login failed for user admin\nINFO: User logged in: admin';
+      const result = sanitizeForLogging(input) as string;
+      expect(result).not.toContain('\n');
+      expect(result).toBe('login failed for user admin\\nINFO: User logged in: admin');
+    });
+
+    it('should escape all C0 control chars, DEL, and ANSI ESC', () => {
+      const input = 'a\r\nb\tc\x00d\x1B[31me\x7Ff';
+      const result = sanitizeForLogging(input) as string;
+      expect(result).toBe('a\\r\\nb\\tc\\x00d\\x1B[31me\\x7Ff');
+      // eslint-disable-next-line no-control-regex -- asserting absence of the control chars we just escaped
+      expect(result).not.toMatch(/[\x00-\x1F\x7F]/);
+    });
+
+    it('should escape control chars in nested structures and log messages', () => {
+      const input = {
+        outer: [{ msg: 'line1\nline2' }],
+      };
+      const result = sanitizeForLogging(input) as { outer: Array<{ msg: string }> };
+      expect(result.outer[0].msg).toBe('line1\\nline2');
+    });
+
+    it('should escape control chars in object keys', () => {
+      const input = {
+        'user\nrole': 'admin\r\nFORGED: true',
+      };
+      const result = sanitizeForLogging(input) as Record<string, string>;
+      expect(result).toHaveProperty('user\\nrole');
+      expect(result['user\\nrole']).toBe('admin\\r\\nFORGED: true');
+      expect(Object.keys(result)[0]).not.toContain('\n');
+    });
+
+    it('should sanitize and escape Error objects', () => {
+      const error = new Error('OAuth token=secret123 failed\nSecond line');
+      const result = sanitizeForLogging(error) as Record<string, unknown>;
+      expect(result.name).toBe('Error');
+      expect(result.message).toContain('[REDACTED]');
+      expect(result.message).not.toContain('\n');
+      expect(result.message).toBe('OAuth token=[REDACTED]123 failed\\nSecond line');
+      if (result.stack) {
+        expect(result.stack).not.toContain('secret123');
+        expect(result.stack).not.toContain('\n');
+        expect(typeof result.stack).toBe('string');
+      }
+    });
+
+    it('should still apply pattern redaction before control-char escaping', () => {
+      const input = 'Bearer eyJhbGci\nsecond line';
+      const result = sanitizeForLogging(input) as string;
+      expect(result).toContain('[REDACTED]');
+      expect(result).not.toContain('\n');
+    });
+
+    it('should return [SANITIZATION_ERROR] if sanitization throws', () => {
+      // Create an object where property access throws
+      const throwingObj = {};
+      Object.defineProperty(throwingObj, 'badProp', {
+        get() {
+          throw new Error('Explosion');
+        },
+        enumerable: true,
+      });
+      const result = sanitizeForLogging(throwingObj);
+      expect(result).toBe('[SANITIZATION_ERROR]');
+    });
+
+    it('should handle large input without ReDoS issues', () => {
+      const longInput = 'A'.repeat(50000) + '\r\n' + 'B'.repeat(50000);
+      const start = Date.now();
+      const result = sanitizeForLogging(longInput) as string;
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(1000);
+      expect(result).toContain('\\r\\n');
+    });
   });
 
   describe('sanitizeOAuthServerList', () => {
@@ -89,6 +166,13 @@ describe('secureLogger', () => {
       expect(result[1]).toBe('server2'); // Only takes first part before |
       expect(result[2]).toContain('server3');
       expect(result[2]).toContain('[OAUTH_REDACTED]');
+    });
+
+    it('should escape control characters in OAuth server names', () => {
+      const servers = ['server1\nmalicious', 'server2\x1B[31m'];
+      const result = sanitizeOAuthServerList(servers);
+      expect(result[0]).toBe('server1\\nmalicious');
+      expect(result[1]).toBe('server2\\x1B[31m');
     });
 
     it('should handle clean server names', () => {

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -133,10 +133,21 @@ describe('secureLogger', () => {
         "token='top secret single unterminated value",
         'secret=def456',
         'client_secret=ghi789',
+        'clientSecret=client_secret_val_888',
         'api-key=jkl012',
+        'apiKey=api_key_val_777',
         'auth-token=mno345',
+        'authToken=auth_token_val_666',
         'access_token=pqr678',
+        'accessToken=access_token_val_555',
         'refresh_token=stu901',
+        'refreshToken=refresh_token_val_444',
+        'private_key=private_key_val_333',
+        'privateKey=private_key_val_222',
+        'authorization_code=auth_code_val_111',
+        'authorizationCode=auth_code_val_000',
+        'Bearer:bearer_token_val_123',
+        'Bearer: bearer_token_val_456',
       ];
       for (const testCase of cases) {
         const result = sanitizeForLogging(testCase) as string;
@@ -150,10 +161,52 @@ describe('secureLogger', () => {
         expect(result).not.toContain('unterminated');
         expect(result).not.toContain('def456');
         expect(result).not.toContain('ghi789');
+        expect(result).not.toContain('client_secret_val_888');
         expect(result).not.toContain('jkl012');
+        expect(result).not.toContain('api_key_val_777');
         expect(result).not.toContain('mno345');
+        expect(result).not.toContain('auth_token_val_666');
         expect(result).not.toContain('pqr678');
+        expect(result).not.toContain('access_token_val_555');
         expect(result).not.toContain('stu901');
+        expect(result).not.toContain('refresh_token_val_444');
+        expect(result).not.toContain('private_key_val_333');
+        expect(result).not.toContain('private_key_val_222');
+        expect(result).not.toContain('auth_code_val_111');
+        expect(result).not.toContain('auth_code_val_000');
+        expect(result).not.toContain('bearer_token_val_123');
+        expect(result).not.toContain('bearer_token_val_456');
+      }
+    });
+
+    it('should redact credentials in JSON stringified payloads and URLs', () => {
+      const jsonCases = [
+        '{"token":"JSON_SECRET_TOKEN_333"}',
+        '{"password": "JSON_SECRET_PASS_444"}',
+        '{"clientSecret": "JSON_SECRET_CS_555", "refreshToken": "JSON_SECRET_RT_666"}',
+      ];
+      for (const jc of jsonCases) {
+        const res = sanitizeForLogging(jc) as string;
+        expect(res).not.toContain('JSON_SECRET_TOKEN_333');
+        expect(res).not.toContain('JSON_SECRET_PASS_444');
+        expect(res).not.toContain('JSON_SECRET_CS_555');
+        expect(res).not.toContain('JSON_SECRET_RT_666');
+        expect(res).toContain('[REDACTED]');
+      }
+
+      const urlCases = [
+        'https://example.com/callback?code=AUTH_CODE_URL_111&state=xyz',
+        'https://example.com/api?refreshToken=RT_URL_222',
+        'https://example.com/api?clientSecret=CLIENT_SECRET_URL_333',
+        'https://example.com/api?authorization_code=AUTH_CODE_URL_444',
+      ];
+      for (const uc of urlCases) {
+        const res = sanitizeForLogging(uc) as string;
+        expect(res).not.toContain('AUTH_CODE_URL_111');
+        expect(res).not.toContain('RT_URL_222');
+        expect(res).not.toContain('CLIENT_SECRET_URL_333');
+        expect(res).not.toContain('AUTH_CODE_URL_444');
+        expect(res).toContain('[REDACTED]');
       }
     });
 

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -101,14 +101,41 @@ describe('secureLogger', () => {
       expect(result.outer[0].msg).toBe('line1\\nline2');
     });
 
-    it('should escape control chars in object keys', () => {
+    it('should escape control chars and redact credential assignments in object keys', () => {
       const input = {
         'user\nrole': 'admin\r\nFORGED: true',
+        'token=secret123': 'active',
+        'client_secret=secret456': 'valid',
       };
       const result = sanitizeForLogging(input) as Record<string, string>;
       expect(result).toHaveProperty('user\\nrole');
       expect(result['user\\nrole']).toBe('admin\\r\\nFORGED: true');
       expect(Object.keys(result)[0]).not.toContain('\n');
+      expect(JSON.stringify(result)).not.toContain('secret123');
+      expect(JSON.stringify(result)).not.toContain('secret456');
+    });
+
+    it('should redact key-value credential assignments across all key families without leaking values', () => {
+      const cases = [
+        'password=abc123',
+        'secret=def456',
+        'client_secret=ghi789',
+        'api-key=jkl012',
+        'auth-token=mno345',
+        'access_token=pqr678',
+        'refresh_token=stu901',
+      ];
+      for (const testCase of cases) {
+        const result = sanitizeForLogging(testCase) as string;
+        expect(result).toContain('[REDACTED]');
+        expect(result).not.toContain('abc123');
+        expect(result).not.toContain('def456');
+        expect(result).not.toContain('ghi789');
+        expect(result).not.toContain('jkl012');
+        expect(result).not.toContain('mno345');
+        expect(result).not.toContain('pqr678');
+        expect(result).not.toContain('stu901');
+      }
     });
 
     it('should sanitize and escape Error objects including custom name and stack', () => {

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -129,6 +129,8 @@ describe('secureLogger', () => {
         "token='secret token with spaces 456'",
         'password="prefix \\"secret with escaped double quotes\\" suffix"',
         "token='prefix \\'secret with escaped single quotes\\' suffix'",
+        'password="top secret unterminated value',
+        "token='top secret single unterminated value",
         'secret=def456',
         'client_secret=ghi789',
         'api-key=jkl012',
@@ -138,12 +140,14 @@ describe('secureLogger', () => {
       ];
       for (const testCase of cases) {
         const result = sanitizeForLogging(testCase) as string;
-        expect(result).toContain('[REDACTED]');
+        expect(result).toBe('[REDACTED]');
         expect(result).not.toContain('abc123');
         expect(result).not.toContain('secret password with spaces 123');
         expect(result).not.toContain('secret token with spaces 456');
-        expect(result).not.toContain('secret with escaped double quotes');
-        expect(result).not.toContain('secret with escaped single quotes');
+        expect(result).not.toContain('prefix');
+        expect(result).not.toContain('suffix');
+        expect(result).not.toContain('escaped');
+        expect(result).not.toContain('unterminated');
         expect(result).not.toContain('def456');
         expect(result).not.toContain('ghi789');
         expect(result).not.toContain('jkl012');
@@ -232,17 +236,22 @@ describe('secureLogger', () => {
       expect(result).not.toContain('\n');
     });
 
-    it('should return [SANITIZATION_ERROR] if sanitization throws', () => {
-      // Create an object where property access throws
+    it('should return [SANITIZATION_ERROR] and log static message if sanitization throws', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      // Create an object where property access throws sensitive message
       const throwingObj = {};
       Object.defineProperty(throwingObj, 'badProp', {
         get() {
-          throw new Error('Explosion');
+          throw new Error('Explosion with password=secret123\nInjected');
         },
         enumerable: true,
       });
       const result = sanitizeForLogging(throwingObj);
       expect(result).toBe('[SANITIZATION_ERROR]');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Sanitization error occurred');
+      expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Explosion'));
+      expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.stringContaining('secret123'));
+      consoleErrorSpy.mockRestore();
     });
 
     it('should handle large input without ReDoS issues', () => {

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -85,12 +85,12 @@ describe('secureLogger', () => {
       expect(result).toBe('login failed for user admin\\nINFO: User logged in: admin');
     });
 
-    it('should escape all C0 control chars, DEL, and ANSI ESC', () => {
-      const input = 'a\r\nb\tc\x00d\x1B[31me\x7Ff';
+    it('should escape all C0 and C1 control chars, DEL, and 7-bit/8-bit ANSI ESC', () => {
+      const input = 'a\r\nb\tc\x00d\x1B[31me\x7Ff\x9B31mg\x80h\x9Fi';
       const result = sanitizeForLogging(input) as string;
-      expect(result).toBe('a\\r\\nb\\tc\\x00d\\x1B[31me\\x7Ff');
-      // eslint-disable-next-line no-control-regex -- asserting absence of the control chars we just escaped
-      expect(result).not.toMatch(/[\x00-\x1F\x7F]/);
+      expect(result).toBe('a\\r\\nb\\tc\\x00d\\x1B[31me\\x7Ff\\x9B31mg\\x80h\\x9Fi');
+      // eslint-disable-next-line no-control-regex -- asserting absence of all C0/C1 and DEL control chars
+      expect(result).not.toMatch(/[\x00-\x1F\x7F-\x9F]/);
     });
 
     it('should escape control chars in nested structures and log messages', () => {
@@ -111,13 +111,16 @@ describe('secureLogger', () => {
       expect(Object.keys(result)[0]).not.toContain('\n');
     });
 
-    it('should sanitize and escape Error objects', () => {
+    it('should sanitize and escape Error objects including custom name and stack', () => {
       const error = new Error('OAuth token=secret123 failed\nSecond line');
+      error.name = 'CustomToken_secret456_Error\nInjected';
       const result = sanitizeForLogging(error) as Record<string, unknown>;
-      expect(result.name).toBe('Error');
+      expect(result.name).toContain('[REDACTED]');
+      expect(result.name).not.toContain('\n');
+      expect(result.name).not.toContain('secret456');
       expect(result.message).toContain('[REDACTED]');
       expect(result.message).not.toContain('\n');
-      expect(result.message).toBe('OAuth token=[REDACTED]123 failed\\nSecond line');
+      expect(result.message).not.toContain('secret123');
       if (result.stack) {
         expect(result.stack).not.toContain('secret123');
         expect(result.stack).not.toContain('\n');

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -127,6 +127,8 @@ describe('secureLogger', () => {
         'password=abc123',
         'password="secret password with spaces 123"',
         "token='secret token with spaces 456'",
+        'password="prefix \\"secret with escaped double quotes\\" suffix"',
+        "token='prefix \\'secret with escaped single quotes\\' suffix'",
         'secret=def456',
         'client_secret=ghi789',
         'api-key=jkl012',
@@ -140,6 +142,8 @@ describe('secureLogger', () => {
         expect(result).not.toContain('abc123');
         expect(result).not.toContain('secret password with spaces 123');
         expect(result).not.toContain('secret token with spaces 456');
+        expect(result).not.toContain('secret with escaped double quotes');
+        expect(result).not.toContain('secret with escaped single quotes');
         expect(result).not.toContain('def456');
         expect(result).not.toContain('ghi789');
         expect(result).not.toContain('jkl012');

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -138,8 +138,9 @@ describe('secureLogger', () => {
       }
     });
 
-    it('should sanitize and escape Error objects including custom name and stack', () => {
-      const error = new Error('OAuth token=secret123 failed\nSecond line');
+    it('should sanitize and escape Error objects including custom name, stack, and cause', () => {
+      const causeErr = new Error('Root cause with password=rootpass123\nInner stack');
+      const error = new Error('OAuth token=secret123 failed\nSecond line', { cause: causeErr });
       error.name = 'CustomToken_secret456_Error\nInjected';
       const result = sanitizeForLogging(error) as Record<string, unknown>;
       expect(result.name).toContain('[REDACTED]');
@@ -153,6 +154,56 @@ describe('secureLogger', () => {
         expect(result.stack).not.toContain('\n');
         expect(typeof result.stack).toBe('string');
       }
+      expect(result.cause).toBeDefined();
+      const sanitizedCause = result.cause as Record<string, unknown>;
+      expect(sanitizedCause.message).toContain('[REDACTED]');
+      expect(sanitizedCause.message).not.toContain('rootpass123');
+    });
+
+    it('should escape Unicode line separators and Trojan Source Bidi overrides', () => {
+      const input = 'admin\u2028line_split\u2029paragraph\u202Ereversed\u2066isolate\u200Bzero\uFEFFbom';
+      const result = sanitizeForLogging(input) as string;
+      expect(result).toBe('admin\\u2028line_split\\u2029paragraph\\u202Ereversed\\u2066isolate\\u200Bzero\\uFEFFbom');
+      expect(result).not.toContain('\u2028');
+      expect(result).not.toContain('\u2029');
+      expect(result).not.toContain('\u202E');
+    });
+
+    it('should redact PEM private keys, Basic auth, and JWT tokens', () => {
+      const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA0...\n-----END RSA PRIVATE KEY-----';
+      expect(sanitizeForLogging(pem)).toContain('[REDACTED]');
+      expect(sanitizeForLogging(pem)).not.toContain('BEGIN RSA PRIVATE KEY');
+
+      const basic = 'Authorization: Basic dXNlcjpwYXNzd29yZDEyMw==';
+      expect(sanitizeForLogging(basic)).toContain('[REDACTED]');
+      expect(sanitizeForLogging(basic)).not.toContain('dXNlcjpwYXNzd29yZDEyMw==');
+
+      const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozG5faivvqpPxSyqLDKLw_n8_B6';
+      expect(sanitizeForLogging(jwt)).toContain('[REDACTED]');
+      expect(sanitizeForLogging(jwt)).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+    });
+
+    it('should safely serialize complex data types (BigInt, Date, RegExp, Set, Map)', () => {
+      const date = new Date('2026-08-24T00:00:00.000Z');
+      expect(sanitizeForLogging(date)).toBe('2026-08-24T00:00:00.000Z');
+
+      const bigint = 9007199254740993n;
+      expect(sanitizeForLogging(bigint)).toBe('9007199254740993n');
+
+      const regex = /test\npattern/g;
+      expect(sanitizeForLogging(regex)).toBe('/test\\npattern/g');
+
+      const set = new Set(['user1', 'token=secret999']);
+      const sanitizedSet = sanitizeForLogging(set) as string[];
+      expect(sanitizedSet).toEqual(['user1', '[REDACTED]']);
+
+      const map = new Map<string, unknown>([
+        ['user\nname', 'alice'],
+        ['secretKey', 'super_secret'],
+      ]);
+      const sanitizedMap = sanitizeForLogging(map) as Record<string, unknown>;
+      expect(sanitizedMap['user\\nname']).toBe('alice');
+      expect(sanitizedMap['secretKey']).toBe('[REDACTED]');
     });
 
     it('should still apply pattern redaction before control-char escaping', () => {

--- a/src/logger/secureLogger.test.ts
+++ b/src/logger/secureLogger.test.ts
@@ -106,6 +106,10 @@ describe('secureLogger', () => {
         'user\nrole': 'admin\r\nFORGED: true',
         'token=secret123': 'active',
         'client_secret=secret456': 'valid',
+        'Authorization: Bearer token_in_key_789': 'header_val',
+        'Authorization: Basic dXNlcjpwYXNzd29yZDk5OQ==': 'auth_val',
+        'jwt_key=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozG5faivvqpPxSyqLDKLw_n8_B6':
+          'jwt_val',
       };
       const result = sanitizeForLogging(input) as Record<string, string>;
       expect(result).toHaveProperty('user\\nrole');
@@ -113,11 +117,16 @@ describe('secureLogger', () => {
       expect(Object.keys(result)[0]).not.toContain('\n');
       expect(JSON.stringify(result)).not.toContain('secret123');
       expect(JSON.stringify(result)).not.toContain('secret456');
+      expect(JSON.stringify(result)).not.toContain('token_in_key_789');
+      expect(JSON.stringify(result)).not.toContain('dXNlcjpwYXNzd29yZDk5OQ==');
+      expect(JSON.stringify(result)).not.toContain('dozG5faivvqpPxSyqLDKLw_n8_B6');
     });
 
     it('should redact key-value credential assignments across all key families without leaking values', () => {
       const cases = [
         'password=abc123',
+        'password="secret password with spaces 123"',
+        "token='secret token with spaces 456'",
         'secret=def456',
         'client_secret=ghi789',
         'api-key=jkl012',
@@ -129,6 +138,8 @@ describe('secureLogger', () => {
         const result = sanitizeForLogging(testCase) as string;
         expect(result).toContain('[REDACTED]');
         expect(result).not.toContain('abc123');
+        expect(result).not.toContain('secret password with spaces 123');
+        expect(result).not.toContain('secret token with spaces 456');
         expect(result).not.toContain('def456');
         expect(result).not.toContain('ghi789');
         expect(result).not.toContain('jkl012');
@@ -169,10 +180,14 @@ describe('secureLogger', () => {
       expect(result).not.toContain('\u202E');
     });
 
-    it('should redact PEM private keys, Basic auth, and JWT tokens', () => {
-      const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA0...\n-----END RSA PRIVATE KEY-----';
-      expect(sanitizeForLogging(pem)).toContain('[REDACTED]');
-      expect(sanitizeForLogging(pem)).not.toContain('BEGIN RSA PRIVATE KEY');
+    it('should redact PEM private keys including full body content, Basic auth, and JWT tokens', () => {
+      const pem =
+        '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA0base64secretkeypayload...\n-----END RSA PRIVATE KEY-----';
+      const sanitizedPem = sanitizeForLogging(pem) as string;
+      expect(sanitizedPem).toBe('[REDACTED]');
+      expect(sanitizedPem).not.toContain('BEGIN RSA PRIVATE KEY');
+      expect(sanitizedPem).not.toContain('MIIEowIBAAKCAQEA0base64secretkeypayload');
+      expect(sanitizedPem).not.toContain('END RSA PRIVATE KEY');
 
       const basic = 'Authorization: Basic dXNlcjpwYXNzd29yZDEyMw==';
       expect(sanitizeForLogging(basic)).toContain('[REDACTED]');

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -4,9 +4,8 @@ import logger from './logger.js';
  * Patterns matching value-bearing credentials (used for both values and object keys)
  */
 const KEY_SENSITIVE_PATTERNS = [
-  // PEM Private Key blocks (CWE-532, matches full block or unclosed header)
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gi,
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----/gi,
+  // PEM Private Key blocks (CWE-532, matches full block or unterminated block through string boundary)
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/gi,
 
   // Bearer tokens in Authorization headers (MUST run before generic key-value to avoid splitting "Token: bearer <token>")
   /bearer\s+[a-zA-Z0-9_\-.~+/]+=*/gi,
@@ -133,7 +132,7 @@ function sanitize(value: unknown, depth = 0): unknown {
   }
 
   if (typeof value === 'symbol') {
-    return escapeControlChars(value.toString());
+    return sanitizeString(value.toString());
   }
 
   if (typeof value === 'function') {
@@ -145,7 +144,7 @@ function sanitize(value: unknown, depth = 0): unknown {
   }
 
   if (value instanceof RegExp) {
-    return escapeControlChars(value.toString());
+    return sanitizeString(value.toString());
   }
 
   if (value instanceof Error) {
@@ -153,7 +152,7 @@ function sanitize(value: unknown, depth = 0): unknown {
       name:
         typeof value.name === 'string'
           ? (sanitize(value.name, depth + 1) as string)
-          : escapeControlChars(String(value.name)),
+          : sanitizeString(String(value.name)),
       message: sanitize(value.message, depth + 1),
     };
     if (value.stack) {
@@ -163,6 +162,9 @@ function sanitize(value: unknown, depth = 0): unknown {
       sanitizedError.cause = sanitize(value.cause, depth + 1);
     }
     for (const [key, val] of Object.entries(value)) {
+      if (key === 'name' || key === 'message' || key === 'stack' || key === 'cause' || key === '__proto__') {
+        continue;
+      }
       const sanitizedKey = sanitizeKey(key);
       if (isSensitiveKey(key)) {
         sanitizedError[sanitizedKey] = '[REDACTED]';
@@ -181,6 +183,9 @@ function sanitize(value: unknown, depth = 0): unknown {
     const mapObj: Record<string, unknown> = {};
     for (const [k, v] of value.entries()) {
       const stringKey = typeof k === 'string' ? k : String(k);
+      if (stringKey === '__proto__') {
+        continue;
+      }
       const sanitizedKey = sanitizeKey(stringKey);
       if (isSensitiveKey(stringKey)) {
         mapObj[sanitizedKey] = '[REDACTED]';
@@ -199,6 +204,9 @@ function sanitize(value: unknown, depth = 0): unknown {
     const sanitized: Record<string, unknown> = {};
 
     for (const [key, val] of Object.entries(value)) {
+      if (key === '__proto__') {
+        continue;
+      }
       const sanitizedKey = sanitizeKey(key);
       if (isSensitiveKey(key)) {
         sanitized[sanitizedKey] = '[REDACTED]';

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -231,7 +231,7 @@ export function sanitizeForLogging(data: unknown): unknown {
  */
 function createLoggerMethod(level: 'debug' | 'info' | 'warn' | 'error') {
   return (message: string, data?: unknown) => {
-    const sanitizedMessage = typeof message === 'string' ? sanitize(message) : message;
+    const sanitizedMessage = sanitizeForLogging(message);
     const sanitizedMessageStr = typeof sanitizedMessage === 'string' ? sanitizedMessage : String(sanitizedMessage);
 
     if (data !== undefined) {
@@ -272,7 +272,7 @@ export function sanitizeOAuthServerList(servers: string[]): string[] {
  * Utility function to create safe error messages that don't expose sensitive data
  */
 export function createSafeErrorMessage(error: string): string {
-  const sanitizedError = sanitize(error);
+  const sanitizedError = sanitizeForLogging(error);
   const errorString = typeof sanitizedError === 'string' ? sanitizedError : String(sanitizedError);
 
   return errorString

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -18,6 +18,9 @@ const SENSITIVE_PATTERNS = [
 
   // Generic secret patterns (consolidates 5 patterns)
   /(?:api[_-]?key|secret|password|passwd|auth[_-]?token)/gi,
+
+  // Key-value credential assignments (e.g., token=xyz, secret: xyz)
+  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token)\s*[:=]\s*[^\s,;&]+/gi,
 ];
 
 /**
@@ -26,11 +29,12 @@ const SENSITIVE_PATTERNS = [
 const SENSITIVE_KEY_PATTERNS = ['secret', 'token', 'password', 'passwd', 'key'];
 
 /**
- * C0 control characters + DEL (CWE-117 log forging defense).
+ * C0 + C1 control characters + DEL (CWE-117 log forging & CWE-150 ANSI injection defense).
+ * Covers \x00-\x1F (C0), \x7F (DEL), and \x80-\x9F (C1 including 8-bit CSI \x9B).
  * Single character class — linear time, no nested quantifiers, no ReDoS risk.
  */
 // eslint-disable-next-line no-control-regex -- intentional: this IS the sanitization pattern
-const CONTROL_CHARS_PATTERN = /[\x00-\x1F\x7F]/g;
+const CONTROL_CHARS_PATTERN = /[\x00-\x1F\x7F-\x9F]/g;
 
 /**
  * Escape control characters as visible literals (log4j2 %encode{}{CRLF} /
@@ -85,7 +89,10 @@ function sanitize(value: unknown, depth = 0): unknown {
 
   if (value instanceof Error) {
     const sanitizedError: Record<string, unknown> = {
-      name: escapeControlChars(value.name),
+      name:
+        typeof value.name === 'string'
+          ? (sanitize(value.name, depth + 1) as string)
+          : escapeControlChars(String(value.name)),
       message: sanitize(value.message, depth + 1),
     };
     if (value.stack) {

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -17,8 +17,8 @@ const KEY_SENSITIVE_PATTERNS = [
   // JWT tokens (Header.Payload.Signature)
   /\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b/gi,
 
-  // Key-value credential assignments (supports unquoted and quoted values with embedded whitespace and escaped quotes)
-  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\s,;&]+)/gi,
+  // Key-value credential assignments (supports unquoted and quoted values, including embedded whitespace, escaped quotes, and unterminated quotes through string/line boundaries)
+  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*(?:"(?:\\[\s\S]|[^"\\])*(?:"|$)|'(?:\\[\s\S]|[^'\\])*(?:'|$)|[^\s,;&]+)/gi,
 
   // URLs with sensitive parameters (consolidates 4 patterns)
   /https?:\/\/[^\s]*[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,
@@ -219,9 +219,9 @@ function sanitize(value: unknown, depth = 0): unknown {
 export function sanitizeForLogging(data: unknown): unknown {
   try {
     return sanitize(data);
-  } catch (error) {
-    // Log the actual error safely without exposing sensitive data
-    console.error('Sanitization error occurred:', error instanceof Error ? error.message : 'Unknown error');
+  } catch {
+    // Log safe static marker to stderr without exposing dynamic error.message (preventing throwing getter bypasses)
+    console.error('Sanitization error occurred');
     return '[SANITIZATION_ERROR]';
   }
 }

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -4,23 +4,27 @@ import logger from './logger.js';
  * Consolidated patterns for sensitive data detection
  */
 const SENSITIVE_PATTERNS = [
-  // OAuth tokens and credentials (consolidates 6 patterns)
-  /(?:access_token|refresh_token|authorization_code|client_secret|client_id|bearer\s+[\w\-.~+/]+=*)/gi,
+  // Bearer tokens in Authorization headers (MUST run before generic key-value to avoid splitting "Token: bearer <token>")
+  /bearer\s+[a-zA-Z0-9_\-.~+/]+=*/gi,
+
+  // Key-value credential assignments (e.g., token=xyz, password=xyz, client_secret=xyz)
+  // MUST run before generic keyword replacement so values are redacted before keys are masked
+  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token)\s*[:=]\s*[^\s,;&]+/gi,
 
   // URLs with sensitive parameters (consolidates 4 patterns)
-  /https?:\/\/[^\s]*[?&](?:[tT]oken|[cC]ode)=[^\s&]*/gi,
+  /https?:\/\/[^\s]*[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,
 
   // Query parameters with sensitive data (consolidates 2 patterns)
-  /[?&](?:[tT]oken|[cC]ode)=[^\s&]*/gi,
+  /[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,
+
+  // OAuth tokens and credentials (consolidates 6 patterns)
+  /(?:access_token|refresh_token|authorization_code|client_secret|client_id)/gi,
 
   // OAuth configuration patterns (consolidates 4 patterns)
   /(?:scopes?|redirect_uris?|with\s+scope):\s*(?:\[[^\]]*\]|[^\s,}]+(?:\s+[^\s]+)*)/gi,
 
-  // Generic secret patterns (consolidates 5 patterns)
+  // Generic secret patterns (consolidates 5 patterns) - fallback keywords
   /(?:api[_-]?key|secret|password|passwd|auth[_-]?token)/gi,
-
-  // Key-value credential assignments (e.g., token=xyz, secret: xyz)
-  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token)\s*[:=]\s*[^\s,;&]+/gi,
 ];
 
 /**
@@ -51,6 +55,28 @@ function escapeControlChars(value: string): string {
 }
 
 /**
+ * Sanitize a string by applying pattern redaction followed by control character escaping.
+ */
+function sanitizeString(value: string): string {
+  let sanitized = value;
+  for (const pattern of SENSITIVE_PATTERNS) {
+    sanitized = sanitized.replace(pattern, '[REDACTED]');
+  }
+  return escapeControlChars(sanitized);
+}
+
+/**
+ * Sanitize an object key: escapes control characters and redacts any inline credential assignments.
+ */
+function sanitizeKey(key: string): string {
+  const redactedKey = key.replace(
+    /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token)\s*[:=]\s*[^\s,;&]+/gi,
+    '[REDACTED]',
+  );
+  return escapeControlChars(redactedKey);
+}
+
+/**
  * Check if a key contains sensitive patterns
  */
 function isSensitiveKey(key: string): boolean {
@@ -73,14 +99,7 @@ function sanitize(value: unknown, depth = 0): unknown {
   }
 
   if (typeof value === 'string') {
-    // Apply pattern-based redaction to strings
-    let sanitized = value;
-    for (const pattern of SENSITIVE_PATTERNS) {
-      sanitized = sanitized.replace(pattern, '[REDACTED]');
-    }
-    // Escape control characters to prevent log forging (CWE-117).
-    // Runs after pattern redaction so redaction markers are not affected.
-    return escapeControlChars(sanitized);
+    return sanitizeString(value);
   }
 
   if (typeof value === 'number' || typeof value === 'boolean') {
@@ -99,7 +118,7 @@ function sanitize(value: unknown, depth = 0): unknown {
       sanitizedError.stack = sanitize(value.stack, depth + 1);
     }
     for (const [key, val] of Object.entries(value)) {
-      const sanitizedKey = escapeControlChars(key);
+      const sanitizedKey = sanitizeKey(key);
       if (isSensitiveKey(key)) {
         sanitizedError[sanitizedKey] = '[REDACTED]';
       } else {
@@ -117,7 +136,7 @@ function sanitize(value: unknown, depth = 0): unknown {
     const sanitized: Record<string, unknown> = {};
 
     for (const [key, val] of Object.entries(value)) {
-      const sanitizedKey = escapeControlChars(key);
+      const sanitizedKey = sanitizeKey(key);
       if (isSensitiveKey(key)) {
         sanitized[sanitizedKey] = '[REDACTED]';
       } else {

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -17,8 +17,8 @@ const KEY_SENSITIVE_PATTERNS = [
   // JWT tokens (Header.Payload.Signature)
   /\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b/gi,
 
-  // Key-value credential assignments (supports unquoted and quoted values with embedded whitespace)
-  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;&]+)/gi,
+  // Key-value credential assignments (supports unquoted and quoted values with embedded whitespace and escaped quotes)
+  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*(?:"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|[^\s,;&]+)/gi,
 
   // URLs with sensitive parameters (consolidates 4 patterns)
   /https?:\/\/[^\s]*[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -7,8 +7,8 @@ const KEY_SENSITIVE_PATTERNS = [
   // PEM Private Key blocks (CWE-532, matches full block or unterminated block through string boundary)
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/gi,
 
-  // Bearer tokens in Authorization headers (MUST run before generic key-value to avoid splitting "Token: bearer <token>")
-  /bearer\s+[a-zA-Z0-9_\-.~+/]+=*/gi,
+  // Bearer tokens in Authorization headers / raw Bearer prefixes (supports space and colon separators)
+  /bearer(?:\s+|:\s*)[a-zA-Z0-9_\-.~+/]+=*/gi,
 
   // Basic authentication credentials (Authorization: Basic <base64>)
   /basic\s+[a-zA-Z0-9+/=]{8,}/gi,
@@ -16,14 +16,14 @@ const KEY_SENSITIVE_PATTERNS = [
   // JWT tokens (Header.Payload.Signature)
   /\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b/gi,
 
-  // Key-value credential assignments (supports unquoted and quoted values, including embedded whitespace, escaped quotes, and unterminated quotes through string/line boundaries)
-  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*(?:"(?:\\[\s\S]|[^"\\])*(?:"|$)|'(?:\\[\s\S]|[^'\\])*(?:'|$)|[^\s,;&]+)/gi,
+  // Key-value credential assignments (supports unquoted, quoted, JSON-stringified, camelCase, snake_case, and kebab-case)
+  /(?:[?&]|["']|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|clientSecret|[pP]assword|[pP]asswd|api[_-]?key|apiKey|auth[_-]?token|authToken|access[_-]?token|accessToken|refresh[_-]?token|refreshToken|private[_-]?key|privateKey|authorization[_-]?code|authorizationCode)\s*["']?\s*[:=]\s*(?:"(?:\\[\s\S]|[^"\\])*(?:"|$)|'(?:\\[\s\S]|[^'\\])*(?:'|$)|[^\s,;&{}"]+)/gi,
 
   // URLs with sensitive parameters (consolidates 4 patterns)
-  /https?:\/\/[^\s]*[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,
+  /https?:\/\/[^\s]*[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey|client_secret|clientSecret|refreshToken|accessToken|authorization_code|authorizationCode)=[^\s&]*/gi,
 
   // Query parameters with sensitive data (consolidates 2 patterns)
-  /[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,
+  /[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey|client_secret|clientSecret|refreshToken|accessToken|authorization_code|authorizationCode)=[^\s&]*/gi,
 ];
 
 /**
@@ -33,7 +33,7 @@ const SENSITIVE_PATTERNS = [
   ...KEY_SENSITIVE_PATTERNS,
 
   // OAuth tokens and credentials (consolidates 6 patterns)
-  /(?:access_token|refresh_token|authorization_code|client_secret|client_id)/gi,
+  /(?:access_token|refresh_token|authorization_code|client_secret)/gi,
 
   // OAuth configuration patterns (consolidates 4 patterns)
   /(?:scopes?|redirect_uris?|with\s+scope):\s*(?:\[[^\]]*\]|[^\s,}]+(?:\s+[^\s]+)*)/gi,
@@ -45,7 +45,17 @@ const SENSITIVE_PATTERNS = [
 /**
  * Base patterns for sensitive key detection (case-insensitive)
  */
-const SENSITIVE_KEY_PATTERNS = ['secret', 'token', 'password', 'passwd', 'key'];
+const SENSITIVE_KEY_PATTERNS = [
+  'secret',
+  'token',
+  'password',
+  'passwd',
+  'key',
+  'authorization_code',
+  'auth_code',
+  'auth_token',
+  'authtoken',
+];
 
 /**
  * C0 + C1 control characters + DEL + Unicode Line/Paragraph Separators + Bidi overrides (CWE-117, CWE-150, Trojan Source CVE-2021-42574).

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -1,10 +1,11 @@
 import logger from './logger.js';
 
 /**
- * Consolidated patterns for sensitive data detection
+ * Patterns matching value-bearing credentials (used for both values and object keys)
  */
-const SENSITIVE_PATTERNS = [
-  // PEM Private Key blocks (CWE-532)
+const KEY_SENSITIVE_PATTERNS = [
+  // PEM Private Key blocks (CWE-532, matches full block or unclosed header)
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----/gi,
 
   // Bearer tokens in Authorization headers (MUST run before generic key-value to avoid splitting "Token: bearer <token>")
@@ -16,15 +17,21 @@ const SENSITIVE_PATTERNS = [
   // JWT tokens (Header.Payload.Signature)
   /\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b/gi,
 
-  // Key-value credential assignments (e.g., token=xyz, password=xyz, client_secret=xyz)
-  // MUST run before generic keyword replacement so values are redacted before keys are masked
-  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*[^\s,;&]+/gi,
+  // Key-value credential assignments (supports unquoted and quoted values with embedded whitespace)
+  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;&]+)/gi,
 
   // URLs with sensitive parameters (consolidates 4 patterns)
   /https?:\/\/[^\s]*[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,
 
   // Query parameters with sensitive data (consolidates 2 patterns)
   /[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,
+];
+
+/**
+ * Consolidated patterns for sensitive data detection in string values
+ */
+const SENSITIVE_PATTERNS = [
+  ...KEY_SENSITIVE_PATTERNS,
 
   // OAuth tokens and credentials (consolidates 6 patterns)
   /(?:access_token|refresh_token|authorization_code|client_secret|client_id)/gi,
@@ -81,13 +88,13 @@ function sanitizeString(value: string): string {
 }
 
 /**
- * Sanitize an object key: escapes control characters and redacts any inline credential assignments.
+ * Sanitize an object key: redacts credential patterns and escapes control characters.
  */
 function sanitizeKey(key: string): string {
-  const redactedKey = key.replace(
-    /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*[^\s,;&]+/gi,
-    '[REDACTED]',
-  );
+  let redactedKey = key;
+  for (const pattern of KEY_SENSITIVE_PATTERNS) {
+    redactedKey = redactedKey.replace(pattern, '[REDACTED]');
+  }
   return escapeControlChars(redactedKey);
 }
 

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -4,12 +4,21 @@ import logger from './logger.js';
  * Consolidated patterns for sensitive data detection
  */
 const SENSITIVE_PATTERNS = [
+  // PEM Private Key blocks (CWE-532)
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/gi,
+
   // Bearer tokens in Authorization headers (MUST run before generic key-value to avoid splitting "Token: bearer <token>")
   /bearer\s+[a-zA-Z0-9_\-.~+/]+=*/gi,
 
+  // Basic authentication credentials (Authorization: Basic <base64>)
+  /basic\s+[a-zA-Z0-9+/=]{8,}/gi,
+
+  // JWT tokens (Header.Payload.Signature)
+  /\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b/gi,
+
   // Key-value credential assignments (e.g., token=xyz, password=xyz, client_secret=xyz)
   // MUST run before generic keyword replacement so values are redacted before keys are masked
-  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token)\s*[:=]\s*[^\s,;&]+/gi,
+  /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*[^\s,;&]+/gi,
 
   // URLs with sensitive parameters (consolidates 4 patterns)
   /https?:\/\/[^\s]*[?&](?:[tT]oken|[cC]ode|[sS]ecret|[kK]ey)=[^\s&]*/gi,
@@ -24,7 +33,7 @@ const SENSITIVE_PATTERNS = [
   /(?:scopes?|redirect_uris?|with\s+scope):\s*(?:\[[^\]]*\]|[^\s,}]+(?:\s+[^\s]+)*)/gi,
 
   // Generic secret patterns (consolidates 5 patterns) - fallback keywords
-  /(?:api[_-]?key|secret|password|passwd|auth[_-]?token)/gi,
+  /(?:api[_-]?key|secret|password|passwd|auth[_-]?token|private[_-]?key)/gi,
 ];
 
 /**
@@ -33,12 +42,14 @@ const SENSITIVE_PATTERNS = [
 const SENSITIVE_KEY_PATTERNS = ['secret', 'token', 'password', 'passwd', 'key'];
 
 /**
- * C0 + C1 control characters + DEL (CWE-117 log forging & CWE-150 ANSI injection defense).
- * Covers \x00-\x1F (C0), \x7F (DEL), and \x80-\x9F (C1 including 8-bit CSI \x9B).
+ * C0 + C1 control characters + DEL + Unicode Line/Paragraph Separators + Bidi overrides (CWE-117, CWE-150, Trojan Source CVE-2021-42574).
+ * Covers \x00-\x1F (C0), \x7F (DEL), \x80-\x9F (C1 including 8-bit CSI \x9B),
+ * \u2028/\u2029 (Unicode line/paragraph separators), \u202A-\u202E/\u2066-\u2069 (Bidi overrides),
+ * and \u200B-\u200D/\uFEFF (Zero-width formatting characters).
  * Single character class — linear time, no nested quantifiers, no ReDoS risk.
  */
 // eslint-disable-next-line no-control-regex -- intentional: this IS the sanitization pattern
-const CONTROL_CHARS_PATTERN = /[\x00-\x1F\x7F-\x9F]/g;
+const CONTROL_CHARS_PATTERN = /[\x00-\x1F\x7F-\x9F\u200B-\u200D\u2028\u2029\u202A-\u202E\u2066-\u2069\uFEFF]/g;
 
 /**
  * Escape control characters as visible literals (log4j2 %encode{}{CRLF} /
@@ -50,7 +61,11 @@ function escapeControlChars(value: string): string {
     if (char === '\n') return '\\n';
     if (char === '\r') return '\\r';
     if (char === '\t') return '\\t';
-    return `\\x${char.charCodeAt(0).toString(16).padStart(2, '0').toUpperCase()}`;
+    const code = char.charCodeAt(0);
+    if (code <= 0xff) {
+      return `\\x${code.toString(16).padStart(2, '0').toUpperCase()}`;
+    }
+    return `\\u${code.toString(16).padStart(4, '0').toUpperCase()}`;
   });
 }
 
@@ -70,7 +85,7 @@ function sanitizeString(value: string): string {
  */
 function sanitizeKey(key: string): string {
   const redactedKey = key.replace(
-    /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token)\s*[:=]\s*[^\s,;&]+/gi,
+    /(?:[?&]|\b)(?:[tT]oken|[cC]ode|[sS]ecret|client_secret|client_id|[pP]assword|[pP]asswd|api[_-]?key|auth[_-]?token|access_token|refresh_token|private[_-]?key)\s*[:=]\s*[^\s,;&]+/gi,
     '[REDACTED]',
   );
   return escapeControlChars(redactedKey);
@@ -106,6 +121,26 @@ function sanitize(value: unknown, depth = 0): unknown {
     return value;
   }
 
+  if (typeof value === 'bigint') {
+    return `${value.toString()}n`;
+  }
+
+  if (typeof value === 'symbol') {
+    return escapeControlChars(value.toString());
+  }
+
+  if (typeof value === 'function') {
+    return '[Function]';
+  }
+
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? 'Invalid Date' : value.toISOString();
+  }
+
+  if (value instanceof RegExp) {
+    return escapeControlChars(value.toString());
+  }
+
   if (value instanceof Error) {
     const sanitizedError: Record<string, unknown> = {
       name:
@@ -117,6 +152,9 @@ function sanitize(value: unknown, depth = 0): unknown {
     if (value.stack) {
       sanitizedError.stack = sanitize(value.stack, depth + 1);
     }
+    if ('cause' in value && value.cause !== undefined) {
+      sanitizedError.cause = sanitize(value.cause, depth + 1);
+    }
     for (const [key, val] of Object.entries(value)) {
       const sanitizedKey = sanitizeKey(key);
       if (isSensitiveKey(key)) {
@@ -126,6 +164,24 @@ function sanitize(value: unknown, depth = 0): unknown {
       }
     }
     return sanitizedError;
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).map((item) => sanitize(item, depth + 1));
+  }
+
+  if (value instanceof Map) {
+    const mapObj: Record<string, unknown> = {};
+    for (const [k, v] of value.entries()) {
+      const stringKey = typeof k === 'string' ? k : String(k);
+      const sanitizedKey = sanitizeKey(stringKey);
+      if (isSensitiveKey(stringKey)) {
+        mapObj[sanitizedKey] = '[REDACTED]';
+      } else {
+        mapObj[sanitizedKey] = sanitize(v, depth + 1);
+      }
+    }
+    return mapObj;
   }
 
   if (Array.isArray(value)) {

--- a/src/logger/secureLogger.ts
+++ b/src/logger/secureLogger.ts
@@ -26,6 +26,27 @@ const SENSITIVE_PATTERNS = [
 const SENSITIVE_KEY_PATTERNS = ['secret', 'token', 'password', 'passwd', 'key'];
 
 /**
+ * C0 control characters + DEL (CWE-117 log forging defense).
+ * Single character class — linear time, no nested quantifiers, no ReDoS risk.
+ */
+// eslint-disable-next-line no-control-regex -- intentional: this IS the sanitization pattern
+const CONTROL_CHARS_PATTERN = /[\x00-\x1F\x7F]/g;
+
+/**
+ * Escape control characters as visible literals (log4j2 %encode{}{CRLF} /
+ * Veracode CWE-117 guidance style) so attacker-controlled input cannot forge
+ * log lines or inject ANSI escape sequences, while preserving audit intent.
+ */
+function escapeControlChars(value: string): string {
+  return value.replace(CONTROL_CHARS_PATTERN, (char) => {
+    if (char === '\n') return '\\n';
+    if (char === '\r') return '\\r';
+    if (char === '\t') return '\\t';
+    return `\\x${char.charCodeAt(0).toString(16).padStart(2, '0').toUpperCase()}`;
+  });
+}
+
+/**
  * Check if a key contains sensitive patterns
  */
 function isSensitiveKey(key: string): boolean {
@@ -53,11 +74,32 @@ function sanitize(value: unknown, depth = 0): unknown {
     for (const pattern of SENSITIVE_PATTERNS) {
       sanitized = sanitized.replace(pattern, '[REDACTED]');
     }
-    return sanitized;
+    // Escape control characters to prevent log forging (CWE-117).
+    // Runs after pattern redaction so redaction markers are not affected.
+    return escapeControlChars(sanitized);
   }
 
   if (typeof value === 'number' || typeof value === 'boolean') {
     return value;
+  }
+
+  if (value instanceof Error) {
+    const sanitizedError: Record<string, unknown> = {
+      name: escapeControlChars(value.name),
+      message: sanitize(value.message, depth + 1),
+    };
+    if (value.stack) {
+      sanitizedError.stack = sanitize(value.stack, depth + 1);
+    }
+    for (const [key, val] of Object.entries(value)) {
+      const sanitizedKey = escapeControlChars(key);
+      if (isSensitiveKey(key)) {
+        sanitizedError[sanitizedKey] = '[REDACTED]';
+      } else {
+        sanitizedError[sanitizedKey] = sanitize(val, depth + 1);
+      }
+    }
+    return sanitizedError;
   }
 
   if (Array.isArray(value)) {
@@ -68,10 +110,11 @@ function sanitize(value: unknown, depth = 0): unknown {
     const sanitized: Record<string, unknown> = {};
 
     for (const [key, val] of Object.entries(value)) {
+      const sanitizedKey = escapeControlChars(key);
       if (isSensitiveKey(key)) {
-        sanitized[key] = '[REDACTED]';
+        sanitized[sanitizedKey] = '[REDACTED]';
       } else {
-        sanitized[key] = sanitize(val, depth + 1);
+        sanitized[sanitizedKey] = sanitize(val, depth + 1);
       }
     }
 
@@ -131,7 +174,8 @@ export function sanitizeOAuthServerList(servers: string[]): string[] {
   return servers.map((server) => {
     // Only show server name without any sensitive configuration
     const serverName = server.split('|')[0] || server; // Extract just the name part
-    return serverName.replace(/[?&](client_id|client_secret|token|code)=[^&]*/gi, '[OAUTH_REDACTED]');
+    const redacted = serverName.replace(/[?&](client_id|client_secret|token|code)=[^&]*/gi, '[OAUTH_REDACTED]');
+    return escapeControlChars(redacted);
   });
 }
 


### PR DESCRIPTION
Fixes #498

### Summary

Harden `secureLogger` with control character escaping (CWE-117/150), comprehensive credential redaction (CWE-532) across full/unterminated PEM blocks, quoted/escaped/JSON-stringified credential assignments, Bearer/Basic/JWT tokens, object keys, and safe type serialization (`Symbol`, `RegExp`, `Error`, `BigInt`, `Date`, `Set`, `Map`). Also harden `waitForServers()` against timer jitter during request timeouts.

### Changes

- **`src/logger/secureLogger.ts`**:
  - Added `CONTROL_CHARS_PATTERN` and `escapeControlChars()` covering C0 (`\x00-\x1F`), DEL (`\x7F`), C1 (`\x80-\x9F`), Unicode line/paragraph separators (`\u2028`, `\u2029`), and Bidi overrides (`\u202A-\u202E`, `\u2066-\u2069`, `\u200B-\u200D`, `\uFEFF`) with visible literal escaping (`\\n`, `\\r`, `\\t`, `\\xHH`, `\\uHHHH`).
  - Hardened `KEY_SENSITIVE_PATTERNS`:
    - Redacts PEM private keys matching complete blocks or unterminated blocks through string boundaries.
    - Matches Bearer tokens with space or colon delimiters (`Bearer <token>`, `Bearer:<token>`).
    - Matches Basic auth headers, JWT tokens, and key-value credential assignments supporting snake_case, camelCase, quoted values, escaped quotes (`\\\"`, `\\\'`), unterminated quotes, and JSON-stringified payloads (`{"token":"..."}`).
  - Routed `Symbol`, `RegExp`, and non-string `Error.name` through `sanitizeString()` to ensure credentials in descriptions and patterns are redacted.
  - Added prototype pollution protection by skipping `__proto__` keys during object, Map, and Error traversal.
  - Suppressed dynamic `error.message` in `sanitizeForLogging`'s catch block using a static constant message to prevent throwing-getter bypasses.
  - Escaped control characters in `sanitizeOAuthServerList()`.

- **`src/commands/wait/wait.ts`**:
  - Added `response.error?.startsWith('Request timed out')` to the timeout condition in `waitForServers()` to ensure deterministic timeout error handling under system clock jitter.

- **`src/logger/secureLogger.test.ts`**:
  - Added unit test cases for CRLF, C0/C1, ANSI escapes, Unicode separators, and Trojan Source Bidi overrides.
  - Added test cases for complete and unterminated PEM blocks with unique body markers, Basic auth, JWTs, and Bearer tokens (with and without colons).
  - Added test cases for quoted, unquoted, camelCase, and unterminated credential assignments.
  - Added test cases for JSON-stringified credential payloads and URL parameter redaction.
  - Added test cases for `Symbol`, `RegExp`, and non-string `Error.name` containing credentials.
  - Added test cases for static error suppression on throwing getters and complex data types (`BigInt`, `Date`, `Set`, `Map`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log sanitization for credentials, tokens, PEM data, authorization headers, URLs, errors, object keys, and complex values.
  - Added escaping for control characters in logs and OAuth server names.
  - Prevented unsafe prototype-related keys from appearing in sanitized output.
  - Recognized inspect API responses beginning with “Request timed out” as server-wait timeouts.
- **Tests**
  - Added comprehensive coverage for sensitive-data redaction, escaping, sanitization failures, ordering, and large inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->