### PR TITLE
fix(storage): unify atomic write primitive, fail-closed migration flags, and capability-degrade directory permissions

### DIFF
--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -241,20 +241,24 @@ describe('FileStorageService', () => {
 
     it('does not unlink pre-existing file if openSync fails with EEXIST', () => {
       const originalOpenSync = fs.openSync;
-      const preExistingTempPath = path.join(service.getStorageDir(), 'pre-existing.tmp');
-      fs.writeFileSync(preExistingTempPath, 'important pre-existing data');
+      let capturedTempPath: string | undefined;
 
       vi.spyOn(fs, 'openSync').mockImplementation((targetPath, flags, mode) => {
         if (typeof targetPath === 'string' && targetPath.endsWith('.tmp')) {
+          capturedTempPath = targetPath;
+          fs.writeFileSync(targetPath, 'important pre-existing data');
           throw Object.assign(new Error('EEXIST: file already exists'), { code: 'EEXIST' });
         }
         return originalOpenSync(targetPath, flags, mode);
       });
 
       expect(() => service.writeData(testPrefix, testId, testData)).toThrow(/EEXIST/);
-      expect(fs.existsSync(preExistingTempPath)).toBe(true);
-      expect(fs.readFileSync(preExistingTempPath, 'utf8')).toBe('important pre-existing data');
-      fs.unlinkSync(preExistingTempPath);
+      expect(capturedTempPath).toBeDefined();
+      expect(fs.existsSync(capturedTempPath!)).toBe(true);
+      expect(fs.readFileSync(capturedTempPath!, 'utf8')).toBe('important pre-existing data');
+      if (capturedTempPath && fs.existsSync(capturedTempPath)) {
+        fs.unlinkSync(capturedTempPath);
+      }
     });
 
     it('hardens legacy data files to 0600 during migration', () => {

--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -197,6 +197,27 @@ describe('FileStorageService', () => {
       fs.rmSync(customDir, { recursive: true, force: true });
     });
 
+    it('fails closed when existing migration flag hardening encounters capability error', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const customDir = path.join(tmpdir(), `custom-flag-enotsup-test-${Date.now()}`);
+      const sessionsPath = path.join(customDir, 'sessions');
+      fs.mkdirSync(sessionsPath, { recursive: true, mode: 0o700 });
+      const flagPath = path.join(sessionsPath, '.migrated-to-server');
+      fs.writeFileSync(flagPath, JSON.stringify({ migrated: true }), { mode: 0o644 });
+
+      const originalChmodSync = fs.chmodSync;
+      vi.spyOn(fs, 'chmodSync').mockImplementation((pathArg, modeArg) => {
+        if (pathArg === flagPath) {
+          throw Object.assign(new Error('ENOTSUP: operation not supported on socket'), { code: 'ENOTSUP' });
+        }
+        return originalChmodSync(pathArg, modeArg);
+      });
+
+      expect(() => new FileStorageService(customDir, 'server')).toThrow(/ENOTSUP/);
+      fs.rmSync(customDir, { recursive: true, force: true });
+    });
+
     it('fails closed when existing migration flag hardening fails with permission error', () => {
       // POSIX-only: Windows ACLs do not map to fs.stat modes
       if (process.platform === 'win32') return;
@@ -216,6 +237,24 @@ describe('FileStorageService', () => {
 
       expect(() => new FileStorageService(customDir, 'server')).toThrow(/EACCES/);
       fs.rmSync(customDir, { recursive: true, force: true });
+    });
+
+    it('does not unlink pre-existing file if openSync fails with EEXIST', () => {
+      const originalOpenSync = fs.openSync;
+      const preExistingTempPath = path.join(service.getStorageDir(), 'pre-existing.tmp');
+      fs.writeFileSync(preExistingTempPath, 'important pre-existing data');
+
+      vi.spyOn(fs, 'openSync').mockImplementation((targetPath, flags, mode) => {
+        if (typeof targetPath === 'string' && targetPath.endsWith('.tmp')) {
+          throw Object.assign(new Error('EEXIST: file already exists'), { code: 'EEXIST' });
+        }
+        return originalOpenSync(targetPath, flags, mode);
+      });
+
+      expect(() => service.writeData(testPrefix, testId, testData)).toThrow(/EEXIST/);
+      expect(fs.existsSync(preExistingTempPath)).toBe(true);
+      expect(fs.readFileSync(preExistingTempPath, 'utf8')).toBe('important pre-existing data');
+      fs.unlinkSync(preExistingTempPath);
     });
 
     it('hardens legacy data files to 0600 during migration', () => {

--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -151,19 +151,19 @@ describe('FileStorageService', () => {
       fs.rmSync(customDir, { recursive: true, force: true });
     });
 
-    it('does not write replacement secret if chmod fails on pre-existing permissive file', () => {
+    it('does not write replacement secret if write fails on pre-existing file', () => {
       // POSIX-only: Windows ACLs do not map to fs.stat modes
       if (process.platform === 'win32') return;
       const filePath = service.getFilePath(testPrefix, testId);
       fs.writeFileSync(filePath, JSON.stringify({ ...testData, value: 'old-secret' }), { mode: 0o644 });
       fs.chmodSync(filePath, 0o644);
 
-      const originalChmodSync = fs.chmodSync;
-      vi.spyOn(fs, 'chmodSync').mockImplementation((pathArg, modeArg) => {
-        if (pathArg === filePath) {
+      const originalRenameSync = fs.renameSync;
+      vi.spyOn(fs, 'renameSync').mockImplementation((oldPath, newPath) => {
+        if (newPath === filePath) {
           throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' });
         }
-        return originalChmodSync(pathArg, modeArg);
+        return originalRenameSync(oldPath, newPath);
       });
 
       expect(() =>
@@ -175,6 +175,47 @@ describe('FileStorageService', () => {
 
       const contentOnDisk = JSON.parse(fs.readFileSync(filePath, 'utf8'));
       expect(contentOnDisk.value).toBe('old-secret');
+    });
+
+    it('tolerates filesystems without POSIX permission support in ensureDirectory', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const customDir = path.join(tmpdir(), `custom-perm-degrade-${Date.now()}`);
+      const sessionsPath = path.join(customDir, 'sessions');
+
+      const originalChmodSync = fs.chmodSync;
+      vi.spyOn(fs, 'chmodSync').mockImplementation((pathArg, modeArg) => {
+        if (pathArg === sessionsPath) {
+          throw Object.assign(new Error('ENOTSUP: operation not supported on socket'), { code: 'ENOTSUP' });
+        }
+        return originalChmodSync(pathArg, modeArg);
+      });
+
+      const customService = new FileStorageService(customDir);
+      expect(customService.getStorageDir()).toBe(sessionsPath);
+      customService.shutdown();
+      fs.rmSync(customDir, { recursive: true, force: true });
+    });
+
+    it('fails closed when existing migration flag hardening fails with permission error', () => {
+      // POSIX-only: Windows ACLs do not map to fs.stat modes
+      if (process.platform === 'win32') return;
+      const customDir = path.join(tmpdir(), `custom-flag-fail-test-${Date.now()}`);
+      const sessionsPath = path.join(customDir, 'sessions');
+      fs.mkdirSync(sessionsPath, { recursive: true, mode: 0o700 });
+      const flagPath = path.join(sessionsPath, '.migrated-to-server');
+      fs.writeFileSync(flagPath, JSON.stringify({ migrated: true }), { mode: 0o644 });
+
+      const originalChmodSync = fs.chmodSync;
+      vi.spyOn(fs, 'chmodSync').mockImplementation((pathArg, modeArg) => {
+        if (pathArg === flagPath) {
+          throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+        }
+        return originalChmodSync(pathArg, modeArg);
+      });
+
+      expect(() => new FileStorageService(customDir, 'server')).toThrow(/EACCES/);
+      fs.rmSync(customDir, { recursive: true, force: true });
     });
 
     it('hardens legacy data files to 0600 during migration', () => {
@@ -229,14 +270,16 @@ describe('FileStorageService', () => {
     it('preserves the previous record when a replacement write fails after truncation', () => {
       service.writeData(testPrefix, testId, testData);
       const targetPath = service.getFilePath(testPrefix, testId);
-      const originalWriteFileSync = fs.writeFileSync;
-      vi.spyOn(fs, 'writeFileSync').mockImplementation((file, data, options) => {
-        originalWriteFileSync(file, '', options);
-        throw new Error(`simulated crash while writing ${String(file)}`);
+      const originalRenameSync = fs.renameSync;
+      vi.spyOn(fs, 'renameSync').mockImplementation((oldPath, newPath) => {
+        if (newPath === targetPath) {
+          throw new Error(`simulated crash while renaming ${String(newPath)}`);
+        }
+        return originalRenameSync(oldPath, newPath);
       });
 
       expect(() =>
-        service.writeDataDurable(testPrefix, testId, {
+        service.writeData(testPrefix, testId, {
           ...testData,
           value: 'replacement value',
         }),

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -45,13 +45,20 @@ export class FileStorageService {
 
   /**
    * Hardens file or directory permissions on POSIX systems.
-   * Tolerates filesystems that lack POSIX permission capabilities (e.g. FAT, exFAT, FUSE).
-   * For real permission violations (EACCES, EPERM, EROFS), it fails closed by rethrowing.
+   * Tolerates filesystems that lack POSIX permission capabilities (e.g. FAT, exFAT, FUSE)
+   * only when explicitly allowed (such as during storage directory initialization).
+   * For credentials and migration flags, or real permission violations (EACCES, EPERM, EROFS),
+   * it strictly fails closed by rethrowing.
    */
-  private hardenPermissionsSafely(targetPath: string, mode: number): void {
+  private hardenPermissionsSafely(
+    targetPath: string,
+    mode: number,
+    options: { degradeCapabilityErrors?: boolean } = {},
+  ): void {
     if (process.platform === 'win32') {
       return;
     }
+    const { degradeCapabilityErrors = false } = options;
     try {
       fs.chmodSync(targetPath, mode);
     } catch (error: unknown) {
@@ -59,9 +66,10 @@ export class FileStorageService {
         error instanceof Error && 'code' in error && typeof (error as { code?: unknown }).code === 'string'
           ? String((error as { code: string }).code)
           : '';
-      if (['ENOTSUP', 'EOPNOTSUPP', 'EINVAL', 'ENOSYS'].includes(code)) {
+      if (degradeCapabilityErrors && ['ENOTSUP', 'EOPNOTSUPP', 'EINVAL', 'ENOSYS'].includes(code)) {
+        const loggableTarget = this.getLoggableFileName(path.basename(targetPath));
         logger.warn(
-          `chmod ${mode.toString(8)} unsupported on ${targetPath} (${code}) — filesystem lacks POSIX permission capabilities, degrading safely`,
+          `chmod ${mode.toString(8)} unsupported on ${loggableTarget} (${code}) — filesystem lacks POSIX permission capabilities, degrading safely`,
         );
         return;
       }
@@ -79,7 +87,7 @@ export class FileStorageService {
         logger.info(`Created storage directory: ${this.storageDir}`);
       }
       if (process.platform !== 'win32') {
-        this.hardenPermissionsSafely(this.storageDir, 0o700);
+        this.hardenPermissionsSafely(this.storageDir, 0o700, { degradeCapabilityErrors: true });
       }
     } catch (error) {
       logger.error(`Failed to create storage directory: ${error}`);
@@ -425,10 +433,12 @@ export class FileStorageService {
   ): void {
     const { durable = false } = options;
     let temporaryPath: string | undefined;
+    let created = false;
     try {
       const filePath = this.getFilePath(filePrefix, id);
       temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
       const fileDescriptor = fs.openSync(temporaryPath, 'wx', 0o600);
+      created = true;
       try {
         fs.writeFileSync(fileDescriptor, JSON.stringify(data, null, 2));
         if (durable) {
@@ -444,7 +454,7 @@ export class FileStorageService {
       }
       logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
     } catch (error) {
-      if (temporaryPath) {
+      if (temporaryPath && created) {
         try {
           fs.unlinkSync(temporaryPath);
         } catch {

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -44,6 +44,32 @@ export class FileStorageService {
   }
 
   /**
+   * Hardens file or directory permissions on POSIX systems.
+   * Tolerates filesystems that lack POSIX permission capabilities (e.g. FAT, exFAT, FUSE).
+   * For real permission violations (EACCES, EPERM, EROFS), it fails closed by rethrowing.
+   */
+  private hardenPermissionsSafely(targetPath: string, mode: number): void {
+    if (process.platform === 'win32') {
+      return;
+    }
+    try {
+      fs.chmodSync(targetPath, mode);
+    } catch (error: unknown) {
+      const code =
+        error instanceof Error && 'code' in error && typeof (error as { code?: unknown }).code === 'string'
+          ? String((error as { code: string }).code)
+          : '';
+      if (['ENOTSUP', 'EOPNOTSUPP', 'EINVAL', 'ENOSYS'].includes(code)) {
+        logger.warn(
+          `chmod ${mode.toString(8)} unsupported on ${targetPath} (${code}) — filesystem lacks POSIX permission capabilities, degrading safely`,
+        );
+        return;
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Ensures the storage directory exists
    */
   private ensureDirectory(): void {
@@ -53,7 +79,7 @@ export class FileStorageService {
         logger.info(`Created storage directory: ${this.storageDir}`);
       }
       if (process.platform !== 'win32') {
-        fs.chmodSync(this.storageDir, 0o700);
+        this.hardenPermissionsSafely(this.storageDir, 0o700);
       }
     } catch (error) {
       logger.error(`Failed to create storage directory: ${error}`);
@@ -111,9 +137,10 @@ export class FileStorageService {
     if (fs.existsSync(migrationFlagPath)) {
       if (process.platform !== 'win32') {
         try {
-          fs.chmodSync(migrationFlagPath, 0o600);
+          this.hardenPermissionsSafely(migrationFlagPath, 0o600);
         } catch (error) {
-          logger.warn(`Failed to harden migration flag permissions: ${error}`);
+          logger.error(`Failed to harden migration flag permissions: ${error}`);
+          throw error;
         }
       }
       logger.debug(`Migration from ${sourceDir} to ${currentSubDir} already completed`);
@@ -139,11 +166,11 @@ export class FileStorageService {
 
         try {
           if (process.platform !== 'win32') {
-            fs.chmodSync(oldPath, 0o600);
+            this.hardenPermissionsSafely(oldPath, 0o600);
           }
           fs.renameSync(oldPath, newPath);
           if (process.platform !== 'win32') {
-            fs.chmodSync(newPath, 0o600);
+            this.hardenPermissionsSafely(newPath, 0o600);
           }
           migrationCount++;
           logger.info(`Migrated ${this.getLoggableFileName(file)} from ${sourceDir} to ${this.storageDir}`);
@@ -180,15 +207,12 @@ export class FileStorageService {
         { mode: 0o600 },
       );
       if (process.platform !== 'win32') {
-        try {
-          fs.chmodSync(migrationFlagPath, 0o600);
-        } catch (error) {
-          logger.warn(`Failed to harden migration flag permissions: ${error}`);
-        }
+        this.hardenPermissionsSafely(migrationFlagPath, 0o600);
       }
       logger.debug(`Created migration flag: .migrated-to-${targetSubDir} in ${sourceDir}`);
     } catch (error) {
-      logger.warn(`Failed to create migration flag: ${error}`);
+      logger.error(`Failed to create migration flag: ${error}`);
+      throw error;
     }
   }
 
@@ -389,31 +413,17 @@ export class FileStorageService {
   }
 
   /**
-   * Writes data to a file with the specified prefix and ID
+   * Internal unified atomic write primitive:
+   * Uses O_CREAT | O_EXCL with mode 0o600 for safe temporary file creation,
+   * writes data, optionally fsyncs, and atomically renames to the destination path.
    */
-  writeData<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
-    try {
-      const filePath = this.getFilePath(filePrefix, id);
-      if (process.platform !== 'win32' && fs.existsSync(filePath)) {
-        fs.chmodSync(filePath, 0o600);
-      }
-      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
-      if (process.platform !== 'win32') {
-        fs.chmodSync(filePath, 0o600);
-      }
-      logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
-    } catch (error) {
-      logger.error(
-        `Failed to write data for ${this.getLoggableId(filePrefix, id)}: ${this.getLoggableError(filePrefix, error)}`,
-      );
-      throw error;
-    }
-  }
-
-  /**
-   * Atomically replaces a record and flushes it before returning.
-   */
-  writeDataDurable<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
+  private writeDataAtomic<T extends ExpirableData>(
+    filePrefix: string,
+    id: string,
+    data: T,
+    options: { durable?: boolean } = {},
+  ): void {
+    const { durable = false } = options;
     let temporaryPath: string | undefined;
     try {
       const filePath = this.getFilePath(filePrefix, id);
@@ -421,13 +431,17 @@ export class FileStorageService {
       const fileDescriptor = fs.openSync(temporaryPath, 'wx', 0o600);
       try {
         fs.writeFileSync(fileDescriptor, JSON.stringify(data, null, 2));
-        fs.fsyncSync(fileDescriptor);
+        if (durable) {
+          fs.fsyncSync(fileDescriptor);
+        }
       } finally {
         fs.closeSync(fileDescriptor);
       }
       fs.renameSync(temporaryPath, filePath);
       temporaryPath = undefined;
-      this.flushStorageDirectory();
+      if (durable) {
+        this.flushStorageDirectory();
+      }
       logger.debug(`Wrote data to ${this.getLoggableFilePath(filePrefix, id)}`);
     } catch (error) {
       if (temporaryPath) {
@@ -442,6 +456,20 @@ export class FileStorageService {
       );
       throw error;
     }
+  }
+
+  /**
+   * Writes data to a file with the specified prefix and ID
+   */
+  writeData<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
+    this.writeDataAtomic(filePrefix, id, data, { durable: false });
+  }
+
+  /**
+   * Atomically replaces a record and flushes it before returning.
+   */
+  writeDataDurable<T extends ExpirableData>(filePrefix: string, id: string, data: T): void {
+    this.writeDataAtomic(filePrefix, id, data, { durable: true });
   }
 
   /**


### PR DESCRIPTION
Fixes #508

### Problem

Following the credential permission hardening in #492, three architectural divergence points remained in `FileStorageService`:

1. **Dual-track write primitive and crash consistency:** `writeData()` performed in-place truncation via `fs.writeFileSync()`, creating a vulnerability window where mid-write process crashes or power outages could produce empty/truncated credential files (which `readData()` deletes upon parse errors, losing session state). In contrast, `writeDataDurable()` implemented an atomic replacement pattern (`fs.openSync(..., 'wx', 0o600)` -> write -> `fs.fsyncSync` -> `fs.renameSync`).
2. **Migration flag error swallowing:** In `migrateOldFilesIfNeeded()`, a POSIX `chmodSync` failure when hardening an existing migration flag was caught and only logged as a warning, returning as if migration completed. In `createMigrationFlag()`, chmod errors were also caught and warned rather than propagated.
3. **Storage directory startup crashes on non-POSIX/FUSE filesystems:** `ensureDirectory()` applied `fs.chmodSync(this.storageDir, 0o700)` with strict error propagation on POSIX platforms. When run on volumes without POSIX permission support (e.g. Docker volumes backed by FAT, exFAT, CIFS, or FUSE), `chmod` returns `ENOTSUP` or `EINVAL`, causing the application to crash on startup.

### Proposed Changes

- **Unified Atomic Write Primitive (`src/auth/storage/fileStorageService.ts`)**:
  - Converged `writeData()` and `writeDataDurable()` onto an internal `writeDataAtomic(filePrefix, id, data, { durable })` primitive.
  - All writes now create a unique temporary file with `fs.openSync(tempPath, 'wx', 0o600)` (kernel-enforced `0o600` creation, eliminating TOCTOU chmod windows), write data, optionally execute `fsyncSync` and directory flush, and atomically replace the destination via `fs.renameSync`.

- **Controlled Filesystem Capability Degradation (`src/auth/storage/fileStorageService.ts`)**:
  - Introduced `hardenPermissionsSafely(targetPath, mode)` with a capability degradation allowlist (`['ENOTSUP', 'EOPNOTSUPP', 'EINVAL', 'ENOSYS']`).
  - Special filesystems without POSIX permission support log an informative warning and degrade gracefully without terminating the application.
  - Real security and access violations (`EACCES`, `EPERM`, `EROFS`, `EIO`) strictly fail closed by rethrowing.

- **Fail-Closed Migration Flag Hardening (`src/auth/storage/fileStorageService.ts`)**:
  - `migrateOldFilesIfNeeded()` now propagates permission errors when hardening existing migration flags, preventing false completion assumption.
  - `createMigrationFlag()` propagates permission failures, ensuring failed flag creations are treated as migration failures that will be retried on next startup.

- **Test Suite Updates (`src/auth/storage/fileStorageService.test.ts`)**:
  - Updated replacement write tests to verify atomic preservation of previous records on write failure.
  - Added regression test `tolerates filesystems without POSIX permission support in ensureDirectory` verifying `ENOTSUP` degradation.
  - Added regression test `fails closed when existing migration flag hardening fails with permission error` verifying `EACCES` propagation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving authentication data by preserving existing data if an update fails.
  * Improved compatibility with filesystems that do not support permission changes.
  * Security-sensitive permission and migration failures now stop processing instead of being silently ignored.
  * Updated migration and write-failure handling for safer recovery from interruptions or filesystem errors.
  * Improved cleanup after interrupted or unsuccessful authentication-data writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->