### PR TITLE
fix(security): redact sensitive IDs in isValidId debug log (CWE-532)

### DIFF
--- a/src/auth/storage/fileStorageService.test.ts
+++ b/src/auth/storage/fileStorageService.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import { ExpirableData } from '@src/auth/sessionTypes.js';
 import { AUTH_CONFIG } from '@src/constants.js';
+import logger from '@src/logger/logger.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -617,6 +618,59 @@ describe('FileStorageService', () => {
 
       noSubdirService.shutdown();
       fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('CWE-532 log redaction — isValidId internal path', () => {
+    it('redacts sensitive ID in thrown Error message when extractUuidPart encounters a mismatched prefix', () => {
+      const sensitiveId = `${AUTH_CONFIG.SERVER.AUTH_CODE.ID_PREFIX}sensitive-secret-token-value`;
+      const wrongPrefix = AUTH_CONFIG.SERVER.SESSION.ID_PREFIX;
+
+      // Exercise the real, unmocked extractUuidPart implementation
+      const extractFn = (
+        service as unknown as { extractUuidPart: (id: string, prefix: string) => string }
+      ).extractUuidPart.bind(service);
+
+      expect(() => extractFn(sensitiveId, wrongPrefix)).toThrow();
+      try {
+        extractFn(sensitiveId, wrongPrefix);
+      } catch (err: unknown) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        expect(errMsg).toContain('[REDACTED]');
+        expect(errMsg).not.toContain('sensitive-secret-token-value');
+        expect(errMsg).not.toContain(sensitiveId);
+      }
+    });
+
+    it('does not log plaintext auth-code ID or error metadata when isValidId encounters an extractUuidPart failure', () => {
+      vi.mocked(logger.debug).mockClear();
+
+      const sensitiveId = `${AUTH_CONFIG.SERVER.AUTH_CODE.ID_PREFIX}sensitive-secret-token-value`;
+      const extractSpy = vi
+        .spyOn(service as unknown as { extractUuidPart: (id: string, prefix: string) => string }, 'extractUuidPart')
+        .mockImplementationOnce(() => {
+          throw new Error(`malformed UUID with sensitive payload: ${sensitiveId}`);
+        });
+
+      const result = service.readData(AUTH_CONFIG.SERVER.AUTH_CODE.FILE_PREFIX, sensitiveId);
+      expect(result).toBeNull();
+      extractSpy.mockRestore();
+
+      expect(vi.mocked(logger.debug)).toHaveBeenCalled();
+      const calls = vi.mocked(logger.debug).mock.calls as unknown as Array<[unknown, unknown?]>;
+      for (const [message, meta] of calls) {
+        const messageStr = String(message);
+        expect(messageStr).toContain('[REDACTED]');
+        expect(messageStr).not.toContain('sensitive-secret-token-value');
+        expect(messageStr).not.toContain(sensitiveId);
+
+        if (meta && typeof meta === 'object' && 'error' in meta) {
+          const errorValue = String((meta as { error: unknown }).error);
+          expect(errorValue).toContain('[REDACTED]');
+          expect(errorValue).not.toContain('sensitive-secret-token-value');
+          expect(errorValue).not.toContain(sensitiveId);
+        }
+      }
     });
   });
 });

--- a/src/auth/storage/fileStorageService.ts
+++ b/src/auth/storage/fileStorageService.ts
@@ -66,7 +66,8 @@ export class FileStorageService {
    */
   private extractUuidPart(id: string, prefix: string): string {
     if (!id.startsWith(prefix)) {
-      throw new Error(`Invalid ID prefix: expected ${prefix}, got ${id}`);
+      const loggableId = this.isSensitivePrefix(prefix) || this.isSensitivePrefix(id) ? '[REDACTED]' : id;
+      throw new Error(`Invalid ID prefix: expected ${prefix}, got ${loggableId}`);
     }
     return id.substring(prefix.length);
   }
@@ -275,7 +276,10 @@ export class FileStorageService {
           const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
           return uuidRegex.test(uuidPart);
         } catch (error) {
-          logger.debug(`extractUuidPart failed for id=${id}, prefix=${prefix}`, { error });
+          const isSensitive = this.isSensitivePrefix(prefix) || this.isSensitivePrefix(id);
+          const loggableId = isSensitive ? '[REDACTED]' : id;
+          const loggableError = isSensitive ? this.getLoggableError(prefix, error) : error;
+          logger.debug(`extractUuidPart failed for id=${loggableId}, prefix=${prefix}`, { error: loggableError });
           return false;
         }
       }
@@ -312,7 +316,9 @@ export class FileStorageService {
   private static getSensitivePrefixes(): readonly string[] {
     return [
       AUTH_CONFIG?.SERVER?.AUTH_CODE?.FILE_PREFIX ?? 'auth_code_',
+      AUTH_CONFIG?.SERVER?.AUTH_CODE?.ID_PREFIX ?? 'code-',
       AUTH_CONFIG?.SERVER?.AUTH_REQUEST?.FILE_PREFIX ?? 'auth_request_',
+      AUTH_CONFIG?.SERVER?.AUTH_REQUEST?.ID_PREFIX ?? 'req-',
     ];
   }
 


### PR DESCRIPTION
Fixes #512

### Context

The atomic authorization-code redemption (AUTH-02 / TOCTOU double-spend prevention) and refresh-token replay family revocation requirements described in #512 were already merged into `main` in commit `97e41f5` (PR #470). This pull request addresses the remaining CWE-532 log redaction issue in `FileStorageService`.

### Problem

In `FileStorageService.isValidId()`, when validating an ID against server prefixes, `extractUuidPart()` is called in a `try...catch` block. Two log leakage surfaces existed:

1. **Source Error Message**: `extractUuidPart()` threw errors containing the raw `id` parameter (`throw new Error(\`Invalid ID prefix: expected ${prefix}, got ${id}\`)`). Furthermore, if `prefix` was non-sensitive but `id` contained a sensitive prefix, the ID was not redacted.
2. **Sink Error Metadata & ID Interpolation**: `isValidId()` logged the raw `id` and unredacted `{ error }` metadata object via `logger.debug()` when `extractUuidPart()` threw. Furthermore, `getSensitivePrefixes()` only registered `FILE_PREFIX`es (`auth_code_`, `auth_request_`), failing to identify `ID_PREFIX`es (`code-`, `req-`) as sensitive.

### Changes

- **`src/auth/storage/fileStorageService.ts`**:
  - Registered `AUTH_CODE.ID_PREFIX` and `AUTH_REQUEST.ID_PREFIX` in `getSensitivePrefixes()`.
  - In `extractUuidPart()`, sanitized `id` in thrown error messages with dual sensitivity check (`isSensitivePrefix(prefix) || isSensitivePrefix(id)`).
  - In `isValidId()`, sanitized both the logged `id` and the `{ error }` metadata object using `getLoggableError()`.
- **`src/auth/storage/fileStorageService.test.ts`**:
  - Added direct regression test exercising the real, unmocked `extractUuidPart()` implementation to ensure thrown error messages are sanitized (mutation resilience).
  - Added regression test verifying that when `extractUuidPart()` throws with a sensitive ID in the error payload, neither the message string nor the error metadata object in `logger.debug` leaks the plaintext identifier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by redacting sensitive authentication and request identifiers from error messages and diagnostic logs.
  * Prevented secret tokens and full sensitive IDs from appearing in debug output when invalid identifiers or storage errors occur.
* **Tests**
  * Added coverage verifying that sensitive values are consistently replaced with `[REDACTED]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->