### PR TITLE
fix(ci): refresh conformance pins and report integrity failures

### DIFF
--- a/test/conformance/foundation/foundation-lock.json
+++ b/test/conformance/foundation/foundation-lock.json
@@ -64,12 +64,12 @@
     {
       "id": "foundation-run",
       "path": "test/conformance/foundation/foundationRun.ts",
-      "digest": "sha256:35e5ceb2204e7dbc52c0958fa818ea441f812e86cb5a659b2a86087383897f32"
+      "digest": "sha256:f14505d083d6e0fc269e140a905ff4b86cb0d1fd0807d9b66fda84bc452fb67a"
     },
     {
       "id": "sdk-boundary-proof",
       "path": "test/conformance/boundary/sdkBoundaryProof.ts",
-      "digest": "sha256:a4d53b00bfb3891cde60a7f75db5254abcdd8e52a873f64125af01ba4092c7ac"
+      "digest": "sha256:1df2f3da228cf31423ed6d039d4bf783a31eaffe7b9e65e2940fac87882f00d7"
     },
     {
       "id": "sdk-import-policy",
@@ -89,17 +89,17 @@
     {
       "id": "sdk-protocol-contract",
       "path": "src/sdk/contracts/protocol.ts",
-      "digest": "sha256:06af5a19dc9207d4f127bde80fc4e563cee12b3693d0a85198e4407430016926"
+      "digest": "sha256:5073bd4b917f868ec1bb469eca05762c2bdaa4bdf2f957a89786d93fb6084ef2"
     },
     {
       "id": "legacy-client-adapter",
       "path": "src/sdk/legacy/client/runtime/legacySdkClientAdapter.ts",
-      "digest": "sha256:882f9279c9a55e31b4ed16768c0e8eabecb4b5e63fa1dd702ac78407ea11b6d3"
+      "digest": "sha256:b91cb703565e8c483f58e4333edefdd4e2eadd6b3d818af2ca3e025c0ad58539"
     },
     {
       "id": "legacy-server-adapter",
       "path": "src/sdk/legacy/server/runtime/legacySdkServerAdapter.ts",
-      "digest": "sha256:6df1e151fde18f079c97460d8b22ee04a2e31fc9df52be723ef21dbbce0fceaf"
+      "digest": "sha256:18d79d42f3cea21215aae8f37002f58c83f414b2ccca0d6479240f8e52f9fe1a"
     },
     {
       "id": "sdk-topology-runtime",

--- a/test/conformance/foundation/foundationRun.test.ts
+++ b/test/conformance/foundation/foundationRun.test.ts
@@ -1,11 +1,41 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import * as conformanceIntegrity from '../integrity/index.js';
 import { type OfficialConformanceResult } from '../official/officialRunner.js';
-import { classifyOfficialClientResult, stopChild } from './foundationRun.js';
+import { classifyOfficialClientResult, runFoundationConformance, stopChild } from './foundationRun.js';
+
+describe('foundation integrity preflight', () => {
+  it('reports a stale artifact pin before attempting evidence generation', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'conformance-integrity-failure-'));
+    const verify = conformanceIntegrity.verifyConformanceIntegrity;
+    const verifier = vi.spyOn(conformanceIntegrity, 'verifyConformanceIntegrity').mockImplementation((options) =>
+      verify({
+        ...options,
+        artifacts: options.artifacts.map((artifact) =>
+          artifact.id === 'sdk-boundary-proof' ? { ...artifact, expectedDigest: `sha256:${'0'.repeat(64)}` } : artifact,
+        ),
+      }),
+    );
+    try {
+      await expect(
+        runFoundationConformance({ root: process.cwd(), outputDirectory: directory, mode: 'baseline' }),
+      ).rejects.toThrow('artifact-digest-mismatch:sdk-boundary-proof');
+      const report = JSON.parse(await readFile(join(directory, 'conformance-integrity.json'), 'utf8'));
+      expect(report).toMatchObject({
+        ok: false,
+        issues: expect.arrayContaining([{ code: 'artifact-digest-mismatch', subject: 'sdk-boundary-proof' }]),
+      });
+      expect(await readdir(directory)).toEqual(['conformance-integrity.json']);
+    } finally {
+      verifier.mockRestore();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});
 
 function officialProductResult(): OfficialConformanceResult {
   return {

--- a/test/conformance/foundation/foundationRun.ts
+++ b/test/conformance/foundation/foundationRun.ts
@@ -1012,6 +1012,10 @@ export async function runFoundationConformance(options: FoundationRunOptions): P
     encoding: 'utf8',
     mode: 0o600,
   });
+  if (!integrity.ok) {
+    const issues = integrity.issues.map(({ code, subject }) => `${code}:${subject}`).join(', ');
+    throw new Error(`Conformance integrity check failed: ${issues}`);
+  }
   const generatedSdkBoundaryProof = await generateSdkBoundaryProof(root, outputDirectory);
   const sdkBoundaryProof =
     generatedSdkBoundaryProof.classification === 'product'


### PR DESCRIPTION
The formatting commit `838aa1eb` changed four files pinned by the conformance foundation without refreshing their checksums, breaking the `test-conformance` job on `main`. The harness then attempted to finalize an empty baseline and replaced the integrity failure with `accepted-contract-mapping-invalid`.

Refresh the four reviewed pins and the pin for the updated runner. After saving the integrity report, stop immediately on failed integrity and report the classified issue codes and artifact IDs. Keep the existing conformance coverage and checksum validation. A regression test injects a stale pin into the real integrity verifier and checks that the original cause is reported before evidence generation.

Validation:

- Lint, typecheck, build, SDK boundary/topology checks, and SDK policy tests passed.
- The regression test failed with the original misleading error before the fix; all 6 foundation runner tests now pass.
- `pnpm test:conformance -- --reporter=minimal` passed on clean commit `62c8ee5`: 117 tests, 6 focused transport tests, 22 TypeScript fixture tests, and 7 Python fixture tests. The persisted baseline digest was independently verified; it contains 4 official runs and 12 matrix assignments with infrastructure green. Existing product-red compatibility findings remain recorded.
- [GitHub CI run 33978776638](https://github.com/1mcp-app/agent/actions/runs/33978776638) passed all 8 jobs, including the complete unit/admin suites, conformance, and all E2E jobs.
- Local unit caveat: the isolated full run passed 5,016/5,017 tests; the unchanged rate-limit spec passed on its focused rerun (16 tests). The hosted full unit suite passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Foundation conformance checks now stop immediately when an artifact integrity mismatch is detected.
  - Failed integrity checks provide clear details about the affected artifacts while preserving the generated integrity report.

- **Tests**
  - Added coverage to verify failure handling, report generation, and temporary output cleanup.
  - Refreshed conformance integrity records for tracked foundation artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->