### PR TITLE
fix(security): address CodeQL alerts

### DIFF
--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -117,11 +117,16 @@ export const FILE_PREFIX_MAPPING = {
   TRANSPORT: ['streamable_session_'],
 } as const;
 
-// Rate limiting configuration for OAuth endpoints
+// Rate limiting configuration for public HTTP endpoints
 export const RATE_LIMIT_CONFIG = {
   OAUTH: {
     WINDOW_MS: 15 * 60 * 1000, // 15 minutes
     MAX: 100, // max requests per window per IP
     MESSAGE: { error: 'Too many requests, please try again later.' },
+  },
+  TOOL_INVOCATIONS: {
+    WINDOW_MS: 15 * 60 * 1000, // 15 minutes
+    MAX: 10_000, // high-volume agent traffic, while still bounding floods per IP
+    MESSAGE: { error: 'Too many tool invocation requests, please try again later.' },
   },
 };

--- a/src/transport/http/routes/apiRoutes.tool-invocations.test.ts
+++ b/src/transport/http/routes/apiRoutes.tool-invocations.test.ts
@@ -122,6 +122,49 @@ describe('apiRoutes /api/tool-invocations', () => {
     expect(serverManager.getClient).not.toHaveBeenCalled();
   });
 
+  it('rate limits tool invocations before authorization', async () => {
+    const serverManager = {
+      getLazyLoadingOrchestrator: vi.fn(() => undefined),
+      getClient: vi.fn(() => undefined),
+      getClients: vi.fn(() => new Map()),
+    };
+    const authorizationAttempts = vi.fn((_req: Request, _res: Response, next: () => void) => next());
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api/v1',
+      createApiRoutes(serverManager as never, authorizationAttempts, { windowMs: 60_000, max: 1 }),
+    );
+
+    const firstResponse = await request(app).post('/api/v1/tool-invocations').send({ tool: 'server/tool' });
+    const secondResponse = await request(app).post('/api/v1/tool-invocations').send({ tool: 'server/tool' });
+
+    expect(firstResponse.status).toBe(503);
+    expect(secondResponse.status).toBe(429);
+    expect(authorizationAttempts).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows tool invocation bursts above the OAuth rate limit by default', async () => {
+    const serverManager = {
+      getLazyLoadingOrchestrator: vi.fn(() => undefined),
+      getClient: vi.fn(() => undefined),
+      getClients: vi.fn(() => new Map()),
+    };
+    const authorizationAttempts = vi.fn((_req: Request, _res: Response, next: () => void) => next());
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1', createApiRoutes(serverManager as never, authorizationAttempts));
+
+    const responses = await Promise.all(
+      Array.from({ length: 101 }, () =>
+        request(app).post('/api/v1/tool-invocations').send({ tool: 'server/tool' }),
+      ),
+    );
+
+    expect(responses.every((response) => response.status === 503)).toBe(true);
+    expect(authorizationAttempts).toHaveBeenCalledTimes(101);
+  });
+
   it('returns 400 when tool field is missing', async () => {
     const serverManager = { getLazyLoadingOrchestrator: vi.fn(() => undefined) };
     const handler = createToolInvocationsHandler(serverManager as never);

--- a/src/transport/http/routes/apiRoutes.ts
+++ b/src/transport/http/routes/apiRoutes.ts
@@ -1,7 +1,9 @@
+import { RATE_LIMIT_CONFIG } from '@src/constants.js';
 import { ServerManager } from '@src/core/server/serverManager.js';
 import tagsExtractor from '@src/transport/http/middlewares/tagsExtractor.js';
 
 import { NextFunction, Request, RequestHandler, Response, Router } from 'express';
+import rateLimit from 'express-rate-limit';
 
 import { createInspectHandler, createServersHandler } from './inspectRoutes.js';
 import { createInstructionsHandler } from './instructionsRoutes.js';
@@ -28,6 +30,16 @@ export type { SDKOAuthServerProvider } from '@src/auth/sdkOAuthServerProvider.js
 
 // ---- Route factory ----
 
+export interface ToolInvocationRateLimitPolicy {
+  windowMs: number;
+  max: number;
+}
+
+const DEFAULT_TOOL_INVOCATION_RATE_LIMIT_POLICY: ToolInvocationRateLimitPolicy = {
+  windowMs: RATE_LIMIT_CONFIG.TOOL_INVOCATIONS.WINDOW_MS,
+  max: RATE_LIMIT_CONFIG.TOOL_INVOCATIONS.MAX,
+};
+
 export function rejectBrowserOriginRequests(req: Request, res: Response, next: NextFunction): void {
   if (req.headers.origin) {
     res.status(403).json({ error: 'Cross-origin requests are not allowed for this endpoint' });
@@ -37,8 +49,19 @@ export function rejectBrowserOriginRequests(req: Request, res: Response, next: N
   next();
 }
 
-export function createApiRoutes(serverManager: ServerManager, scopeAuthMiddleware: RequestHandler): Router {
+export function createApiRoutes(
+  serverManager: ServerManager,
+  scopeAuthMiddleware: RequestHandler,
+  rateLimitPolicy: ToolInvocationRateLimitPolicy = DEFAULT_TOOL_INVOCATION_RATE_LIMIT_POLICY,
+): Router {
   const router = Router();
+  const toolInvocationLimiter = rateLimit({
+    windowMs: rateLimitPolicy.windowMs,
+    max: rateLimitPolicy.max,
+    message: RATE_LIMIT_CONFIG.TOOL_INVOCATIONS.MESSAGE,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
 
   router.get('/inspect', tagsExtractor, scopeAuthMiddleware, createInspectHandler(serverManager));
   router.get('/instructions', tagsExtractor, scopeAuthMiddleware, createInstructionsHandler(serverManager));
@@ -47,6 +70,7 @@ export function createApiRoutes(serverManager: ServerManager, scopeAuthMiddlewar
   router.post(
     '/tool-invocations',
     rejectBrowserOriginRequests,
+    toolInvocationLimiter,
     tagsExtractor,
     scopeAuthMiddleware,
     createToolInvocationsHandler(serverManager),

--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -1,0 +1,15 @@
+import { createHash as cryptoCreateHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { createHash } from './crypto.js';
+
+describe('createHash', () => {
+  it('does not expose an unkeyed SHA-256 digest of secret-bearing input', () => {
+    const input = 'https://user:password@example.com/mcp';
+    const unkeyedDigest = cryptoCreateHash('sha256').update(input).digest('hex');
+
+    expect(createHash(input)).not.toBe(unkeyedDigest);
+    expect(createHash(input)).toBe(createHash(input));
+  });
+});

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,10 +1,16 @@
-import { createHash as cryptoCreateHash } from 'crypto';
+import { randomBytes, scryptSync } from 'crypto';
+
+const runtimeHashSalt = randomBytes(32);
 
 /**
- * Creates a SHA-256 hash of the given string
+ * Creates a process-local password-hard hash of the given string.
+ *
+ * Callers use this for runtime identity and cache comparison, which can include
+ * rendered credentials. A keyed digest keeps those values resistant to offline
+ * guessing while remaining deterministic for the lifetime of the process.
  */
 export function createHash(data: string): string {
-  return cryptoCreateHash('sha256').update(data).digest('hex');
+  return scryptSync(data, runtimeHashSalt, 32).toString('hex');
 }
 
 /**


### PR DESCRIPTION
## Description

- replace unkeyed SHA-256 runtime fingerprints with process-local salted scrypt so rendered credentials are not exposed to offline guessing
- rate limit `/api/v1/tool-invocations` before authorization and execution with a dedicated high-volume policy of 10,000 requests per 15 minutes per IP
- add regression coverage for both CodeQL findings and for bursts above the OAuth rate limit

Code scanning alerts:
- https://github.com/1mcp-app/agent/security/code-scanning/74
- https://github.com/1mcp-app/agent/security/code-scanning/72

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Focused API route and crypto tests (77 tests)
- [x] `CI=true pnpm test:unit` (4,911 tests)
- [x] `git diff --check`

## Checklist

- [x] Code follows the style guidelines
- [x] Self-review completed
- [x] Regression tests added
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rate limiting for tool-invocation requests, with standard response headers and a clear error message when limits are exceeded.
  - Configured a default allowance of up to 10,000 requests per IP within 15 minutes.

- **Security Improvements**
  - Strengthened secret hashing with salted, key-derived digests for improved protection and consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->