### PR TITLE
chore: add .gitattributes for cross-platform line-ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Normalize all detected-text files to LF in the repository; leave the
+# working-tree representation to platform defaults.
+* text=auto
+
+# POSIX interpreters fail hard on CRLF shebangs - force LF everywhere.
+*.sh text eol=lf
+
+# Windows-native scripts stay CRLF in the working tree (storage remains LF).
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary assets must never be line-ending processed.
+*.png binary
+*.ico binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.zip binary
+*.gz binary
+*.tar binary


### PR DESCRIPTION
Closes #510

## Summary

Adds a committed root `.gitattributes` so line-ending normalization becomes an enforced property of the repository instead of relying on `.editorconfig` + Prettier, which are both bypassable layers (no plugin installed / formatter not run).

**Zero-cost adoption window:** verified against current `main`, all 1209 tracked files are stored pure-LF (0 files contain CR), so merging this requires no renormalization commit and produces no blame noise. No other files are touched.

## Why this shape

Follows the three-layer model used by major projects - `.gitattributes` owns the storage/checkout truth (the only cross-machine-enforced layer):

| Layer | Tool | Enforceable |
|---|---|---|
| Storage/checkout truth | `.gitattributes` | Yes - ships with every clone |
| Editor behavior | `.editorconfig` | No |
| Formatter fallback | Prettier/ESLint | No |

Precedent: [`dotnet/runtime`](https://github.com/dotnet/runtime/blob/main/.gitattributes) (`* text=auto` + `.sh` LF + `.bat/.cmd` CRLF), [`PowerShell/PowerShell`](https://github.com/PowerShell/PowerShell/blob/master/.gitattributes) (`* text=auto`, unpinned ps1), [`microsoft/vscode`](https://github.com/microsoft/vscode/blob/main/.gitattributes).

**`.ps1` deliberately left unpinned** - PowerShell's parser tolerates both endings; dotnet/runtime does not pin it either. Happy to pin `eol=lf` if you prefer byte-stable cross-runner hashing, or `eol=crlf` for Windows-native checkouts - maintainer's call, one line to change.

## What this gives contributors

- Windows clones with default `autocrlf=true` stop producing phantom whole-file diffs on script/config edits
- `.sh` files are guaranteed LF on every checkout/CI runner (kills the `bash\r` bad-interpreter failure class)
- Binary assets marked explicitly so content detection can never corrupt them

After merge, a single `git add --renormalize .` is expected to be an empty diff given the pure-LF index.